### PR TITLE
fix: ensure reply consumer readiness before first send

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -11,6 +11,7 @@ import io.gatling.core.stats.StatsEngine
 import io.gatling.core.util.NameGen
 import org.apache.kafka.common.serialization.Serializer
 import org.galaxio.gatling.kafka.KafkaLogging
+import org.galaxio.gatling.kafka.client.{KafkaMessageTracker, KafkaTrackerProvider}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.protocol.KafkaComponents
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
@@ -19,11 +20,28 @@ import org.galaxio.gatling.kafka.request.builder.KafkaRequestReplyAttributes
 import scala.reflect.{ClassTag, classTag}
 
 object KafkaRequestReplyAction {
+  private[kafka] final case class PreparedTracker(
+      matchId: Array[Byte],
+      tracker: KafkaMessageTracker,
+  )
+
   private[kafka] def requestMatchIdOrError(
       protocolMessage: KafkaProtocolMessage,
       messageMatcher: KafkaMatcher,
   ): Either[String, Array[Byte]] =
     Option(messageMatcher.requestMatch(protocolMessage)).toRight("request matcher returned null match id")
+
+  private[kafka] def prepareTrackerOrError(
+      protocolMessage: KafkaProtocolMessage,
+      trackersPool: KafkaTrackerProvider,
+      messageMatcher: KafkaMatcher,
+  ): Either[String, PreparedTracker] =
+    requestMatchIdOrError(protocolMessage, messageMatcher).map { matchId =>
+      PreparedTracker(
+        matchId,
+        trackersPool.tracker(protocolMessage.inputTopic, protocolMessage.outputTopic, messageMatcher, None),
+      )
+    }
 }
 
 class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
