### PR TITLE
refactor: switch from kafka-streams to consumer for more control over settings

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
@@ -1,0 +1,101 @@
+package org.galaxio.gatling.kafka.client
+
+import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer}
+import org.apache.kafka.common.errors.WakeupException
+
+import java.time.Duration
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
+import scala.jdk.CollectionConverters._
+
+object DynamicKafkaConsumer {
+
+  def apply[K, V](
+      settingsMap: Map[String, AnyRef],
+      topics: Set[String],
+      onRecord: ConsumerRecord[K, V] => Unit,
+      onFailure: Exception => Unit,
+  ): DynamicKafkaConsumer[K, V] = {
+    val settings = new Properties()
+    settings.putAll(settingsMap.asJava)
+    new DynamicKafkaConsumer[K, V](settings, topics, onRecord, onFailure)
+  }
+}
+
+final class DynamicKafkaConsumer[K, V] private (
+    settings: Properties,
+    topics: Set[String],
+    onRecord: ConsumerRecord[K, V] => Unit,
+    onFailure: Exception => Unit,
+) extends Runnable with AutoCloseable {
+
+  private val topicsQueue: java.util.Queue[String] = new ConcurrentLinkedQueue[String]()
+  topicsQueue.addAll(topics.asJava)
+
+  private val running: AtomicBoolean        = new AtomicBoolean(true)
+  private val consumer: KafkaConsumer[K, V] = new KafkaConsumer[K, V](settings)
+  private val initLatch: CountDownLatch     = if (this.topicsQueue.isEmpty) new CountDownLatch(1) else new CountDownLatch(0)
+
+  def addTopicForSubscription(newTopic: String): Unit = {
+    this.topicsQueue.add(newTopic)
+    if (initLatch.getCount > 0) { // need for staring processing loop
+      initLatch.countDown()
+    }
+  }
+
+  private def getTopicsForSubscription: java.util.Set[String] = {
+    if (!this.topicsQueue.isEmpty) {
+      val forSubscribe = new java.util.HashSet[String]()
+      while (!this.topicsQueue.isEmpty)
+        forSubscribe.add(this.topicsQueue.poll)
+      if (this.consumer.subscription.containsAll(forSubscribe))
+        return java.util.Set.of()
+      forSubscribe.addAll(this.consumer.subscription)
+      return java.util.Collections.unmodifiableSet(forSubscribe)
+    }
+    java.util.Set.of()
+  }
+
+  override def run(): Unit = {
+    try {
+      this.initLatch.await()
+      this.consumer.subscribe(getTopicsForSubscription)
+      while (running.get) {
+        val records = this.consumer.poll(Duration.ofMillis(1000))
+        records.forEach(record =>
+          try this.onRecord(record)
+          catch {
+            case e: Exception =>
+              this.onFailure(e)
+          },
+        )
+
+        val topicsForSubscription = getTopicsForSubscription
+        if (!topicsForSubscription.isEmpty) {
+          consumer.subscribe(topicsForSubscription) // Subscribe to all
+
+        }
+      }
+    } catch {
+      case e: WakeupException =>
+        // Ignore exception if closing
+        // rethrow when someone call wakeup while it is working
+        if (running.get) throw e
+      case e: Exception       =>
+        // unexpected exception
+        throw new RuntimeException(e)
+    } finally {
+      this.topicsQueue.clear()
+      consumer.close()
+    }
+  }
+
+  override def close(): Unit = {
+    this.running.set(false)
+    if (this.initLatch.getCount > 0) {
+      this.initLatch.countDown()
+    }
+    this.consumer.wakeup()
+  }
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
@@ -1,5 +1,6 @@
 package org.galaxio.gatling.kafka.protocol
 
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.StreamsConfig
@@ -80,8 +81,8 @@ final case class KafkaProtocolBuilder(
     )
 
     val consumeDefaults = Map(
-      StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG   -> Serdes.ByteArray().getClass.getName,
-      StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG -> Serdes.ByteArray().getClass.getName,
+      ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> Serdes.ByteArray().deserializer().getClass.getName,
+      ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> Serdes.ByteArray().deserializer().getClass.getName,
     )
 
     KafkaProtocol("kafka-test", producerSettings ++ serializers, consumeDefaults ++ consumeSettings, timeout, messageMatcher)

--- a/src/main/scala/org/galaxio/gatling/kafka/request/KafkaProtocolMessage.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/KafkaProtocolMessage.scala
@@ -36,7 +36,7 @@ final case class KafkaProtocolMessage(
 
 object KafkaProtocolMessage {
   def from(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], inputTopic: Option[String]): KafkaProtocolMessage =
-    new KafkaProtocolMessage(
+    KafkaProtocolMessage(
       consumerRecord.key(),
       consumerRecord.value(),
       inputTopic.getOrElse("<unknown>"),


### PR DESCRIPTION

The internal implementation of message consumption from a topic has been changed to a consumer, which subscribes dynamically to new topics. Also, since there is only one consumer and it exists the entire time of the test, there is no need to regenerate applicationId/groupId. This is either taken from the consumer settings or generated using the template `gatling-kafka-test-N` where N - is some integer

Closes #28 
