### PR TITLE
feat: allow custom kafka matcher

### DIFF
--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/protocol/KafkaProtocolBuilderNew.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/protocol/KafkaProtocolBuilderNew.java
@@ -2,6 +2,7 @@ package org.galaxio.gatling.kafka.javaapi.protocol;
 
 import io.gatling.core.protocol.Protocol;
 import io.gatling.javaapi.core.ProtocolBuilder;
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol;
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage;
 import scala.Function1;
 
@@ -23,11 +24,15 @@ public class KafkaProtocolBuilderNew implements ProtocolBuilder {
         return this;
     }
 
+    public KafkaProtocolBuilderNew matchByKafkaMatcher(KafkaProtocol.KafkaMatcher kafkaMatcher) {
+        this.wrapped = wrapped.matchByKafkaMatcher(kafkaMatcher);
+        return this;
+    }
+
     @Override
     public Protocol protocol() {
         return wrapped.build();
     }
 
 }
-
 

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -11,11 +11,20 @@ import io.gatling.core.stats.StatsEngine
 import io.gatling.core.util.NameGen
 import org.apache.kafka.common.serialization.Serializer
 import org.galaxio.gatling.kafka.KafkaLogging
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.protocol.KafkaComponents
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.galaxio.gatling.kafka.request.builder.KafkaRequestReplyAttributes
 
 import scala.reflect.{ClassTag, classTag}
+
+object KafkaRequestReplyAction {
+  private[kafka] def requestMatchIdOrError(
+      protocolMessage: KafkaProtocolMessage,
+      messageMatcher: KafkaMatcher,
+  ): Either[String, Array[Byte]] =
+    Option(messageMatcher.requestMatch(protocolMessage)).toRight("request matcher returned null match id")
+}
 
 class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
     components: KafkaComponents,
@@ -87,19 +96,36 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
         if (logger.underlying.isDebugEnabled) {
           logMessage(s"Record sent user=${session.userId} key=${new String(msg.key)} topic=${rm.topic()}", msg)
         }
-        val id = components.kafkaProtocol.messageMatcher.requestMatch(msg)
-        components.trackersPool
-          .tracker(msg.inputTopic, msg.outputTopic, components.kafkaProtocol.messageMatcher, None)
-          .track(
-            id,
-            clock.nowMillis,
-            components.kafkaProtocol.timeout.toMillis,
-            attributes.checks,
-            session,
-            next,
-            requestNameString,
-            attributes.silent.getOrElse(false),
-          )
+        KafkaRequestReplyAction.requestMatchIdOrError(msg, components.kafkaProtocol.messageMatcher) match {
+          case Right(id)          =>
+            components.trackersPool
+              .tracker(msg.inputTopic, msg.outputTopic, components.kafkaProtocol.messageMatcher, None)
+              .track(
+                id,
+                clock.nowMillis,
+                components.kafkaProtocol.timeout.toMillis,
+                attributes.checks,
+                session,
+                next,
+                requestNameString,
+                attributes.silent.getOrElse(false),
+              )
+          case Left(errorMessage) =>
+            logger.error(errorMessage)
+            if (!attributes.silent.getOrElse(false)) {
+              statsEngine.logResponse(
+                session.scenario,
+                session.groups,
+                requestNameString,
+                now,
+                clock.nowMillis,
+                KO,
+                Some("500"),
+                Some(errorMessage),
+              )
+            }
+            next ! session.logGroupRequestTimings(now, clock.nowMillis).markAsFailed
+        }
       },
       e => {
         logger.error(e.getMessage, e)

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNew.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNew.scala
@@ -29,6 +29,9 @@ case class KafkaProtocolBuilderNew(
     messageMatcher: KafkaMatcher = KafkaKeyMatcher,
 ) extends {
 
+  def matchByKafkaMatcher(kafkaMatcher: KafkaMatcher): KafkaProtocolBuilderNew =
+    messageMatcher(kafkaMatcher)
+
   def matchByValue: KafkaProtocolBuilderNew =
     messageMatcher(KafkaValueMatcher)
 

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
@@ -1,0 +1,37 @@
+package org.galaxio.gatling.kafka.actions
+
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.scalatest.funsuite.AnyFunSuite
+
+class KafkaRequestReplyActionSpec extends AnyFunSuite {
+
+  private val protocolMessage = KafkaProtocolMessage(
+    key = "request-key".getBytes(),
+    value = "response-value".getBytes(),
+    inputTopic = "requests",
+    outputTopic = "replies",
+  )
+
+  test("requestMatchIdOrError returns request match id when matcher is valid") {
+    val matcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+
+    val result = KafkaRequestReplyAction.requestMatchIdOrError(protocolMessage, matcher)
+
+    assert(result.exists(_.sameElements("request-key".getBytes())))
+  }
+
+  test("requestMatchIdOrError rejects null request match id") {
+    val matcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = null
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+
+    val result = KafkaRequestReplyAction.requestMatchIdOrError(protocolMessage, matcher)
+
+    assert(result == Left("request matcher returned null match id"))
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNewSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNewSpec.scala
@@ -1,0 +1,33 @@
+package org.galaxio.gatling.kafka.protocol
+
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.concurrent.duration.DurationInt
+
+class KafkaProtocolBuilderNewSpec extends AnyFunSuite {
+
+  test("matchByKafkaMatcher keeps different request and response extractors") {
+    val matcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+
+    val protocol = KafkaProtocolBuilderNew
+      .producerSettings(Map("bootstrap.servers" -> "localhost:9092"))
+      .consumeSettings(Map("bootstrap.servers" -> "localhost:9092"))
+      .timeout(5.seconds)
+      .matchByKafkaMatcher(matcher)
+      .build
+
+    val message = KafkaProtocolMessage(
+      key = "request-id".getBytes(),
+      value = "response-id".getBytes(),
+      inputTopic = "requests",
+      outputTopic = "replies",
+    )
+
+    assert(protocol.messageMatcher.requestMatch(message).sameElements("request-id".getBytes()))
+    assert(protocol.messageMatcher.responseMatch(message).sameElements("response-id".getBytes()))
+  }
+}


### PR DESCRIPTION
Supersedes #51 for the Gatling 3.11 line.

This PR brings custom `KafkaMatcher` support to the `deprecated/gatling-3-11` branch and adds the missing hardening needed for safer review.

What is included:
- expose `matchByKafkaMatcher(...)` in the 3.11 Scala request-reply protocol builder
- expose `matchByKafkaMatcher(...)` in the 3.11 Java DSL
- add automated coverage for asymmetric request/reply matcher wiring
- reject `null` request-side match ids with a controlled KO instead of tracking them under an empty key

Validation:
- `sbt 'testOnly org.galaxio.gatling.kafka.protocol.KafkaProtocolBuilderNewSpec org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionSpec'`
- `sbt scalafmtCheckAll`
- `sbt --batch 'Test / compile'`

Related follow-ups:
- #53
- #58
- #60