@@ -91,17 +109,16 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
 
   private def publishAndLogMessage(requestNameString: String, msg: KafkaProtocolMessage, session: Session): Unit = {
     val now = clock.nowMillis
-    components.sender.send(msg)(
-      rm => {
-        if (logger.underlying.isDebugEnabled) {
-          logMessage(s"Record sent user=${session.userId} key=${new String(msg.key)} topic=${rm.topic()}", msg)
-        }
-        KafkaRequestReplyAction.requestMatchIdOrError(msg, components.kafkaProtocol.messageMatcher) match {
-          case Right(id)          =>
-            components.trackersPool
-              .tracker(msg.inputTopic, msg.outputTopic, components.kafkaProtocol.messageMatcher, None)
+    KafkaRequestReplyAction.prepareTrackerOrError(msg, components.trackersPool, components.kafkaProtocol.messageMatcher) match {
+      case Right(preparedTracker) =>
+        components.sender.send(msg)(
+          rm => {
+            if (logger.underlying.isDebugEnabled) {
+              logMessage(s"Record sent user=${session.userId} key=${new String(msg.key)} topic=${rm.topic()}", msg)
+            }
+            preparedTracker.tracker
               .track(
-                id,
+                preparedTracker.matchId,
                 clock.nowMillis,
                 components.kafkaProtocol.timeout.toMillis,
                 attributes.checks,
@@ -110,8 +127,9 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
                 requestNameString,
                 attributes.silent.getOrElse(false),
               )
-          case Left(errorMessage) =>
-            logger.error(errorMessage)
+          },
+          e => {
+            logger.error(e.getMessage, e)
             if (!attributes.silent.getOrElse(false)) {
               statsEngine.logResponse(
                 session.scenario,
@@ -121,14 +139,13 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
                 clock.nowMillis,
                 KO,
                 Some("500"),
-                Some(errorMessage),
+                Some(e.getMessage),
               )
             }
-            next ! session.logGroupRequestTimings(now, clock.nowMillis).markAsFailed
-        }
-      },
-      e => {
-        logger.error(e.getMessage, e)
+          },
+        )
+      case Left(errorMessage)     =>
+        logger.error(errorMessage)
         if (!attributes.silent.getOrElse(false)) {
           statsEngine.logResponse(
             session.scenario,
@@ -138,11 +155,11 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
             clock.nowMillis,
             KO,
             Some("500"),
-            Some(e.getMessage),
+            Some(errorMessage),
           )
         }
-      },
-    )
+        next ! session.logGroupRequestTimings(now, clock.nowMillis).markAsFailed
+    }
   }
 
   override def name: String = genName("kafkaRequestReply")

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaTrackerProvider.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaTrackerProvider.scala
@@ -1,0 +1,13 @@
+package org.galaxio.gatling.kafka.client
+
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+
+trait KafkaTrackerProvider {
+  def tracker(
+      inputTopic: String,
+      outputTopic: String,
+      messageMatcher: KafkaMatcher,
+      responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
+  ): KafkaMessageTracker
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
@@ -13,21 +13,49 @@ import org.galaxio.gatling.kafka.client.KafkaMessageTrackerActor.MessageConsumed
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, TimeUnit}
+import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
+
+object TrackersPool {
+  private val ConsumerStartupTimeout = 30.seconds
+
+  private[client] def awaitRunning(
+      currentState: () => KafkaStreams.State,
+      registerListener: KafkaStreams.StateListener => Unit,
+      start: () => Unit,
+      timeoutMillis: Long,
+  ): Unit = {
+    if (currentState() == KafkaStreams.State.RUNNING) {
+      ()
+    } else {
+      val readyLatch = new CountDownLatch(1)
+      registerListener { (newState, _) =>
+        if (newState == KafkaStreams.State.RUNNING) {
+          readyLatch.countDown()
+        }
+      }
+      start()
+
+      if (currentState() != KafkaStreams.State.RUNNING && !readyLatch.await(timeoutMillis, TimeUnit.MILLISECONDS)) {
+        throw new IllegalStateException(s"Reply consumer did not reach RUNNING state within ${timeoutMillis} ms")
+      }
+    }
+  }
+}
 
 class TrackersPool(
     streamsSettings: Map[String, AnyRef],
     system: ActorSystem,
     statsEngine: StatsEngine,
     clock: Clock,
-) extends KafkaLogging with NameGen {
+) extends KafkaTrackerProvider with KafkaLogging with NameGen {
 
   private val trackers = new ConcurrentHashMap[String, KafkaMessageTracker]
   private val props    = new java.util.Properties()
   props.putAll(streamsSettings.asJava)
 
-  def tracker(
+  override def tracker(
       inputTopic: String,
       outputTopic: String,
       messageMatcher: KafkaMatcher,
@@ -73,8 +101,15 @@ class TrackersPool(
 
         val streams = new KafkaStreams(builder.build(), props)
 
-        streams.cleanUp()
-        streams.start()
+        TrackersPool.awaitRunning(
+          () => streams.state(),
+          streams.setStateListener,
+          () => {
+            streams.cleanUp()
+            streams.start()
+          },
+          TrackersPool.ConsumerStartupTimeout.toMillis,
+        )
 
         CoordinatedShutdown(system).addJvmShutdownHook(streams.close())
 

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaComponents.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaComponents.scala
@@ -3,12 +3,12 @@ package org.galaxio.gatling.kafka.protocol
 import io.gatling.core.CoreComponents
 import io.gatling.core.protocol.ProtocolComponents
 import io.gatling.core.session.Session
-import org.galaxio.gatling.kafka.client.{KafkaSender, TrackersPool}
+import org.galaxio.gatling.kafka.client.{KafkaSender, KafkaTrackerProvider}
 
 case class KafkaComponents(
     coreComponents: CoreComponents,
     kafkaProtocol: KafkaProtocol,
-    trackersPool: TrackersPool,
+    trackersPool: KafkaTrackerProvider,
     sender: KafkaSender,
 ) extends ProtocolComponents {
 

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
@@ -1,8 +1,11 @@
 package org.galaxio.gatling.kafka.actions
 
+import org.galaxio.gatling.kafka.client.{KafkaMessageTracker, KafkaTrackerProvider}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.mutable.ArrayBuffer
 
 class KafkaRequestReplyActionSpec extends AnyFunSuite {
 
@@ -33,5 +36,61 @@ class KafkaRequestReplyActionSpec extends AnyFunSuite {
     val result = KafkaRequestReplyAction.requestMatchIdOrError(protocolMessage, matcher)
 
     assert(result == Left("request matcher returned null match id"))
+  }
+
+  test("prepareTrackerOrError prepares tracker after request match extraction") {
+    val events   = ArrayBuffer.empty[String]
+    val matcher  = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte] = {
+        events += "match"
+        msg.key
+      }
+
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+    val trackers = new KafkaTrackerProvider {
+      override def tracker(
+          inputTopic: String,
+          outputTopic: String,
+          messageMatcher: KafkaProtocol.KafkaMatcher,
+          responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
+      ): KafkaMessageTracker = {
+        events += s"tracker:$inputTopic->$outputTopic"
+        null.asInstanceOf[KafkaMessageTracker]
+      }
+    }
+
+    val result = KafkaRequestReplyAction.prepareTrackerOrError(protocolMessage, trackers, matcher)
+
+    assert(result.exists(_.matchId.sameElements("request-key".getBytes())))
+    assert(events.toList == List("match", "tracker:requests->replies"))
+  }
+
+  test("prepareTrackerOrError does not create tracker when request match id is null") {
+    val events   = ArrayBuffer.empty[String]
+    val matcher  = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte] = {
+        events += "match"
+        null
+      }
+
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+    val trackers = new KafkaTrackerProvider {
+      override def tracker(
+          inputTopic: String,
+          outputTopic: String,
+          messageMatcher: KafkaProtocol.KafkaMatcher,
+          responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
+      ): KafkaMessageTracker = {
+        events += "tracker"
+        null.asInstanceOf[KafkaMessageTracker]
+      }
+    }
+
+    val result = KafkaRequestReplyAction.prepareTrackerOrError(protocolMessage, trackers, matcher)
+
+    assert(result == Left("request matcher returned null match id"))
+    assert(events.toList == List("match"))
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
@@ -1,0 +1,44 @@
+package org.galaxio.gatling.kafka.client
+
+import org.apache.kafka.streams.KafkaStreams
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.concurrent.atomic.AtomicReference
+
+class TrackersPoolSpec extends AnyFunSuite {
+
+  test("awaitRunning starts the consumer and waits for RUNNING state") {
+    val currentState = new AtomicReference(KafkaStreams.State.CREATED)
+    val started      = new AtomicReference(false)
+    val listenerRef  = new AtomicReference[KafkaStreams.StateListener]()
+
+    TrackersPool.awaitRunning(
+      () => currentState.get(),
+      listener => listenerRef.set(listener),
+      () => {
+        started.set(true)
+        currentState.set(KafkaStreams.State.RUNNING)
+        Option(listenerRef.get()).foreach(_.onChange(KafkaStreams.State.RUNNING, KafkaStreams.State.REBALANCING))
+      },
+      timeoutMillis = 100,
+    )
+
+    assert(started.get())
+    assert(listenerRef.get() != null)
+  }
+
+  test("awaitRunning fails when the consumer never reaches RUNNING") {
+    val currentState = new AtomicReference(KafkaStreams.State.CREATED)
+
+    val error = intercept[IllegalStateException] {
+      TrackersPool.awaitRunning(
+        () => currentState.get(),
+        _ => (),
+        () => currentState.set(KafkaStreams.State.REBALANCING),
+        timeoutMillis = 10,
+      )
+    }
+
+    assert(error.getMessage.contains("did not reach RUNNING state"))
+  }
+}


### PR DESCRIPTION
Closes #54.

This PR hardens the request-reply lifecycle for the Gatling 3.11 line so the reply consumer is prepared before the first request is sent.

What changed:
- prepare the tracker/consumer before producer send in `KafkaRequestReplyAction`
- wait for the Kafka Streams reply consumer to reach `RUNNING` before returning the tracker
- extract a small `KafkaTrackerProvider` interface to make the lifecycle testable
- add regression coverage for tracker preparation ordering and consumer readiness waiting

Why this matters:
- avoids under-reported request-reply latency caused by consumer startup lag
- reduces the risk of missing very early replies on the first tracked request

Validation:
- `sbt 'testOnly org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionSpec org.galaxio.gatling.kafka.client.TrackersPoolSpec'`
- `sbt scalafmtCheckAll`
- `sbt --batch 'Test / compile'`
