### PR TITLE
feat: allow custom kafka matcher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val root = (project in file("."))
     scalaVersion                := scalaV,
     libraryDependencies ++= gatling,
     libraryDependencies ++= gatlingTest,
+    libraryDependencies ++= unitTest,
     libraryDependencies ++= kafka,
     libraryDependencies ++= Seq(avro4s, avroCore, avroSerdes, avroSerializers),
     schemaRegistrySubjects ++= avroSchemas,
@@ -21,6 +22,7 @@ lazy val root = (project in file("."))
     // Do not publish artifacts for Gatling-configured scopes (this is a library)
     Gatling / publishArtifact   := false,
     GatlingIt / publishArtifact := false,
+    Test / testFrameworks += new TestFramework("org.scalatest.tools.Framework"),
     scalacOptions ++= Seq(
       "-encoding",
       "UTF-8",            // Option and arguments on same line

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object Dependencies {
   private object Versions {
     val kafka          = "7.9.2-ccs"
-    val gatling        = "3.13.5"
+    val gatling        = "3.15.0"
     val avro4s         = "4.1.2"
     val avro           = "1.12.0"
     val kafkaAvroSerde = "7.9.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
     val avro4s         = "4.1.2"
     val avro           = "1.12.0"
     val kafkaAvroSerde = "7.9.2"
+    val scalaTest      = "3.2.19"
   }
 
   lazy val gatling: Seq[ModuleID] = Seq(
@@ -17,6 +18,10 @@ object Dependencies {
   lazy val gatlingTest: Seq[ModuleID] = Seq(
     "io.gatling.highcharts" % "gatling-charts-highcharts" % Versions.gatling % "it,test",
     "io.gatling"            % "gatling-test-framework"    % Versions.gatling % "it,test",
+  )
+
+  lazy val unitTest: Seq[ModuleID] = Seq(
+    "org.scalatest" %% "scalatest" % Versions.scalaTest % Test,
   )
 
   lazy val kafka: Seq[ModuleID] = Seq(

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/protocol/KafkaProtocolBuilder.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/protocol/KafkaProtocolBuilder.java
@@ -2,6 +2,7 @@ package org.galaxio.gatling.kafka.javaapi.protocol;
 
 import io.gatling.core.protocol.Protocol;
 import io.gatling.javaapi.core.ProtocolBuilder;
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol;
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage;
 import scala.Function1;
 
@@ -20,6 +21,11 @@ public class KafkaProtocolBuilder implements ProtocolBuilder {
 
     public KafkaProtocolBuilder matchByMessage(Function1<KafkaProtocolMessage, byte[]> keyExtractor) {
         this.wrapped = wrapped.matchByMessage(keyExtractor);
+        return this;
+    }
+
+    public KafkaProtocolBuilder matchByKafkaMatcher(KafkaProtocol.KafkaMatcher kafkaMatcher) {
+        this.wrapped = wrapped.matchByKafkaMatcher(kafkaMatcher);
         return this;
     }
 

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -9,11 +9,20 @@ import io.gatling.core.controller.throttle.Throttler
 import io.gatling.core.session.Session
 import io.gatling.core.stats.StatsEngine
 import org.galaxio.gatling.kafka.client.KafkaMessageTracker
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.protocol.KafkaComponents
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.galaxio.gatling.kafka.request.builder.KafkaAttributes
 
 import scala.reflect.ClassTag
+
+object KafkaRequestReplyAction {
+  private[kafka] def requestMatchIdOrError(
+      protocolMessage: KafkaProtocolMessage,
+      messageMatcher: KafkaMatcher,
+  ): Either[String, Array[Byte]] =
+    Option(messageMatcher.requestMatch(protocolMessage)).toRight("request matcher returned null match id")
+}
 
 class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
     components: KafkaComponents,
@@ -37,26 +46,41 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
             protocolMessage,
           )
         }
-        val id = components.kafkaProtocol.messageMatcher.requestMatch(protocolMessage)
-
-        components.trackersPool.map { trackers =>
-          val tracker = trackers.tracker(
-            protocolMessage.producerTopic,
-            protocolMessage.consumerTopic,
-            components.kafkaProtocol.messageMatcher,
-            None,
-            components.kafkaProtocol.timeout,
-          )
-          tracker ! KafkaMessageTracker
-            .MessagePublished(
-              id,
-              clock.nowMillis,
-              components.kafkaProtocol.timeout.toMillis,
-              attributes.checks,
-              session,
-              next,
+        KafkaRequestReplyAction.requestMatchIdOrError(protocolMessage, components.kafkaProtocol.messageMatcher) match {
+          case Right(id)          =>
+            components.trackersPool.map { trackers =>
+              val tracker = trackers.tracker(
+                protocolMessage.producerTopic,
+                protocolMessage.consumerTopic,
+                components.kafkaProtocol.messageMatcher,
+                None,
+                components.kafkaProtocol.timeout,
+              )
+              tracker ! KafkaMessageTracker
+                .MessagePublished(
+                  id,
+                  clock.nowMillis,
+                  components.kafkaProtocol.timeout.toMillis,
+                  attributes.checks,
+                  session,
+                  next,
+                  requestNameString,
+                )
+            }
+          case Left(errorMessage) =>
+            val requestEndDate = clock.nowMillis
+            logger.error(errorMessage)
+            statsEngine.logResponse(
+              session.scenario,
+              session.groups,
               requestNameString,
+              requestStartDate,
+              requestEndDate,
+              KO,
+              Some("500"),
+              Some(errorMessage),
             )
+            next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
         }
       },
       e => {

--- a/src/main/scala/org/galaxio/gatling/kafka/checks/AvroBodyCheckBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/checks/AvroBodyCheckBuilder.scala
@@ -24,6 +24,6 @@ object AvroBodyCheckBuilder {
       }
     }.expressionSuccess
 
-    new Find.Default[KafkaMessageCheckType, KafkaProtocolMessage, T](tExtractor, displayActualValue = true)
+    new Find.Default[KafkaMessageCheckType, KafkaProtocolMessage, T](tExtractor, logActualValueInError = true)
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
@@ -63,6 +63,8 @@ final case class KafkaProtocolBuilder(
     messageMatcher: KafkaMatcher = KafkaKeyMatcher,
 ) {
 
+  def matchByKafkaMatcher(kafkaMatcher: KafkaMatcher): KafkaProtocolBuilder = messageMatcher(kafkaMatcher)
+
   def matchByValue: KafkaProtocolBuilder =
     messageMatcher(KafkaValueMatcher)
 

--- a/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
+++ b/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
@@ -5,6 +5,7 @@ import io.gatling.javaapi.core.Simulation;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.galaxio.gatling.kafka.javaapi.KafkaDsl;
 import org.galaxio.gatling.kafka.javaapi.protocol.KafkaProtocolBuilder;
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol;
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage;
 
 import java.time.Duration;
@@ -56,6 +57,33 @@ public class MatchSimulation extends Simulation {
             )
             .timeout(Duration.ofSeconds(5))
             .matchByMessage(this::matchByOwnVal);
+
+    private final KafkaProtocolBuilder kafkaProtocolMatchByKafkaMatcher = KafkaDsl.kafka()
+            .producerSettings(
+                    Map.of(
+                            ProducerConfig.ACKS_CONFIG, "1",
+                            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"
+                    )
+            )
+            .consumeSettings(
+                    Map.of(
+                            "bootstrap.servers", "localhost:9092"
+                    )
+            )
+            .timeout(Duration.ofSeconds(5))
+            .matchByKafkaMatcher(new KafkaProtocol.KafkaMatcher() {
+                // here you can fully customize your logic in order to use different properties
+                // for request and response
+                @Override
+                public byte[] requestMatch(KafkaProtocolMessage msg) {
+                    return msg.key();
+                }
+
+                @Override
+                public byte[] responseMatch(KafkaProtocolMessage msg) {
+                    return msg.key();
+                }
+            });
 
     private final AtomicInteger c = new AtomicInteger(0);
     private final Iterator<Map<String, Object>> feeder =

--- a/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
+++ b/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
@@ -47,6 +47,30 @@ class MatchSimulation : Simulation() {
         .timeout(Duration.ofSeconds(5))
         .matchByMessage { message: KafkaProtocolMessage -> matchByOwnVal(message) }
 
+    private val kafkaProtocolMatchByKafkaMatcher = kafka().requestReply()
+        .producerSettings(
+            mapOf<String, Any>(
+                ProducerConfig.ACKS_CONFIG to "1",
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:9092"
+            )
+        )
+        .consumeSettings(
+            mapOf<String, Any>(
+                "bootstrap.servers" to "localhost:9092"
+            )
+        )
+        .timeout(Duration.ofSeconds(5))
+        .matchByKafkaMatcher(object : KafkaMatcher {
+            // here you can fully customize your logic in order to use different properties
+            // for request and response
+            override fun requestMatch(msg: KafkaProtocolMessage): ByteArray {
+                return msg.key
+            }
+            override fun responseMatch(msg: KafkaProtocolMessage): ByteArray {
+                return msg.key
+            }
+        })
+
     private val c = AtomicInteger(0)
 
     private val feeder = generateSequence {

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
@@ -1,0 +1,37 @@
+package org.galaxio.gatling.kafka.actions
+
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.scalatest.funsuite.AnyFunSuite
+
+class KafkaRequestReplyActionSpec extends AnyFunSuite {
+
+  private val protocolMessage = KafkaProtocolMessage(
+    key = "request-key".getBytes(),
+    value = "response-value".getBytes(),
+    producerTopic = "requests",
+    consumerTopic = "replies",
+  )
+
+  test("requestMatchIdOrError returns request match id when matcher is valid") {
+    val matcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+
+    val result = KafkaRequestReplyAction.requestMatchIdOrError(protocolMessage, matcher)
+
+    assert(result.exists(_.sameElements("request-key".getBytes())))
+  }
+
+  test("requestMatchIdOrError rejects null request match id") {
+    val matcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = null
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+
+    val result = KafkaRequestReplyAction.requestMatchIdOrError(protocolMessage, matcher)
+
+    assert(result == Left("request matcher returned null match id"))
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -13,6 +13,7 @@ import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import scala.concurrent.duration.DurationInt
@@ -119,6 +120,25 @@ class KafkaGatlingTest extends Simulation {
     )
     .timeout(7.seconds)
     .matchByMessage(matchByOwnVal)
+
+  val kafkaProtocolRRAvroCustomMatcher: KafkaProtocol = kafka
+    .producerSettings(
+      ProducerConfig.ACKS_CONFIG                   -> "1",
+      ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> "localhost:9093",
+      ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> "org.apache.kafka.common.serialization.StringSerializer",
+      ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "io.confluent.kafka.serializers.KafkaAvroSerializer",
+      "value.subject.name.strategy"                -> "io.confluent.kafka.serializers.subject.RecordNameStrategy",
+      "schema.registry.url"                        -> "http://localhost:9094",
+    )
+    .consumeSettings(
+      "bootstrap.servers" -> "localhost:9093",
+    )
+    .timeout(7.seconds)
+    .matchByKafkaMatcher(new KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.key
+
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.key
+    })
 
   val scnRR: ScenarioBuilder = scenario("RequestReply String")
     .exec(

--- a/src/test/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderSpec.scala
@@ -1,0 +1,33 @@
+package org.galaxio.gatling.kafka.protocol
+
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.concurrent.duration.DurationInt
+
+class KafkaProtocolBuilderSpec extends AnyFunSuite {
+
+  test("matchByKafkaMatcher keeps different request and response extractors") {
+    val matcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+
+    val protocol = KafkaProtocolBuilder
+      .producerSettings("bootstrap.servers" -> "localhost:9092")
+      .consumeSettings("bootstrap.servers" -> "localhost:9092")
+      .timeout(5.seconds)
+      .matchByKafkaMatcher(matcher)
+      .build
+
+    val message = KafkaProtocolMessage(
+      key = "request-id".getBytes(),
+      value = "response-id".getBytes(),
+      producerTopic = "requests",
+      consumerTopic = "replies",
+    )
+
+    assert(protocol.messageMatcher.requestMatch(message).sameElements("request-id".getBytes()))
+    assert(protocol.messageMatcher.responseMatch(message).sameElements("response-id".getBytes()))
+  }
+}


### PR DESCRIPTION
Supersedes #51.

This PR keeps the custom `KafkaMatcher` support from #51, but moves review to a repository-owned branch and adds hardening that was missing from the original proposal.

What is included:
- expose `matchByKafkaMatcher(...)` in Scala and Java DSL
- keep support for asymmetric request/reply extraction logic via `KafkaMatcher`
- add unit-test support with ScalaTest
- add automated coverage for custom matcher wiring
- reject `null` request-side match ids with a controlled KO instead of tracking them under an empty key

Why supersede #51:
- the original PR comes from an external branch
- this branch is rebased and owned in-repo
- it includes the missing automated coverage and request-side guardrails

Validation:
- `sbt 'testOnly org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionSpec org.galaxio.gatling.kafka.protocol.KafkaProtocolBuilderSpec'`
- `sbt scalafmtCheckAll`
- `sbt --batch 'Test / compile'`

Follow-ups still recommended before calling the matcher API production-ready:
- #53
- #58
- #60
