### PR TITLE
Improved gatling el interaction for java/kotlin dsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ project/plugins/project/
 /.idea/
 /.bsp/
 .DS_Store
+/results

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/KafkaDsl.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/KafkaDsl.java
@@ -2,17 +2,109 @@ package org.galaxio.gatling.kafka.javaapi;
 
 import static io.gatling.javaapi.core.internal.Expressions.*;
 
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.gatling.core.check.CheckBuilder;
+import io.gatling.core.check.Check;
+import io.gatling.core.check.CheckMaterializer;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.utils.Bytes;
+import org.galaxio.gatling.kafka.javaapi.checks.KafkaCheckType;
 import org.galaxio.gatling.kafka.javaapi.checks.KafkaChecks;
 import org.galaxio.gatling.kafka.javaapi.protocol.*;
 import org.galaxio.gatling.kafka.javaapi.request.builder.*;
+import org.galaxio.gatling.kafka.javaapi.request.expressions.Builders.*;
+import org.galaxio.gatling.kafka.javaapi.request.expressions.ExpressionBuilder;
+import org.galaxio.gatling.kafka.javaapi.request.expressions.JExpression;
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage;
-import org.galaxio.gatling.kafka.javaapi.protocol.KafkaProtocolBuilderBase;
-import org.galaxio.gatling.kafka.javaapi.request.builder.KafkaRequestBuilderBase;
-import scala.Function1;
+
+import java.nio.ByteBuffer;
+import java.util.function.Function;
 
 public final class KafkaDsl {
+
+    public static <T> JExpression<T> cf(T t) {
+        return i -> t;
+    }
+
+    public static ExpressionBuilder<String> stringExp(JExpression<String> f) {
+        return new StringExpressionBuilder(f);
+    }
+
+    public static ExpressionBuilder<String> stringExp(String v) {
+        return stringExp(cf(v));
+    }
+
+    public static ExpressionBuilder<Float> floatExp(JExpression<Float> f) {
+        return new FloatExpressionBuilder(f);
+    }
+
+    public static ExpressionBuilder<Float> floatExp(Float v) {
+        return floatExp(cf(v));
+    }
+
+    public static ExpressionBuilder<Double> doubleExp(JExpression<Double> f) {
+        return new DoubleExpressionBuilder(f);
+    }
+
+    public static ExpressionBuilder<Double> doubleExp(Double v) {
+        return doubleExp(cf(v));
+    }
+
+    public static ExpressionBuilder<Short> shortExp(JExpression<Short> f) {
+        return new ShortExpressionBuilder(f);
+    }
+
+    public static ExpressionBuilder<Short> shortExp(Short v) {
+        return shortExp(cf(v));
+    }
+
+    public static ExpressionBuilder<Integer> integerExp(JExpression<Integer> f) {
+        return new IntegerExpressionBuilder(f);
+    }
+
+    public static ExpressionBuilder<Integer> integerExp(Integer v) {
+        return integerExp(cf(v));
+    }
+
+    public static ExpressionBuilder<Long> longExp(JExpression<Long> f) {
+        return new LongExpressionBuilder(f);
+    }
+
+    public static ExpressionBuilder<Long> longExp(Long v) {
+        return longExp(cf(v));
+    }
+
+    public static ExpressionBuilder<ByteBuffer> byteBufferExp(JExpression<ByteBuffer> f) {
+        return new ByteBufferExpressionBuilder(f);
+    }
+
+    public static ExpressionBuilder<ByteBuffer> byteBufferExp(ByteBuffer v) {
+        return byteBufferExp(cf(v));
+    }
+
+    public static ExpressionBuilder<byte[]> byteArrayExp(byte[] v) {
+        return byteArrayExp(cf(v));
+    }
+
+    public static ExpressionBuilder<byte[]> byteArrayExp(JExpression<byte[]> f) {
+        return new ByteArrayExpressionBuilder(f);
+    }
+
+    public static ExpressionBuilder<Bytes> bytesExp(JExpression<Bytes> f) {
+        return new BytesExpressionBuilder(f);
+    }
+
+    public static ExpressionBuilder<Bytes> bytesExp(Bytes v) {
+        return bytesExp(cf(v));
+    }
+
+    public static AvroExpressionBuilder avro(Object o, SchemaRegistryClient client) {
+        return avro(cf(o), client);
+    }
+
+    public static AvroExpressionBuilder avro(JExpression<Object> s, SchemaRegistryClient client) {
+        return new AvroExpressionBuilder(s, client);
+    }
 
     public static KafkaProtocolBuilderBase kafka() {
         return new KafkaProtocolBuilderBase();
@@ -22,8 +114,26 @@ public final class KafkaDsl {
         return new KafkaRequestBuilderBase(org.galaxio.gatling.kafka.Predef.kafka(toStringExpression(requestName)), requestName);
     }
 
-    public static KafkaChecks.KafkaCheckTypeWrapper simpleCheck(Function1<KafkaProtocolMessage, Boolean> f) {
-        return new KafkaChecks.KafkaCheckTypeWrapper(new KafkaChecks.SimpleChecksScala().simpleCheck(f.andThen(Boolean::valueOf)));
+
+    public static io.gatling.javaapi.core.CheckBuilder simpleCheck(Function<KafkaProtocolMessage, Boolean> f) {
+        return new io.gatling.javaapi.core.CheckBuilder() {
+            @Override
+            @SuppressWarnings("rawtypes")
+            public CheckBuilder<?, ?> asScala() {
+                return new CheckBuilder() {
+                    @Override
+                    public Check<?> build( CheckMaterializer materializer) {
+                        return new KafkaChecks.SimpleChecksScala().simpleCheck(f::apply);
+
+                    }
+                };
+            }
+
+            @Override
+            public CheckType type() {
+                return KafkaCheckType.Simple;
+            }
+        };
     }
 
     public static CheckBuilder.Find<Object, KafkaProtocolMessage, GenericRecord> avroBody() {

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaCheckType.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaCheckType.java
@@ -3,5 +3,6 @@ package org.galaxio.gatling.kafka.javaapi.checks;
 import io.gatling.javaapi.core.CheckBuilder.CheckType;
 
 public enum KafkaCheckType implements CheckType {
-    ResponseCode
+    ResponseCode,
+    Simple
 }

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaChecks.scala
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaChecks.scala
@@ -1,6 +1,5 @@
 package org.galaxio.gatling.kafka.javaapi.checks
 
-import io.gatling.core.check.Check
 import io.gatling.core.check._
 import io.gatling.core.check.bytes.BodyBytesCheckType
 import io.gatling.core.check.jmespath.JmesPathCheckType
@@ -9,69 +8,70 @@ import io.gatling.core.check.string.BodyStringCheckType
 import io.gatling.core.check.substring.SubstringCheckType
 import io.gatling.core.check.xpath.XPathCheckType
 import io.gatling.javaapi.core.internal.CoreCheckType
+import org.galaxio.gatling.kafka.checks.{KafkaCheckMaterializer, KafkaCheckSupport}
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.{KafkaCheck, checks}
 import net.sf.saxon.s9api.XdmNode
 import com.fasterxml.jackson.databind.JsonNode
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.common.serialization.Serde
-import org.galaxio.gatling.kafka.KafkaCheck
-import org.galaxio.gatling.kafka.checks.{KafkaCheckMaterializer, KafkaCheckSupport}
-import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import java.{util => ju}
 import scala.jdk.CollectionConverters._
 
 object KafkaChecks {
-  case class KafkaCheckTypeWrapper(value: Check[KafkaProtocolMessage])
   class SimpleChecksScala extends KafkaCheckSupport {}
 
   val avroSerde: Serde[GenericRecord] = new GenericAvroSerde()
 
-  private def toScalaCheck(javaCheck: Object): KafkaCheck = {
-    javaCheck match {
-      case _: io.gatling.javaapi.core.CheckBuilder =>
-        val checkBuilder = javaCheck.asInstanceOf[io.gatling.javaapi.core.CheckBuilder]
-        val scalaCheck   = checkBuilder.asScala
-        checkBuilder.`type` match {
-          case CoreCheckType.BodyBytes     =>
-            scalaCheck
-              .asInstanceOf[CheckBuilder[BodyBytesCheckType, Array[Byte]]]
-              .build(KafkaCheckMaterializer.bodyBytes)
-          case CoreCheckType.BodyString    =>
-            scalaCheck
-              .asInstanceOf[CheckBuilder[BodyStringCheckType, String]]
-              .build(KafkaCheckMaterializer.bodyString(io.gatling.core.Predef.configuration))
-          case CoreCheckType.Substring     =>
-            scalaCheck
-              .asInstanceOf[CheckBuilder[SubstringCheckType, String]]
-              .build(KafkaCheckMaterializer.substring(io.gatling.core.Predef.configuration))
-          case CoreCheckType.XPath         =>
-            scalaCheck
-              .asInstanceOf[CheckBuilder[XPathCheckType, XdmNode]]
-              .build(KafkaCheckMaterializer.xpath(io.gatling.core.Predef.configuration))
-          case CoreCheckType.JsonPath      =>
-            scalaCheck
-              .asInstanceOf[CheckBuilder[JsonPathCheckType, JsonNode]]
-              .build(
-                KafkaCheckMaterializer.jsonPath(io.gatling.core.Predef.defaultJsonParsers, io.gatling.core.Predef.configuration),
-              )
-          case CoreCheckType.JmesPath      =>
-            scalaCheck
-              .asInstanceOf[CheckBuilder[JmesPathCheckType, JsonNode]]
-              .build(
-                KafkaCheckMaterializer.jmesPath(io.gatling.core.Predef.defaultJsonParsers, io.gatling.core.Predef.configuration),
-              )
-          case KafkaCheckType.ResponseCode =>
-            scalaCheck
-              .asInstanceOf[CheckBuilder[KafkaCheckMaterializer.KafkaMessageCheckType, KafkaProtocolMessage]]
-              .build(
-                KafkaCheckMaterializer.kafkaStatusCheck,
-              )
-          case unknown                     => throw new IllegalArgumentException(s"Kafka DSL doesn't support $unknown")
-        }
+  private def toScalaCheck(javaCheckBuilder: io.gatling.javaapi.core.CheckBuilder): KafkaCheck = {
+    val scalaCheck = javaCheckBuilder.asScala
+    javaCheckBuilder.`type` match {
+      case CoreCheckType.BodyBytes     =>
+        scalaCheck
+          .asInstanceOf[CheckBuilder[BodyBytesCheckType, Array[Byte]]]
+          .build(KafkaCheckMaterializer.bodyBytes)
+      case CoreCheckType.BodyString    =>
+        scalaCheck
+          .asInstanceOf[CheckBuilder[BodyStringCheckType, String]]
+          .build(KafkaCheckMaterializer.bodyString(io.gatling.core.Predef.configuration))
+      case CoreCheckType.Substring     =>
+        scalaCheck
+          .asInstanceOf[CheckBuilder[SubstringCheckType, String]]
+          .build(KafkaCheckMaterializer.substring(io.gatling.core.Predef.configuration))
+      case CoreCheckType.XPath         =>
+        scalaCheck
+          .asInstanceOf[CheckBuilder[XPathCheckType, XdmNode]]
+          .build(KafkaCheckMaterializer.xpath(io.gatling.core.Predef.configuration))
+      case CoreCheckType.JsonPath      =>
+        scalaCheck
+          .asInstanceOf[CheckBuilder[JsonPathCheckType, JsonNode]]
+          .build(
+            KafkaCheckMaterializer.jsonPath(io.gatling.core.Predef.defaultJsonParsers, io.gatling.core.Predef.configuration),
+          )
+      case CoreCheckType.JmesPath      =>
+        scalaCheck
+          .asInstanceOf[CheckBuilder[JmesPathCheckType, JsonNode]]
+          .build(
+            KafkaCheckMaterializer.jmesPath(io.gatling.core.Predef.defaultJsonParsers, io.gatling.core.Predef.configuration),
+          )
+      case KafkaCheckType.ResponseCode =>
+        scalaCheck
+          .asInstanceOf[CheckBuilder[checks.KafkaCheckMaterializer.KafkaMessageCheckType, KafkaProtocolMessage]]
+          .build(
+            KafkaCheckMaterializer.kafkaStatusCheck,
+          )
+      case KafkaCheckType.Simple       =>
+        scalaCheck
+          .asInstanceOf[CheckBuilder[checks.KafkaCheckMaterializer.KafkaMessageCheckType, KafkaProtocolMessage]]
+          .build(KafkaCheckMaterializer.kafkaStatusCheck)
+      case unknown                     => throw new IllegalArgumentException(s"Kafka DSL doesn't support $unknown")
     }
+
   }
 
-  def toScalaChecks(javaChecks: ju.List[Object]): Seq[KafkaCheck] =
+  def toScalaChecks(javaChecks: ju.List[io.gatling.javaapi.core.CheckBuilder]): Seq[KafkaCheck] =
     javaChecks.asScala.map(toScalaCheck).toSeq
+
 }

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/protocol/KPConsumeSettingsStep.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/protocol/KPConsumeSettingsStep.java
@@ -4,8 +4,6 @@ import java.time.Duration;
 import java.util.Map;
 
 import static scala.jdk.javaapi.CollectionConverters.asScala;
-
-import org.galaxio.gatling.kafka.protocol.KafkaProtocol;
 import scala.jdk.javaapi.DurationConverters;
 
 public class KPConsumeSettingsStep {
@@ -21,12 +19,12 @@ public class KPConsumeSettingsStep {
     public KafkaProtocolBuilderNew timeout(Duration timeout) {
         scala.collection.immutable.Map<String, Object> ps = scala.collection.immutable.Map.from(asScala(this.producerSettings));
         scala.collection.immutable.Map<String, Object> cs = scala.collection.immutable.Map.from(asScala(this.consumeSettings));
-        return new KafkaProtocolBuilderNew(org.galaxio.gatling.kafka.protocol.KafkaProtocolBuilderNew.apply(ps, cs, DurationConverters.toScala(timeout), KafkaProtocol.KafkaKeyMatcher$.MODULE$));
+        return new KafkaProtocolBuilderNew(org.galaxio.gatling.kafka.protocol.KafkaProtocolBuilderNew.apply(ps, cs, DurationConverters.toScala(timeout), org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher$.MODULE$));
     }
 
     public KafkaProtocolBuilderNew withDefaultTimeout() {
         scala.collection.immutable.Map<String, Object> ps = scala.collection.immutable.Map.from(asScala(this.producerSettings));
         scala.collection.immutable.Map<String, Object> cs = scala.collection.immutable.Map.from(asScala(this.consumeSettings));
-        return new KafkaProtocolBuilderNew(org.galaxio.gatling.kafka.protocol.KafkaProtocolBuilderNew.apply(ps, cs, DurationConverters.toScala(Duration.ofSeconds(60)), KafkaProtocol.KafkaKeyMatcher$.MODULE$));
+        return new KafkaProtocolBuilderNew(org.galaxio.gatling.kafka.protocol.KafkaProtocolBuilderNew.apply(ps, cs, DurationConverters.toScala(Duration.ofSeconds(60)), org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher$.MODULE$));
     }
 }

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/KafkaRequestBuilderBase.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/KafkaRequestBuilderBase.java
@@ -4,8 +4,15 @@ import io.gatling.commons.validation.Validation;
 import io.gatling.core.session.Session;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.galaxio.gatling.kafka.request.builder.Sender;
+import org.apache.kafka.common.utils.Bytes;
+import org.galaxio.gatling.kafka.javaapi.request.expressions.ExpressionBuilder;
+
+import static org.galaxio.gatling.kafka.javaapi.KafkaDsl.*;
+
+import org.galaxio.gatling.kafka.javaapi.request.expressions.JExpression;
 import scala.Function1;
+
+import java.nio.ByteBuffer;
 
 import static io.gatling.javaapi.core.internal.Expressions.*;
 import static io.gatling.javaapi.core.internal.Expressions.toStaticValueExpression;
@@ -16,14 +23,22 @@ public class KafkaRequestBuilderBase {
     private final String requestName;
 
     private <T> Function1<Session, Validation<T>> calculateExpression(T obj) {
-        Function1<Session, Validation<T>> expression;
-
-        if (obj instanceof String || obj.getClass().isPrimitive() || obj instanceof CharSequence || obj instanceof byte[]) {
-            expression = toExpression(obj.toString(), obj.getClass());
-        } else {
-            expression = toStaticValueExpression(obj);
+        if (obj == null)
+            return null;
+        if (obj instanceof String || obj.getClass().isPrimitive() || obj instanceof CharSequence) {
+            return toExpression(obj.toString(), obj.getClass());
         }
-        return expression;
+//        else if (obj instanceof byte[] bytes) {
+//            String strBytes = new String(bytes);
+//            if (strBytes.matches("#\\{[a-zA-Z].*\\}")) {
+//                return toExpression(strBytes, bytes.getClass());
+//            } else {
+//                return toStaticValueExpression(obj);
+//            }
+//        }
+        else {
+            return toStaticValueExpression(obj);
+        }
     }
 
     public KafkaRequestBuilderBase(org.galaxio.gatling.kafka.request.builder.KafkaRequestBuilderBase wrapped, String requestName) {
@@ -31,39 +46,291 @@ public class KafkaRequestBuilderBase {
         this.requestName = requestName;
     }
 
-    public <K, V> RequestBuilder<?, ?> send(K key, V payload) {
-        return new RequestBuilder<>(
-                wrapped.send(
-                        calculateExpression(key),
-                        calculateExpression(payload),
-                        toStaticValueExpression(new RecordHeaders()),
-                        Sender.noSchemaSender()
-                ));
+
+    public RequestBuilder<String, String> send(String key, String payload) {
+        return send(stringExp(cf(key)), stringExp(cf(payload)));
     }
 
-    public <K, V> RequestBuilder<?, ?> send(K key, V payload, Headers headers) {
-        return new RequestBuilder<>(
+    public RequestBuilder<String, String> send(String key, String payload, Headers headers) {
+        return send(stringExp(cf(key)), stringExp(cf(payload)), headers);
+    }
+
+    public RequestBuilder<String, String> send(String key, String payload, JExpression<Headers> headers) {
+        return send(stringExp(cf(key)), stringExp(cf(payload)), headers);
+    }
+
+    public <V> RequestBuilder<String, V> send(String key, ExpressionBuilder<V> payload) {
+        return send(stringExp(cf(key)), payload);
+    }
+
+    public <V> RequestBuilder<String, V> send(String key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(stringExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestBuilder<String, V> send(String key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(stringExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestBuilder<K, String> send(ExpressionBuilder<K> key, String payload) {
+        return send(key, stringExp(cf(payload)));
+    }
+
+    public <K> RequestBuilder<K, String> send(ExpressionBuilder<K> key, String payload, Headers headers) {
+        return send(key, stringExp(cf(payload)), headers);
+    }
+
+    public <K> RequestBuilder<K, String> send(ExpressionBuilder<K> key, String payload, JExpression<Headers> headers) {
+        return send(key, stringExp(cf(payload)), headers);
+    }
+
+    public <V> RequestBuilder<Float, V> send(Float key, ExpressionBuilder<V> payload) {
+        return send(floatExp(cf(key)), payload);
+    }
+
+    public <V> RequestBuilder<Float, V> send(Float key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(floatExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestBuilder<Float, V> send(Float key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(floatExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestBuilder<K, Float> send(ExpressionBuilder<K> key, Float payload) {
+        return send(key, floatExp(cf(payload)));
+    }
+
+    public <K> RequestBuilder<K, Float> send(ExpressionBuilder<K> key, Float payload, Headers headers) {
+        return send(key, floatExp(cf(payload)), headers);
+    }
+
+    public <K> RequestBuilder<K, Float> send(ExpressionBuilder<K> key, Float payload, JExpression<Headers> headers) {
+        return send(key, floatExp(cf(payload)), headers);
+    }
+
+    public <V> RequestBuilder<Double, V> send(Double key, ExpressionBuilder<V> payload) {
+        return send(doubleExp(cf(key)), payload);
+    }
+
+    public <V> RequestBuilder<Double, V> send(Double key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(doubleExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestBuilder<Double, V> send(Double key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(doubleExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestBuilder<K, Double> send(ExpressionBuilder<K> key, Double payload) {
+        return send(key, doubleExp(cf(payload)));
+    }
+
+    public <K> RequestBuilder<K, Double> send(ExpressionBuilder<K> key, Double payload, Headers headers) {
+        return send(key, doubleExp(cf(payload)), headers);
+    }
+
+    public <K> RequestBuilder<K, Double> send(ExpressionBuilder<K> key, Double payload, JExpression<Headers> headers) {
+        return send(key, doubleExp(cf(payload)), headers);
+    }
+
+    public <V> RequestBuilder<Short, V> send(Short key, ExpressionBuilder<V> payload) {
+        return send(shortExp(cf(key)), payload);
+    }
+
+    public <V> RequestBuilder<Short, V> send(Short key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(shortExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestBuilder<Short, V> send(Short key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(shortExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestBuilder<K, Short> send(ExpressionBuilder<K> key, Short payload) {
+        return send(key, shortExp(cf(payload)));
+    }
+
+    public <K> RequestBuilder<K, Short> send(ExpressionBuilder<K> key, Short payload, Headers headers) {
+        return send(key, shortExp(cf(payload)), headers);
+    }
+
+    public <K> RequestBuilder<K, Short> send(ExpressionBuilder<K> key, Short payload, JExpression<Headers> headers) {
+        return send(key, shortExp(cf(payload)), headers);
+    }
+
+    public <V> RequestBuilder<Integer, V> send(Integer key, ExpressionBuilder<V> payload) {
+        return send(integerExp(cf(key)), payload);
+    }
+
+    public <V> RequestBuilder<Integer, V> send(Integer key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(integerExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestBuilder<Integer, V> send(Integer key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(integerExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestBuilder<K, Integer> send(ExpressionBuilder<K> key, Integer payload) {
+        return send(key, integerExp(cf(payload)));
+    }
+
+    public <K> RequestBuilder<K, Integer> send(ExpressionBuilder<K> key, Integer payload, Headers headers) {
+        return send(key, integerExp(cf(payload)), headers);
+    }
+
+    public <K> RequestBuilder<K, Integer> send(ExpressionBuilder<K> key, Integer payload, JExpression<Headers> headers) {
+        return send(key, integerExp(cf(payload)), headers);
+    }
+
+    public <V> RequestBuilder<Long, V> send(Long key, ExpressionBuilder<V> payload) {
+        return send(longExp(cf(key)), payload);
+    }
+
+    public <V> RequestBuilder<Long, V> send(Long key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(longExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestBuilder<Long, V> send(Long key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(longExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestBuilder<K, Long> send(ExpressionBuilder<K> key, Long payload) {
+        return send(key, longExp(cf(payload)));
+    }
+
+    public <K> RequestBuilder<K, Long> send(ExpressionBuilder<K> key, Long payload, Headers headers) {
+        return send(key, longExp(cf(payload)), headers);
+    }
+
+    public <K> RequestBuilder<K, Long> send(ExpressionBuilder<K> key, Long payload, JExpression<Headers> headers) {
+        return send(key, longExp(cf(payload)), headers);
+    }
+
+    public <V> RequestBuilder<ByteBuffer, V> send(ByteBuffer key, ExpressionBuilder<V> payload) {
+        return send(byteBufferExp(cf(key)), payload);
+    }
+
+    public <V> RequestBuilder<ByteBuffer, V> send(ByteBuffer key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(byteBufferExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestBuilder<ByteBuffer, V> send(ByteBuffer key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(byteBufferExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestBuilder<K, ByteBuffer> send(ExpressionBuilder<K> key, ByteBuffer payload) {
+        return send(key, byteBufferExp(cf(payload)));
+    }
+
+    public <K> RequestBuilder<K, ByteBuffer> send(ExpressionBuilder<K> key, ByteBuffer payload, Headers headers) {
+        return send(key, byteBufferExp(cf(payload)), headers);
+    }
+
+    public <K> RequestBuilder<K, ByteBuffer> send(ExpressionBuilder<K> key, ByteBuffer payload, JExpression<Headers> headers) {
+        return send(key, byteBufferExp(cf(payload)), headers);
+    }
+
+    public <V> RequestBuilder<Bytes, V> send(Bytes key, ExpressionBuilder<V> payload) {
+        return send(bytesExp(cf(key)), payload);
+    }
+
+    public <V> RequestBuilder<Bytes, V> send(Bytes key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(bytesExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestBuilder<Bytes, V> send(Bytes key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(bytesExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestBuilder<K, Bytes> send(ExpressionBuilder<K> key, Bytes payload) {
+        return send(key, bytesExp(cf(payload)));
+    }
+
+    public <K> RequestBuilder<K, Bytes> send(ExpressionBuilder<K> key, Bytes payload, Headers headers) {
+        return send(key, bytesExp(cf(payload)), headers);
+    }
+
+    public <K> RequestBuilder<K, Bytes> send(ExpressionBuilder<K> key, Bytes payload, JExpression<Headers> headers) {
+        return send(key, bytesExp(cf(payload)), headers);
+    }
+
+    public <V> RequestBuilder<byte[], V> send(byte[] key, ExpressionBuilder<V> payload) {
+        return send(byteArrayExp(cf(key)), payload);
+    }
+
+    public <V> RequestBuilder<byte[], V> send(byte[] key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(byteArrayExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestBuilder<byte[], V> send(byte[] key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(byteArrayExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestBuilder<K, byte[]> send(ExpressionBuilder<K> key, byte[] payload) {
+        return send(key, byteArrayExp(cf(payload)));
+    }
+
+    public <K> RequestBuilder<K, byte[]> send(ExpressionBuilder<K> key, byte[] payload, Headers headers) {
+        return send(key, byteArrayExp(cf(payload)), headers);
+    }
+
+    public <K> RequestBuilder<K, byte[]> send(ExpressionBuilder<K> key, byte[] payload, JExpression<Headers> headers) {
+        return send(key, byteArrayExp(cf(payload)), headers);
+    }
+
+    public <K, V> RequestBuilder<K, V> send(ExpressionBuilder<K> key, ExpressionBuilder<V> payload) {
+        return send(key, payload, new RecordHeaders());
+    }
+
+    public <K, V> RequestBuilder<K, V> send(ExpressionBuilder<K> key, ExpressionBuilder<V> payload, Headers headers) {
+        return new RequestBuilder<K, V>(wrapped.send(
+                key.gatlingExpression(),
+                payload.gatlingExpression(),
+                toStaticValueExpression(headers),
+                org.galaxio.gatling.kafka.request.builder.Sender.noSchemaSender()
+        ));
+    }
+
+    public <K, V> RequestBuilder<K, V> send(ExpressionBuilder<K> key, ExpressionBuilder<V> payload,
+                                            JExpression<Headers> headers) {
+        return new RequestBuilder<K, V>(wrapped.send(
+                key.gatlingExpression(),
+                payload.gatlingExpression(),
+                javaFunctionToExpression(headers),
+                org.galaxio.gatling.kafka.request.builder.Sender.noSchemaSender()
+        ));
+    }
+
+    public <V> RequestBuilder<Void, V> send(V payload) {
+        return send(payload, new RecordHeaders());
+    }
+
+    public <V> RequestBuilder<Void, V> send(V payload, Headers headers) {
+        return send(null, payload, headers);
+    }
+
+    public <V> RequestBuilder<Void, V> send(V payload, JExpression<Headers> headers) {
+        return send(null, payload, headers);
+    }
+
+    public <K, V> RequestBuilder<K, V> send(K key, V payload) {
+        return send(key, payload, new RecordHeaders());
+    }
+
+    public <K, V> RequestBuilder<K, V> send(K key, V payload, Headers headers) {
+        return new RequestBuilder<K, V>(
                 wrapped.send(
                         calculateExpression(key),
                         calculateExpression(payload),
                         toStaticValueExpression(headers),
-                        Sender.noSchemaSender()
+                        org.galaxio.gatling.kafka.request.builder.Sender.noSchemaSender()
                 ));
     }
 
-    public <V> RequestBuilder<?, ?> send(V payload) {
-        return new RequestBuilder<>(wrapped.send(
-                calculateExpression(payload),
-                Sender.noSchemaSender()));
-    }
-
-    public <K, V> RequestBuilder<?, ?> send(V payload, Headers headers) {
-        return new RequestBuilder<>(
+    public <K, V> RequestBuilder<K, V> send(K key, V payload, JExpression<Headers> headers) {
+        return new RequestBuilder<K, V>(
                 wrapped.send(
-                        null,
+                        calculateExpression(key),
                         calculateExpression(payload),
-                        toStaticValueExpression(headers),
-                        Sender.noSchemaSender()
+                        javaFunctionToExpression(headers),
+                        org.galaxio.gatling.kafka.request.builder.Sender.noSchemaSender()
                 ));
     }
 

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/KafkaRequestBuilderBase.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/KafkaRequestBuilderBase.java
@@ -28,14 +28,6 @@ public class KafkaRequestBuilderBase {
         if (obj instanceof String || obj.getClass().isPrimitive() || obj instanceof CharSequence) {
             return toExpression(obj.toString(), obj.getClass());
         }
-//        else if (obj instanceof byte[] bytes) {
-//            String strBytes = new String(bytes);
-//            if (strBytes.matches("#\\{[a-zA-Z].*\\}")) {
-//                return toExpression(strBytes, bytes.getClass());
-//            } else {
-//                return toStaticValueExpression(obj);
-//            }
-//        }
         else {
             return toStaticValueExpression(obj);
         }

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/RRInTopicStep.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/RRInTopicStep.java
@@ -1,16 +1,27 @@
 package org.galaxio.gatling.kafka.javaapi.request.builder;
 
+
+import io.gatling.commons.validation.Validation;
+import io.gatling.core.session.Session;
+import io.gatling.javaapi.core.internal.Expressions;
+
+import java.util.function.Function;
+
 public class RRInTopicStep {
 
-    private final String inputTopic;
+    private final scala.Function1<Session, Validation<String>> inputTopic;
     private final String requestName;
 
-    public RRInTopicStep(String inputTopic, String requestName) {
+    public RRInTopicStep(scala.Function1<Session, Validation<String>> inputTopic, String requestName) {
         this.inputTopic = inputTopic;
         this.requestName = requestName;
     }
 
     public RROutTopicStep replyTopic(String outputTopic) {
-        return new RROutTopicStep(this.inputTopic, outputTopic, this.requestName);
+        return new RROutTopicStep(this.inputTopic,  Expressions.toStringExpression(outputTopic), this.requestName);
+    }
+
+    public RROutTopicStep replyTopic(Function<io.gatling.javaapi.core.Session, String> outputTopic) {
+        return new RROutTopicStep(this.inputTopic, Expressions.javaFunctionToExpression(outputTopic), this.requestName);
     }
 }

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/RROutTopicStep.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/RROutTopicStep.java
@@ -1,44 +1,275 @@
 package org.galaxio.gatling.kafka.javaapi.request.builder;
 
+import io.gatling.commons.validation.Validation;
+import io.gatling.core.session.Session;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.*;
+import org.apache.kafka.common.utils.Bytes;
+import org.galaxio.gatling.kafka.javaapi.request.expressions.ExpressionBuilder;
+import org.galaxio.gatling.kafka.javaapi.request.expressions.JExpression;
 import org.galaxio.gatling.kafka.request.builder.KafkaRequestBuilderBase;
 import scala.reflect.ClassTag;
 
 import static io.gatling.javaapi.core.internal.Expressions.*;
+import static org.galaxio.gatling.kafka.javaapi.KafkaDsl.*;
+
+import java.nio.ByteBuffer;
 
 public class RROutTopicStep {
 
-    private final String inputTopic;
-    private final String outputTopic;
+    private final scala.Function1<Session, Validation<String>> inputTopic;
+    private final scala.Function1<Session, Validation<String>> outputTopic;
     private final String requestName;
 
-    public RROutTopicStep(String inputTopic, String outputTopic, String requestName) {
+    public RROutTopicStep(scala.Function1<Session, Validation<String>> inputTopic, scala.Function1<Session, Validation<String>> outputTopic, String requestName) {
         this.inputTopic = inputTopic;
         this.outputTopic = outputTopic;
         this.requestName = requestName;
     }
 
-    public <K, V> RequestReplyBuilder<?, ?> send(K key, V payload, Headers headers, Class<K> keyClass, Class<V> payloadClass) {
-        return new RequestReplyBuilder<K, V>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
-                .requestTopic(toStringExpression(this.inputTopic))
-                .replyTopic(toStringExpression(this.outputTopic))
+    public <V> RequestReplyBuilder<String, V> send(String key, ExpressionBuilder<V> payload) {
+        return send(stringExp(cf(key)), payload);
+    }
+
+    public <V> RequestReplyBuilder<String, V> send(String key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(stringExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestReplyBuilder<String, V> send(String key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(stringExp(cf(key)), payload, headers);
+    }
+
+    public RequestReplyBuilder<String, String> send(String key, String payload) {
+        return send(key, payload, new RecordHeaders());
+    }
+
+    public RequestReplyBuilder<String, String> send(String key, String payload, Headers headers) {
+        return send(stringExp(cf(key)), stringExp(cf(payload)), headers);
+    }
+
+    public RequestReplyBuilder<String, String> send(String key, String payload, JExpression<Headers> headers) {
+        return send(stringExp(cf(key)), stringExp(cf(payload)), headers);
+    }
+
+    public <K> RequestReplyBuilder<K, String> send(ExpressionBuilder<K> key, String payload) {
+        return send(key, stringExp(cf(payload)));
+    }
+
+    public <K> RequestReplyBuilder<K, String> send(ExpressionBuilder<K> key, String payload, Headers headers) {
+        return send(key, stringExp(cf(payload)), headers);
+    }
+
+    public <K> RequestReplyBuilder<K, String> send(ExpressionBuilder<K> key, String payload, JExpression<Headers> headers) {
+        return send(key, stringExp(cf(payload)), headers);
+    }
+
+    public <V> RequestReplyBuilder<Float, V> send(Float key, ExpressionBuilder<V> payload) {
+        return send(floatExp(cf(key)), payload);
+    }
+
+    public <V> RequestReplyBuilder<Float, V> send(Float key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(floatExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestReplyBuilder<Float, V> send(Float key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(floatExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Float> send(ExpressionBuilder<K> key, Float payload) {
+        return send(key, floatExp(cf(payload)));
+    }
+
+    public <K> RequestReplyBuilder<K, Float> send(ExpressionBuilder<K> key, Float payload, Headers headers) {
+        return send(key, floatExp(cf(payload)), headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Float> send(ExpressionBuilder<K> key, Float payload, JExpression<Headers> headers) {
+        return send(key, floatExp(cf(payload)), headers);
+    }
+
+    public <V> RequestReplyBuilder<Double, V> send(Double key, ExpressionBuilder<V> payload) {
+        return send(doubleExp(cf(key)), payload);
+    }
+
+    public <V> RequestReplyBuilder<Double, V> send(Double key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(doubleExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestReplyBuilder<Double, V> send(Double key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(doubleExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Double> send(ExpressionBuilder<K> key, Double payload) {
+        return send(key, doubleExp(cf(payload)));
+    }
+
+    public <K> RequestReplyBuilder<K, Double> send(ExpressionBuilder<K> key, Double payload, Headers headers) {
+        return send(key, doubleExp(cf(payload)), headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Double> send(ExpressionBuilder<K> key, Double payload, JExpression<Headers> headers) {
+        return send(key, doubleExp(cf(payload)), headers);
+    }
+
+    public <V> RequestReplyBuilder<Short, V> send(Short key, ExpressionBuilder<V> payload) {
+        return send(shortExp(cf(key)), payload);
+    }
+
+    public <V> RequestReplyBuilder<Short, V> send(Short key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(shortExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestReplyBuilder<Short, V> send(Short key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(shortExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Short> send(ExpressionBuilder<K> key, Short payload) {
+        return send(key, shortExp(cf(payload)));
+    }
+
+    public <K> RequestReplyBuilder<K, Short> send(ExpressionBuilder<K> key, Short payload, Headers headers) {
+        return send(key, shortExp(cf(payload)), headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Short> send(ExpressionBuilder<K> key, Short payload, JExpression<Headers> headers) {
+        return send(key, shortExp(cf(payload)), headers);
+    }
+
+    public <V> RequestReplyBuilder<Integer, V> send(Integer key, ExpressionBuilder<V> payload) {
+        return send(integerExp(cf(key)), payload);
+    }
+
+    public <V> RequestReplyBuilder<Integer, V> send(Integer key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(integerExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestReplyBuilder<Integer, V> send(Integer key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(integerExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Integer> send(ExpressionBuilder<K> key, Integer payload) {
+        return send(key, integerExp(cf(payload)));
+    }
+
+    public <K> RequestReplyBuilder<K, Integer> send(ExpressionBuilder<K> key, Integer payload, Headers headers) {
+        return send(key, integerExp(cf(payload)), headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Integer> send(ExpressionBuilder<K> key, Integer payload, JExpression<Headers> headers) {
+        return send(key, integerExp(cf(payload)), headers);
+    }
+
+    public <V> RequestReplyBuilder<Long, V> send(Long key, ExpressionBuilder<V> payload) {
+        return send(longExp(cf(key)), payload);
+    }
+
+    public <V> RequestReplyBuilder<Long, V> send(Long key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(longExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestReplyBuilder<Long, V> send(Long key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(longExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Long> send(ExpressionBuilder<K> key, Long payload) {
+        return send(key, longExp(cf(payload)));
+    }
+
+    public <K> RequestReplyBuilder<K, Long> send(ExpressionBuilder<K> key, Long payload, Headers headers) {
+        return send(key, longExp(cf(payload)), headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Long> send(ExpressionBuilder<K> key, Long payload, JExpression<Headers> headers) {
+        return send(key, longExp(cf(payload)), headers);
+    }
+
+    public <V> RequestReplyBuilder<ByteBuffer, V> send(ByteBuffer key, ExpressionBuilder<V> payload) {
+        return send(byteBufferExp(cf(key)), payload);
+    }
+
+    public <V> RequestReplyBuilder<ByteBuffer, V> send(ByteBuffer key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(byteBufferExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestReplyBuilder<ByteBuffer, V> send(ByteBuffer key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(byteBufferExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestReplyBuilder<K, ByteBuffer> send(ExpressionBuilder<K> key, ByteBuffer payload) {
+        return send(key, byteBufferExp(cf(payload)));
+    }
+
+    public <K> RequestReplyBuilder<K, ByteBuffer> send(ExpressionBuilder<K> key, ByteBuffer payload, Headers headers) {
+        return send(key, byteBufferExp(cf(payload)), headers);
+    }
+
+    public <K> RequestReplyBuilder<K, ByteBuffer> send(ExpressionBuilder<K> key, ByteBuffer payload, JExpression<Headers> headers) {
+        return send(key, byteBufferExp(cf(payload)), headers);
+    }
+
+    public <V> RequestReplyBuilder<Bytes, V> send(Bytes key, ExpressionBuilder<V> payload) {
+        return send(bytesExp(cf(key)), payload);
+    }
+
+    public <V> RequestReplyBuilder<Bytes, V> send(Bytes key, ExpressionBuilder<V> payload, Headers headers) {
+        return send(bytesExp(cf(key)), payload, headers);
+    }
+
+    public <V> RequestReplyBuilder<Bytes, V> send(Bytes key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return send(bytesExp(cf(key)), payload, headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Bytes> send(ExpressionBuilder<K> key, Bytes payload) {
+        return send(key, bytesExp(cf(payload)));
+    }
+
+    public <K> RequestReplyBuilder<K, Bytes> send(ExpressionBuilder<K> key, Bytes payload, Headers headers) {
+        return send(key, bytesExp(cf(payload)), headers);
+    }
+
+    public <K> RequestReplyBuilder<K, Bytes> send(ExpressionBuilder<K> key, Bytes payload, JExpression<Headers> headers) {
+        return send(key, bytesExp(cf(payload)), headers);
+    }
+
+    public <K, V> RequestReplyBuilder<K, V> send(ExpressionBuilder<K> key, ExpressionBuilder<V> payload) {
+        return send(key, payload, new RecordHeaders());
+    }
+
+    public <K, V> RequestReplyBuilder<K, V> send(ExpressionBuilder<K> key, ExpressionBuilder<V> payload, Headers headers) {
+        return new RequestReplyBuilder<>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
+                .requestTopic(this.inputTopic)
+                .replyTopic(this.outputTopic)
                 .send(
-                        toStaticValueExpression(key),
-                        toStaticValueExpression(payload),
+                        key.gatlingExpression(),
+                        payload.gatlingExpression(),
                         toStaticValueExpression(headers),
-                        Serdes.serdeFrom(keyClass),
-                        ClassTag.apply(keyClass),
-                        Serdes.serdeFrom(payloadClass),
-                        ClassTag.apply(payloadClass)
+                        key.getSerde(),
+                        ClassTag.apply(key.getType()),
+                        payload.getSerde(),
+                        ClassTag.apply(payload.getType())
                 ));
     }
 
-    public <K, V> RequestReplyBuilder<?, ?> send(K key, V payload, Class<K> keyClass, Class<V> payloadClass) {
-        return new RequestReplyBuilder<K, V>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
-                .requestTopic(toStringExpression(this.inputTopic))
-                .replyTopic(toStringExpression(this.outputTopic))
+    public <K, V> RequestReplyBuilder<K, V> send(ExpressionBuilder<K> key, ExpressionBuilder<V> payload, JExpression<Headers> headers) {
+        return new RequestReplyBuilder<>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
+                .requestTopic(this.inputTopic)
+                .replyTopic(this.outputTopic)
+                .send(
+                        key.gatlingExpression(),
+                        payload.gatlingExpression(),
+                        javaFunctionToExpression(headers),
+                        key.getSerde(),
+                        ClassTag.apply(key.getType()),
+                        payload.getSerde(),
+                        ClassTag.apply(payload.getType())
+                ));
+    }
+
+    public <K, V> RequestReplyBuilder<K, V> send(K key, V payload, Class<K> keyClass, Class<V> payloadClass) {
+        return new RequestReplyBuilder<>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
+                .requestTopic(this.inputTopic)
+                .replyTopic(this.outputTopic)
                 .send(
                         toStaticValueExpression(key),
                         toStaticValueExpression(payload),
@@ -50,10 +281,40 @@ public class RROutTopicStep {
                 ));
     }
 
+    public <K, V> RequestReplyBuilder<K, V> send(K key, V payload, Headers headers, Class<K> keyClass, Class<V> payloadClass) {
+        return new RequestReplyBuilder<>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
+                .requestTopic(this.inputTopic)
+                .replyTopic(this.outputTopic)
+                .send(
+                        toStaticValueExpression(key),
+                        toStaticValueExpression(payload),
+                        toStaticValueExpression(headers),
+                        Serdes.serdeFrom(keyClass),
+                        ClassTag.apply(keyClass),
+                        Serdes.serdeFrom(payloadClass),
+                        ClassTag.apply(payloadClass)
+                ));
+    }
+
+    public <K, V> RequestReplyBuilder<K, V> send(K key, V payload, JExpression<Headers> headers, Class<K> keyClass, Class<V> payloadClass) {
+        return new RequestReplyBuilder<>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
+                .requestTopic(this.inputTopic)
+                .replyTopic(this.outputTopic)
+                .send(
+                        toStaticValueExpression(key),
+                        toStaticValueExpression(payload),
+                        javaFunctionToExpression(headers),
+                        Serdes.serdeFrom(keyClass),
+                        ClassTag.apply(keyClass),
+                        Serdes.serdeFrom(payloadClass),
+                        ClassTag.apply(payloadClass)
+                ));
+    }
+
     public <K, V> RequestReplyBuilder<?, ?> send(K key, V payload, Class<K> keyClass, Class<V> payloadClass, Serializer<V> ser, Deserializer<V> de) {
         return new RequestReplyBuilder<K, V>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
-                .requestTopic(toStringExpression(this.inputTopic))
-                .replyTopic(toStringExpression(this.outputTopic))
+                .requestTopic(this.inputTopic)
+                .replyTopic(this.outputTopic)
                 .send(
                         toStaticValueExpression(key),
                         toStaticValueExpression(payload),
@@ -67,12 +328,27 @@ public class RROutTopicStep {
 
     public <K, V> RequestReplyBuilder<?, ?> send(K key, V payload, Headers headers, Class<K> keyClass, Class<V> payloadClass, Serializer<V> ser, Deserializer<V> de) {
         return new RequestReplyBuilder<K, V>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
-                .requestTopic(toStringExpression(this.inputTopic))
-                .replyTopic(toStringExpression(this.outputTopic))
+                .requestTopic(this.inputTopic)
+                .replyTopic(this.outputTopic)
                 .send(
                         toStaticValueExpression(key),
                         toStaticValueExpression(payload),
                         toStaticValueExpression(headers),
+                        Serdes.serdeFrom(keyClass),
+                        ClassTag.apply(keyClass),
+                        Serdes.serdeFrom(ser, de),
+                        ClassTag.apply(payloadClass)
+                ));
+    }
+
+    public <K, V> RequestReplyBuilder<?, ?> send(K key, V payload, JExpression<Headers> headers, Class<K> keyClass, Class<V> payloadClass, Serializer<V> ser, Deserializer<V> de) {
+        return new RequestReplyBuilder<K, V>(KafkaRequestBuilderBase.apply(toStringExpression(this.requestName)).requestReply()
+                .requestTopic(this.inputTopic)
+                .replyTopic(this.outputTopic)
+                .send(
+                        toStaticValueExpression(key),
+                        toStaticValueExpression(payload),
+                        javaFunctionToExpression(headers),
                         Serdes.serdeFrom(keyClass),
                         ClassTag.apply(keyClass),
                         Serdes.serdeFrom(ser, de),

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/ReqRepBase.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/ReqRepBase.java
@@ -1,5 +1,8 @@
 package org.galaxio.gatling.kafka.javaapi.request.builder;
 
+import io.gatling.javaapi.core.internal.Expressions;
+import org.galaxio.gatling.kafka.javaapi.request.expressions.JExpression;
+
 public class ReqRepBase {
 
     private final String requestName;
@@ -9,6 +12,10 @@ public class ReqRepBase {
     }
 
     public RRInTopicStep requestTopic(String inputTopic) {
-        return new RRInTopicStep(inputTopic, this.requestName);
+        return new RRInTopicStep(Expressions.toStringExpression(inputTopic), this.requestName);
+    }
+
+    public RRInTopicStep requestTopic(JExpression<String> inputTopic){
+        return new RRInTopicStep(Expressions.javaFunctionToExpression(inputTopic), this.requestName);
     }
 }

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/RequestReplyBuilder.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/RequestReplyBuilder.java
@@ -1,25 +1,25 @@
 package org.galaxio.gatling.kafka.javaapi.request.builder;
 
 import io.gatling.javaapi.core.ActionBuilder;
+import io.gatling.javaapi.core.CheckBuilder;
 import org.galaxio.gatling.kafka.javaapi.checks.KafkaChecks;
-import org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionBuilder;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class RequestReplyBuilder<K, V> implements ActionBuilder {
 
-    private KafkaRequestReplyActionBuilder<K, V> wrapped;
+    private org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionBuilder<K, V> wrapped;
 
-    public RequestReplyBuilder(KafkaRequestReplyActionBuilder<K,V> wrapped) {
+    public RequestReplyBuilder(org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionBuilder<K,V> wrapped) {
         this.wrapped = wrapped;
     }
 
-    public RequestReplyBuilder<K, V> check(Object... checks) {
+    public RequestReplyBuilder<K, V> check(CheckBuilder... checks) {
         return check(Arrays.asList(checks));
     }
 
-    public RequestReplyBuilder<K, V> check(List<Object> checks) {
+    public RequestReplyBuilder<K, V> check(List<CheckBuilder> checks) {
         this.wrapped = wrapped.check(KafkaChecks.toScalaChecks(checks));
         return this;
     }

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/expressions/Builders.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/expressions/Builders.java
@@ -1,0 +1,75 @@
+package org.galaxio.gatling.kafka.javaapi.request.expressions;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+
+import java.nio.ByteBuffer;
+
+public class Builders {
+    public Builders() {
+    }
+
+    public static final class FloatExpressionBuilder extends ExpressionBuilder<Float> {
+        public FloatExpressionBuilder(JExpression<Float> javaExpression) {
+            super(javaExpression, Float.class, Serdes.Float());
+        }
+    }
+
+    public static final class DoubleExpressionBuilder extends ExpressionBuilder<Double> {
+        public DoubleExpressionBuilder(JExpression<Double> javaExpression) {
+            super(javaExpression, Double.class, Serdes.Double());
+        }
+    }
+
+    public static final class ShortExpressionBuilder extends ExpressionBuilder<Short> {
+        public ShortExpressionBuilder(JExpression<Short> javaExpression) {
+            super(javaExpression, Short.class, Serdes.Short());
+        }
+    }
+
+    public static final class IntegerExpressionBuilder extends ExpressionBuilder<Integer> {
+        public IntegerExpressionBuilder(JExpression<Integer> javaExpression) {
+            super(javaExpression, Integer.class, Serdes.Integer());
+        }
+    }
+
+    public static final class LongExpressionBuilder extends ExpressionBuilder<Long> {
+        public LongExpressionBuilder(JExpression<Long> javaExpression) {
+            super(javaExpression, Long.class, Serdes.Long());
+        }
+    }
+
+    public static final class ByteArrayExpressionBuilder extends ExpressionBuilder<byte[]> {
+        public ByteArrayExpressionBuilder(JExpression<byte[]> javaExpression) {
+            super(javaExpression, byte[].class, Serdes.ByteArray());
+        }
+    }
+
+    public static final class ByteBufferExpressionBuilder extends ExpressionBuilder<ByteBuffer> {
+        public ByteBufferExpressionBuilder(JExpression<ByteBuffer> javaExpression) {
+            super(javaExpression, ByteBuffer.class, Serdes.ByteBuffer());
+        }
+    }
+
+    public static final class BytesExpressionBuilder extends ExpressionBuilder<Bytes> {
+        public BytesExpressionBuilder(JExpression<Bytes> javaExpression) {
+            super(javaExpression, Bytes.class, Serdes.Bytes());
+        }
+    }
+
+    public static final class StringExpressionBuilder extends ExpressionBuilder<String> {
+        public StringExpressionBuilder(JExpression<String> javaExpression) {
+            super(javaExpression, String.class, Serdes.String());
+        }
+    }
+
+    public static final class AvroExpressionBuilder extends ExpressionBuilder<Object> {
+        public AvroExpressionBuilder(JExpression<Object> valueF, SchemaRegistryClient client) {
+            super(valueF, Object.class, Serdes.serdeFrom(new KafkaAvroSerializer(client), new KafkaAvroDeserializer(client)));
+        }
+    }
+
+}

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/expressions/ExpressionBuilder.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/expressions/ExpressionBuilder.java
@@ -1,0 +1,33 @@
+package org.galaxio.gatling.kafka.javaapi.request.expressions;
+
+import io.gatling.commons.validation.Validation;
+import io.gatling.javaapi.core.internal.Expressions;
+import org.apache.kafka.common.serialization.Serde;
+
+public abstract class ExpressionBuilder<V> {
+    private final JExpression<V> javaExpression;
+    private final Class<V> type;
+    private final Serde<V> serde;
+
+    protected ExpressionBuilder(JExpression<V> javaExpression, Class<V> type, Serde<V> serde) {
+        this.javaExpression = javaExpression;
+        this.type = type;
+        this.serde = serde;
+    }
+
+    scala.Function1<io.gatling.core.session.Session, Validation<byte[]>> bytes(String topic){
+        return Expressions.javaFunctionToExpression(javaExpression.andThen(v -> serde.serializer().serialize(topic, v)));
+    }
+
+    public scala.Function1<io.gatling.core.session.Session, Validation<V>> gatlingExpression(){
+        return Expressions.javaFunctionToExpression(javaExpression);
+    }
+
+    public Class<V> getType(){
+        return type;
+    }
+
+    public Serde<V> getSerde() {
+        return serde;
+    }
+}

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/expressions/JExpression.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/expressions/JExpression.java
@@ -1,0 +1,4 @@
+package org.galaxio.gatling.kafka.javaapi.request.expressions;
+
+@FunctionalInterface
+public interface JExpression<T> extends java.util.function.Function<io.gatling.javaapi.core.Session, T>{}

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAvro4sRequestAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAvro4sRequestAction.scala
@@ -1,20 +1,22 @@
 package org.galaxio.gatling.kafka.actions
 
 import io.gatling.commons.stats.{KO, OK}
-import io.gatling.commons.util.DefaultClock
-import io.gatling.commons.validation.Validation
+import io.gatling.commons.util.Clock
+import io.gatling.commons.validation._
 import io.gatling.core.CoreComponents
 import io.gatling.core.action.{Action, ExitableAction}
-import io.gatling.core.session.Session
+import io.gatling.core.session.{Expression, Session}
 import io.gatling.core.stats.StatsEngine
 import io.gatling.core.util.NameGen
 import org.apache.avro.generic.GenericRecord
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord, RecordMetadata}
-import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.common.header.Headers
+import org.galaxio.gatling.kafka.protocol.{KafkaComponents, KafkaProtocol}
 import org.galaxio.gatling.kafka.request.builder.Avro4sAttributes
 
 class KafkaAvro4sRequestAction[K, V](
     val producer: KafkaProducer[K, GenericRecord],
+    val components: KafkaComponents,
     val attr: Avro4sAttributes[K, V],
     val coreComponents: CoreComponents,
     val kafkaProtocol: KafkaProtocol,
@@ -22,69 +24,98 @@ class KafkaAvro4sRequestAction[K, V](
     val next: Action,
 ) extends ExitableAction with NameGen {
 
-  val statsEngine: StatsEngine = coreComponents.statsEngine
-  val clock                    = new DefaultClock
   override val name: String    = genName("kafkaAvroRequest")
+  val statsEngine: StatsEngine = coreComponents.statsEngine
+  val clock: Clock             = coreComponents.clock
 
-  override def execute(session: Session): Unit = recover(session) {
-    attr requestName session flatMap { requestName =>
-      val outcome = sendRequest(requestName, producer, attr, throttled, session)
+  override def execute(session: Session): Unit = {
+    recover(session) {
+      val outcome = for {
+        requestNameData <- attr.requestName(session)
+        producerRecord  <- resolveProducerRecord(session)
+      } yield coreComponents.throttler match {
+        case Some(th) if throttled =>
+          th.throttle(session.scenario, () => sendAndLogProducerRecord(requestNameData, producerRecord, session))
+        case _                     => sendAndLogProducerRecord(requestNameData, producerRecord, session)
+      }
 
-      outcome.onFailure(errorMessage => {
-        logger.error(errorMessage)
-        statsEngine.logRequestCrash(session.scenario, session.groups, requestName, s"Failed to build request: $errorMessage")
-      })
+      outcome.onFailure { errorMessage => reportUnbuildableRequest(session, errorMessage) }
 
       outcome
     }
+
   }
 
-  def sendRequest(
-      requestName: String,
-      producer: KafkaProducer[K, GenericRecord],
-      attr: Avro4sAttributes[K, V],
-      throttled: Boolean,
-      session: Session,
-  ): Validation[Unit] = {
-
-    attr payload session map { payload =>
-      val headers = attr.headers
-        .map(h => h(session).toOption.get)
-        .orNull
-      val key     = attr.key
-        .map(k => k(session).toOption.get)
-        .getOrElse(null.asInstanceOf[K])
-
-      val record: ProducerRecord[K, GenericRecord] =
-        new ProducerRecord(kafkaProtocol.producerTopic, null, key, attr.format.to(payload), headers)
-
-      val requestStartDate = clock.nowMillis
-
-      producer.send(
-        record,
-        (_: RecordMetadata, e: Exception) => {
-
-          val requestEndDate = clock.nowMillis
-          statsEngine.logResponse(
-            session.scenario,
-            session.groups,
-            requestName,
-            requestStartDate,
-            requestEndDate,
-            if (e == null) OK else KO,
-            None,
-            if (e == null) None else Some(e.getMessage),
-          )
-
-          coreComponents.throttler match {
-            case Some(th) if throttled => th.throttle(session.scenario, () => next ! session)
-            case _                     => next ! session
-          }
-
-        },
-      )
-
+  private def reportUnbuildableRequest(session: Session, error: String): Unit = {
+    val loggedName = attr.requestName(session) match {
+      case Success(requestNameValue) =>
+        statsEngine.logRequestCrash(session.scenario, session.groups, requestNameValue, s"Failed to build request: $error")
+        requestNameValue
+      case _                         =>
+        name
     }
+    logger.error(s"'$loggedName' failed to execute: $error")
+  }
 
+  private def resolveProducerRecord: Expression[ProducerRecord[K, GenericRecord]] = s =>
+    for {
+      payload <- attr.payload(s).flatMap(pl => scala.util.Try(attr.format.to(pl)).toValidation)
+      key     <- attr.key.fold(null.asInstanceOf[K].success)(_(s))
+      headers <- attr.headers.fold(null.asInstanceOf[Headers].success)(_(s))
+    } yield new ProducerRecord[K, GenericRecord](
+      kafkaProtocol.producerTopic,
+      null,
+      key,
+      payload,
+      headers,
+    )
+
+  private def sendAndLogProducerRecord(
+      requestName: String,
+      record: ProducerRecord[K, GenericRecord],
+      session: Session,
+  ): Unit = {
+    val requestStartDate = clock.nowMillis
+    scala.concurrent.blocking(
+      scala.concurrent
+        .Future(producer.send(record).get())(components.sender.executionContext)
+        .onComplete {
+          case util.Success(rm) =>
+            val requestEndDate = clock.nowMillis
+            if (logger.underlying.isDebugEnabled) {
+              logger.debug(s"Avro record sent user=${session.userId} key=${record.key} topic=${rm.topic()}")
+              logger.trace(s"ProducerRecord=$record")
+            }
+
+            statsEngine.logResponse(
+              session.scenario,
+              session.groups,
+              requestName,
+              startTimestamp = requestStartDate,
+              endTimestamp = requestEndDate,
+              OK,
+              None,
+              None,
+            )
+            next ! session.logGroupRequestTimings(requestStartDate, requestEndDate)
+
+          case util.Failure(exception) =>
+            val requestEndDate = clock.nowMillis
+
+            logger.error(exception.getMessage, exception)
+
+            statsEngine.logResponse(
+              session.scenario,
+              session.groups,
+              requestName,
+              startTimestamp = requestStartDate,
+              endTimestamp = requestEndDate,
+              KO,
+              None,
+              Some(exception.getMessage),
+            )
+            next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
+        }(components.sender.executionContext),
+    )
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestActionBuilder.scala
@@ -24,6 +24,7 @@ class KafkaRequestActionBuilder[K, V](attr: KafkaAttributes[K, V]) extends Actio
 
     new KafkaRequestAction(
       producer,
+      kafkaComponents,
       attr,
       coreComponents,
       kafkaComponents.kafkaProtocol,

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAvro4sActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAvro4sActionBuilder.scala
@@ -23,6 +23,7 @@ class KafkaRequestAvro4sActionBuilder[K, V](attr: Avro4sAttributes[K, V]) extend
 
     new KafkaAvro4sRequestAction(
       producer,
+      kafkaComponents,
       attr,
       coreComponents,
       kafkaComponents.kafkaProtocol,

--- a/src/main/scala/org/galaxio/gatling/kafka/checks/AvroBodyCheckBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/checks/AvroBodyCheckBuilder.scala
@@ -7,7 +7,7 @@ import io.gatling.core.session.ExpressionSuccessWrapper
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.common.serialization.Serde
 import org.galaxio.gatling.kafka.KafkaCheck
-import KafkaCheckMaterializer.KafkaMessageCheckType
+import org.galaxio.gatling.kafka.checks.KafkaCheckMaterializer.KafkaMessageCheckType
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import scala.util.Try

--- a/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaCheckSupport.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaCheckSupport.scala
@@ -17,7 +17,7 @@ import net.sf.saxon.s9api.XdmNode
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.common.serialization.Serde
 import org.galaxio.gatling.kafka.KafkaCheck
-import KafkaCheckMaterializer.KafkaMessageCheckType
+import org.galaxio.gatling.kafka.checks.KafkaCheckMaterializer.KafkaMessageCheckType
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import scala.annotation.implicitNotFound

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorRef
 import io.gatling.core.action.Action
 import io.gatling.core.session.Session
 import org.galaxio.gatling.kafka.KafkaCheck
-import KafkaMessageTrackerActor.MessagePublished
+import org.galaxio.gatling.kafka.client.KafkaMessageTrackerActor.MessagePublished
 
 class KafkaMessageTracker(actor: ActorRef) {
 

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaSender.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaSender.scala
@@ -8,6 +8,7 @@ import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success}
 
 trait KafkaSender {
+  val executionContext: ExecutionContext
   def send(protocolMessage: KafkaProtocolMessage)(
       onSuccess: RecordMetadata => Unit,
       onFailure: Throwable => Unit,
@@ -30,6 +31,7 @@ object KafkaSender {
     override def close(): Unit =
       producer.close()
 
+    override val executionContext: ExecutionContext = ec
   }
 
   def apply(producerSettings: Map[String, AnyRef])(implicit ec: ExecutionContext): KafkaSender = {

--- a/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
@@ -9,8 +9,7 @@ import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.scala.serialization.Serdes._
 import org.galaxio.gatling.kafka.KafkaLogging
-import KafkaMessageTrackerActor.MessageConsumed
-import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
+import org.galaxio.gatling.kafka.client.KafkaMessageTrackerActor.MessageConsumed
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocol.scala
@@ -3,8 +3,8 @@ package org.galaxio.gatling.kafka.protocol
 import io.gatling.core.CoreComponents
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.protocol.{Protocol, ProtocolKey}
-import KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.client.{KafkaSender, TrackersPool}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import java.util.concurrent.Executors

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
@@ -1,6 +1,6 @@
 package org.galaxio.gatling.kafka.protocol
 
-import KafkaProtocol.KafkaKeyMatcher
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher
 
 import scala.concurrent.duration.DurationInt
 

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNew.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNew.scala
@@ -4,7 +4,7 @@ import io.gatling.core.session.Expression
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.StreamsConfig
-import KafkaProtocol._
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol._
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}

--- a/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/ProducerSimulation.java
+++ b/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/ProducerSimulation.java
@@ -1,12 +1,17 @@
 package org.galaxio.gatling.kafka.javaapi.examples;
 
 import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.core.Session;
 import io.gatling.javaapi.core.Simulation;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.galaxio.gatling.kafka.javaapi.protocol.KafkaProtocolBuilder;
 import org.galaxio.gatling.kafka.javaapi.KafkaDsl;
 
+import java.nio.charset.Charset;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.gatling.javaapi.core.CoreDsl.*;
 import static org.galaxio.gatling.kafka.javaapi.KafkaDsl.kafka;
@@ -15,10 +20,16 @@ public class ProducerSimulation extends Simulation {
 
     private final KafkaProtocolBuilder kafkaConsumerConf =
             KafkaDsl.kafka().topic("test.topic")
-            .properties(Map.of(ProducerConfig.ACKS_CONFIG, "1"));
+                    .properties(Map.of(ProducerConfig.ACKS_CONFIG, "1"));
+
+    private Headers header(Session session) {
+        var uuid = Optional.ofNullable(session.getString("UUID")).orElse("");
+        return new RecordHeaders().add("uuid-header", uuid.getBytes(Charset.defaultCharset()));
+    }
 
     private final ScenarioBuilder scn = scenario("Basic")
-            .exec(KafkaDsl.kafka("BasicRequest").send("foo"))
-            .exec(KafkaDsl.kafka("dld").send("true", 12.0));
+            .exec(kafka("BasicRequest").send("foo"))
+            .exec(kafka("dld").send("true", 12.0))
+            .exec(kafka("Msg1").send("key", "val", this::header));
 
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaJavaapiMethodsGatlingTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaJavaapiMethodsGatlingTest.scala
@@ -1,14 +1,29 @@
 package org.galaxio.gatling.kafka.examples
 
 import io.gatling.core.Predef._
+import io.gatling.core.feeder.Feeder
+import io.gatling.core.protocol.Protocol
 import io.gatling.core.structure.ScenarioBuilder
 import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.galaxio.gatling.kafka.javaapi.KafkaDsl._
+import org.galaxio.gatling.kafka.javaapi.request.expressions.JExpression
+
+import java.util.concurrent.atomic.AtomicInteger
 
 class KafkaJavaapiMethodsGatlingTest extends Simulation {
 
-  val kafkaConfwoKey = kafka
+  val c                            = new AtomicInteger(0)
+  val feeder: Feeder[Int]          = Iterator.continually(Map("key" -> c.incrementAndGet()))
+  val hFeeder: Feeder[Array[Byte]] = Iterator.continually(Map("headerId" -> java.util.UUID.randomUUID().toString.getBytes))
+
+  val headers: JExpression[Headers] = s => {
+    val bytes = java.util.Optional.ofNullable(s.get[Array[Byte]]("headerId")).orElse("".getBytes)
+    new RecordHeaders().add("test-header", bytes)
+  }
+
+  val kafkaConfwoKey: Protocol = kafka
     .topic("myTopic3")
     .properties(
       java.util.Map.of(
@@ -26,6 +41,8 @@ class KafkaJavaapiMethodsGatlingTest extends Simulation {
 
   setUp(
     scenario("Request String without key")
+      .feed(hFeeder)
+      .feed(feeder)
       .exec(
         kafka("Request String without headers and key")
           .send("testJavaWithoutKeyAndHeaders")
@@ -36,6 +53,7 @@ class KafkaJavaapiMethodsGatlingTest extends Simulation {
           .send("testJavaWithHeadersWithoutKey", new RecordHeaders().add("test-header", "test_value".getBytes()))
           .asScala(),
       )
+      .exec(kafka("MsgBuilders").send("key#{key}", "val", headers).asScala())
       .inject(nothingFor(1), atOnceUsers(1))
       .protocols(kafkaConfwoKey),
   )


### PR DESCRIPTION
Hello all. 
These are add-ons for DSL in Java and Kotlin that allow you to interact with session variables in requests in a way similar to how it works in Scala. It also solves the problem of not being able to get any variables from the session and put them in headers. You can check how it works fully in [ProducerSimulation.java](https://github.com/galax-io/gatling-kafka-plugin/blob/8cc494537fa21e1765ac818293c1407136d3ee24/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/ProducerSimulation.java)

**Example Java-DSL:**
```java
...
private Headers header(Session session) {
    var uuid = Optional.ofNullable(session.getString("UUID")).orElse("");
    return new RecordHeaders().add("uuid-header", uuid.getBytes(Charset.defaultCharset()));
}
...
scenario("Basic").exec(kafka("Msg1").send("key", "val", this::header));
```

It also introduces a new [ExpressionBuilder](https://github.com/galax-io/gatling-kafka-plugin/blob/8cc494537fa21e1765ac818293c1407136d3ee24/src/main/java/org/galaxio/gatling/kafka/javaapi/request/expressions/ExpressionBuilder.java) class that encapsulates the logic of serialization/deserialization of keys and values ​​in Kafka messages. Ready-made functions were also added that create builders for primitive types and Avro classes.
**Example Avro:**
```java
import static org.galaxio.gatling.kafka.javaapi.KafkaDsl.*;
...
 private static final SchemaRegistryClient client = new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16);
...
kafka("Message1").send("#{key}", avro(new MyAvroClass("data"), client));
kafka("msg").send("#{key}", avro(s -> new MyAvroClass(s.getString("sessionVar")), client));
```

Closes #15
Closes #17