### PR TITLE
test: add matcher coverage for request-reply flows

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
@@ -42,6 +42,12 @@ object TrackersPool {
       }
     }
   }
+
+  private[client] def responseMatchIdOrError(
+      message: KafkaProtocolMessage,
+      messageMatcher: KafkaMatcher,
+  ): Either[String, Array[Byte]] =
+    Option(messageMatcher.responseMatch(message)).toRight("response matcher returned null match id")
 }
 
 class TrackersPool(
@@ -71,31 +77,31 @@ class TrackersPool(
 
         builder.stream[Array[Byte], Array[Byte]](outputTopic).foreach { case (k, v) =>
           val message = KafkaProtocolMessage(k, v, inputTopic, outputTopic)
-          if (messageMatcher.responseMatch(message) == null) {
-            logger.error(s"no messageMatcher key for read message")
-          } else {
-            if (k == null || v == null)
-              logger.info(s" --- received message with null key or value")
-            else
-              logger.info(s" --- received  ${new String(k)} ${new String(v)}")
-            val receivedTimestamp = clock.nowMillis
-            val replyId           = messageMatcher.responseMatch(message)
-            if (k != null)
-              logMessage(
-                s"Record received key=${new String(k)}",
-                message,
-              )
-            else
-              logMessage(
-                s"Record received key=null",
-                message,
-              )
+          TrackersPool.responseMatchIdOrError(message, messageMatcher) match {
+            case Left(_)        =>
+              logger.error(s"no messageMatcher key for read message")
+            case Right(replyId) =>
+              if (k == null || v == null)
+                logger.info(s" --- received message with null key or value")
+              else
+                logger.info(s" --- received  ${new String(k)} ${new String(v)}")
+              val receivedTimestamp = clock.nowMillis
+              if (k != null)
+                logMessage(
+                  s"Record received key=${new String(k)}",
+                  message,
+                )
+              else
+                logMessage(
+                  s"Record received key=null",
+                  message,
+                )
 
-            actor ! MessageConsumed(
-              replyId,
-              receivedTimestamp,
-              responseTransformer.map(_(message)).getOrElse(message),
-            )
+              actor ! MessageConsumed(
+                replyId,
+                receivedTimestamp,
+                responseTransformer.map(_(message)).getOrElse(message),
+              )
           }
         }
 

--- a/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
+++ b/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.galaxio.gatling.kafka.javaapi.protocol.KafkaProtocolBuilderNew;
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage;
 import org.galaxio.gatling.kafka.javaapi.KafkaDsl;
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -56,6 +57,31 @@ public class MatchSimulation extends Simulation {
             )
             .timeout(Duration.ofSeconds(5))
     .matchByMessage(this::matchByOwnVal);
+
+    private final KafkaProtocolBuilderNew kafkaProtocolMatchByKafkaMatcher = KafkaDsl.kafka().requestReply()
+            .producerSettings(
+                    Map.of(
+                            ProducerConfig.ACKS_CONFIG, "1",
+                            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"
+                    )
+            )
+            .consumeSettings(
+                    Map.of(
+                            "bootstrap.servers", "localhost:9092"
+                    )
+            )
+            .timeout(Duration.ofSeconds(5))
+            .matchByKafkaMatcher(new KafkaProtocol.KafkaMatcher() {
+                @Override
+                public byte[] requestMatch(KafkaProtocolMessage msg) {
+                    return msg.key();
+                }
+
+                @Override
+                public byte[] responseMatch(KafkaProtocolMessage msg) {
+                    return msg.value();
+                }
+            });
 
     private final AtomicInteger c = new AtomicInteger(0);
     private final Iterator<Map<String, Object>> feeder =

--- a/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
+++ b/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
@@ -5,6 +5,7 @@ import io.gatling.javaapi.core.Simulation
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.galaxio.gatling.kafka.javaapi.*
 import org.galaxio.gatling.kafka.javaapi.KafkaDsl.*
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.*
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
@@ -46,6 +47,29 @@ class MatchSimulation : Simulation() {
         )
         .timeout(Duration.ofSeconds(5))
         .matchByMessage { message: KafkaProtocolMessage -> matchByOwnVal(message) }
+
+    private val kafkaProtocolMatchByKafkaMatcher = kafka().requestReply()
+        .producerSettings(
+            mapOf<String, Any>(
+                ProducerConfig.ACKS_CONFIG to "1",
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:9092"
+            )
+        )
+        .consumeSettings(
+            mapOf<String, Any>(
+                "bootstrap.servers" to "localhost:9092"
+            )
+        )
+        .timeout(Duration.ofSeconds(5))
+        .matchByKafkaMatcher(object : KafkaMatcher {
+            override fun requestMatch(msg: KafkaProtocolMessage): ByteArray {
+                return msg.key
+            }
+
+            override fun responseMatch(msg: KafkaProtocolMessage): ByteArray {
+                return msg.value
+            }
+        })
 
     private val c = AtomicInteger(0)
 

--- a/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
@@ -1,11 +1,42 @@
 package org.galaxio.gatling.kafka.client
 
 import org.apache.kafka.streams.KafkaStreams
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.util.concurrent.atomic.AtomicReference
 
 class TrackersPoolSpec extends AnyFunSuite {
+
+  private val protocolMessage = KafkaProtocolMessage(
+    key = "request-id".getBytes(),
+    value = "reply-id".getBytes(),
+    inputTopic = "requests",
+    outputTopic = "replies",
+  )
+
+  test("responseMatchIdOrError returns response match id independently from request match id") {
+    val matcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+
+    val result = TrackersPool.responseMatchIdOrError(protocolMessage, matcher)
+
+    assert(result.exists(_.sameElements("reply-id".getBytes())))
+  }
+
+  test("responseMatchIdOrError rejects null response match id") {
+    val matcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = null
+    }
+
+    val result = TrackersPool.responseMatchIdOrError(protocolMessage, matcher)
+
+    assert(result == Left("response matcher returned null match id"))
+  }
 
   test("awaitRunning starts the consumer and waits for RUNNING state") {
     val currentState = new AtomicReference(KafkaStreams.State.CREATED)


### PR DESCRIPTION
Closes #60.

This PR adds the missing automated coverage around custom `KafkaMatcher` support in the Gatling 3.11 line.

What is covered now:
- request-side matcher extraction is covered independently
- response-side matcher extraction is covered independently
- null matcher values are covered for both request and response paths
- Java DSL smoke coverage for `matchByKafkaMatcher(...)`
- Kotlin DSL smoke coverage for `matchByKafkaMatcher(...)`

Implementation notes:
- extracted a small `responseMatchIdOrError(...)` helper in `TrackersPool` to make the response-side matcher contract testable
- updated Java/Kotlin example simulations so `Test / compile` validates the public DSL entrypoints

Validation:
- `sbt --batch 'testOnly org.galaxio.gatling.kafka.protocol.KafkaProtocolBuilderNewSpec org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionSpec org.galaxio.gatling.kafka.client.TrackersPoolSpec'`
- `sbt --batch 'Test / compile'`
- `sbt scalafmtCheckAll`
