### PR TITLE
feat: allow to implement custom matcher

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object Dependencies {
   private object Versions {
     val kafka          = "7.9.2-ccs"
-    val gatling        = "3.13.5"
+    val gatling        = "3.15.0"
     val avro4s         = "4.1.2"
     val avro           = "1.12.0"
     val kafkaAvroSerde = "7.9.2"

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/protocol/KafkaProtocolBuilder.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/protocol/KafkaProtocolBuilder.java
@@ -2,6 +2,7 @@ package org.galaxio.gatling.kafka.javaapi.protocol;
 
 import io.gatling.core.protocol.Protocol;
 import io.gatling.javaapi.core.ProtocolBuilder;
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol;
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage;
 import scala.Function1;
 
@@ -20,6 +21,11 @@ public class KafkaProtocolBuilder implements ProtocolBuilder {
 
     public KafkaProtocolBuilder matchByMessage(Function1<KafkaProtocolMessage, byte[]> keyExtractor) {
         this.wrapped = wrapped.matchByMessage(keyExtractor);
+        return this;
+    }
+
+    public KafkaProtocolBuilder matchByKafkaMatcher(KafkaProtocol.KafkaMatcher kafkaMatcher) {
+        this.wrapped = wrapped.matchByKafkaMatcher(kafkaMatcher);
         return this;
     }
 

--- a/src/main/scala/org/galaxio/gatling/kafka/checks/AvroBodyCheckBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/checks/AvroBodyCheckBuilder.scala
@@ -24,6 +24,6 @@ object AvroBodyCheckBuilder {
       }
     }.expressionSuccess
 
-    new Find.Default[KafkaMessageCheckType, KafkaProtocolMessage, T](tExtractor, displayActualValue = true)
+    new Find.Default[KafkaMessageCheckType, KafkaProtocolMessage, T](tExtractor, logActualValueInError = true)
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
@@ -63,6 +63,8 @@ final case class KafkaProtocolBuilder(
     messageMatcher: KafkaMatcher = KafkaKeyMatcher,
 ) {
 
+  def matchByKafkaMatcher(kafkaMatcher: KafkaMatcher): KafkaProtocolBuilder = messageMatcher(kafkaMatcher)
+
   def matchByValue: KafkaProtocolBuilder =
     messageMatcher(KafkaValueMatcher)
 

--- a/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
+++ b/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
@@ -5,6 +5,7 @@ import io.gatling.javaapi.core.Simulation;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.galaxio.gatling.kafka.javaapi.KafkaDsl;
 import org.galaxio.gatling.kafka.javaapi.protocol.KafkaProtocolBuilder;
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol;
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage;
 
 import java.time.Duration;
@@ -56,6 +57,33 @@ public class MatchSimulation extends Simulation {
             )
             .timeout(Duration.ofSeconds(5))
             .matchByMessage(this::matchByOwnVal);
+
+    private final KafkaProtocolBuilder kafkaProtocolMatchByKafkaMatcher = KafkaDsl.kafka()
+            .producerSettings(
+                    Map.of(
+                            ProducerConfig.ACKS_CONFIG, "1",
+                            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"
+                    )
+            )
+            .consumeSettings(
+                    Map.of(
+                            "bootstrap.servers", "localhost:9092"
+                    )
+            )
+            .timeout(Duration.ofSeconds(5))
+            .matchByKafkaMatcher(new KafkaProtocol.KafkaMatcher() {
+                // here you can fully customize your logic in order to use different properties
+                // for request and response
+                @Override
+                public byte[] requestMatch(KafkaProtocolMessage msg) {
+                    return msg.key();
+                }
+
+                @Override
+                public byte[] responseMatch(KafkaProtocolMessage msg) {
+                    return msg.key();
+                }
+            });
 
     private final AtomicInteger c = new AtomicInteger(0);
     private final Iterator<Map<String, Object>> feeder =

--- a/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
+++ b/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
@@ -47,6 +47,30 @@ class MatchSimulation : Simulation() {
         .timeout(Duration.ofSeconds(5))
         .matchByMessage { message: KafkaProtocolMessage -> matchByOwnVal(message) }
 
+    private val kafkaProtocolMatchByKafkaMatcher = kafka().requestReply()
+        .producerSettings(
+            mapOf<String, Any>(
+                ProducerConfig.ACKS_CONFIG to "1",
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:9092"
+            )
+        )
+        .consumeSettings(
+            mapOf<String, Any>(
+                "bootstrap.servers" to "localhost:9092"
+            )
+        )
+        .timeout(Duration.ofSeconds(5))
+        .matchByKafkaMatcher(object : KafkaMatcher {
+            // here you can fully customize your logic in order to use different properties
+            // for request and response
+            override fun requestMatch(msg: KafkaProtocolMessage): ByteArray {
+                return msg.key
+            }
+            override fun responseMatch(msg: KafkaProtocolMessage): ByteArray {
+                return msg.key
+            }
+        })
+
     private val c = AtomicInteger(0)
 
     private val feeder = generateSequence {

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -13,6 +13,7 @@ import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import scala.concurrent.duration.DurationInt
@@ -119,6 +120,25 @@ class KafkaGatlingTest extends Simulation {
     )
     .timeout(7.seconds)
     .matchByMessage(matchByOwnVal)
+
+  val kafkaProtocolRRAvroCustomMatcher: KafkaProtocol = kafka
+    .producerSettings(
+      ProducerConfig.ACKS_CONFIG                   -> "1",
+      ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> "localhost:9093",
+      ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> "org.apache.kafka.common.serialization.StringSerializer",
+      ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "io.confluent.kafka.serializers.KafkaAvroSerializer",
+      "value.subject.name.strategy"                -> "io.confluent.kafka.serializers.subject.RecordNameStrategy",
+      "schema.registry.url"                        -> "http://localhost:9094",
+    )
+    .consumeSettings(
+      "bootstrap.servers" -> "localhost:9093",
+    )
+    .timeout(7.seconds)
+    .matchByKafkaMatcher(new KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.key
+
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.key
+    })
 
   val scnRR: ScenarioBuilder = scenario("RequestReply String")
     .exec(


### PR DESCRIPTION
This MR allows user to have full control over matcher in case you need different logic to extract the value in request and response.
I've also update the gatling version to 3.15.0