### PR TITLE
test: add request-reply timeout regressions

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActor.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActor.scala
@@ -39,8 +39,29 @@ object KafkaMessageTrackerActor {
 
   case object TimeoutScan
 
-  private def makeKeyForSentMessages(m: Array[Byte]): String =
+  private[client] def makeTrackingKey(m: Array[Byte]): String =
     Option(m).map(java.util.Base64.getEncoder.encodeToString).getOrElse("")
+
+  private[client] def timedOutMessages(
+      now: Long,
+      sentMessages: mutable.HashMap[String, MessagePublished],
+  ): List[MessagePublished] =
+    sentMessages.valuesIterator.filter { messagePublished =>
+      val replyTimeout = messagePublished.replyTimeout
+      replyTimeout > 0 && (now - messagePublished.sent) > replyTimeout
+    }.toList
+
+  private[client] def removeTrackedMessage(
+      matchId: Array[Byte],
+      sentMessages: mutable.HashMap[String, MessagePublished],
+  ): Option[MessagePublished] =
+    sentMessages.remove(makeTrackingKey(matchId))
+
+  private[client] def removeTimedOutMessages(
+      timedOutMessages: List[MessagePublished],
+      sentMessages: mutable.HashMap[String, MessagePublished],
+  ): List[MessagePublished] =
+    timedOutMessages.filter(message => removeTrackedMessage(message.matchId, sentMessages).isDefined)
 }
 
 class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends Actor with Timers with LazyLogging {
@@ -127,7 +148,7 @@ class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends A
   ): Receive = {
     // message was sent; add the timestamps to the map
     case messageSent: MessagePublished =>
-      val key = makeKeyForSentMessages(messageSent.matchId)
+      val key = makeTrackingKey(messageSent.matchId)
       sentMessages += key -> messageSent
       if (messageSent.replyTimeout > 0) {
         triggerPeriodicTimeoutScan(periodicTimeoutScanTriggered, sentMessages, timedOutMessages)
@@ -136,21 +157,18 @@ class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends A
     // message was received; publish stats and remove from the map
     case MessageConsumed(replyId, received, message) =>
       // if key is missing, message was already acked and is a dup, or request timeout
-      val key = makeKeyForSentMessages(replyId)
-      sentMessages.remove(key).foreach { case MessagePublished(_, sent, _, checks, session, next, requestName, silentRequest) =>
-        processMessage(session, sent, received, checks, message, next, requestName, silentRequest)
+      removeTrackedMessage(replyId, sentMessages).foreach {
+        case MessagePublished(_, sent, _, checks, session, next, requestName, silentRequest) =>
+          processMessage(session, sent, received, checks, message, next, requestName, silentRequest)
       }
 
     case TimeoutScan =>
       val now = clock.nowMillis
-      sentMessages.valuesIterator.foreach { messagePublished =>
-        val replyTimeout = messagePublished.replyTimeout
-        if (replyTimeout > 0 && (now - messagePublished.sent) > replyTimeout) {
-          timedOutMessages += messagePublished
-        }
-      }
-      for (MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName, silentRequest) <- timedOutMessages) {
-        sentMessages.remove(makeKeyForSentMessages(matchId))
+      timedOutMessages ++= KafkaMessageTrackerActor.timedOutMessages(now, sentMessages)
+      for (
+        MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName, silentRequest) <-
+          removeTimedOutMessages(timedOutMessages.toList, sentMessages)
+      ) {
         executeNext(
           session.markAsFailed,
           sent,

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActorSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActorSpec.scala
@@ -1,0 +1,75 @@
+package org.galaxio.gatling.kafka.client
+
+import org.galaxio.gatling.kafka.client.KafkaMessageTrackerActor.MessagePublished
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.mutable
+
+class KafkaMessageTrackerActorSpec extends AnyFunSuite {
+
+  test("timedOutMessages selects only entries whose timeout has elapsed") {
+    val sentMessages = mutable.HashMap(
+      KafkaMessageTrackerActor.makeTrackingKey("late".getBytes())      ->
+        MessagePublished(
+          "late".getBytes(),
+          sent = 1_000L,
+          replyTimeout = 2_000L,
+          Nil,
+          null,
+          null,
+          "req",
+          silentRequest = false,
+        ),
+      KafkaMessageTrackerActor.makeTrackingKey("ontime".getBytes())    ->
+        MessagePublished(
+          "ontime".getBytes(),
+          sent = 4_000L,
+          replyTimeout = 2_000L,
+          Nil,
+          null,
+          null,
+          "req",
+          silentRequest = false,
+        ),
+      KafkaMessageTrackerActor.makeTrackingKey("notimeout".getBytes()) ->
+        MessagePublished(
+          "notimeout".getBytes(),
+          sent = 1_000L,
+          replyTimeout = 0L,
+          Nil,
+          null,
+          null,
+          "req",
+          silentRequest = false,
+        ),
+    )
+
+    val timedOut = KafkaMessageTrackerActor.timedOutMessages(now = 3_500L, sentMessages)
+
+    assert(timedOut.map(_.matchId.map(_.toChar).mkString).toSet == Set("late"))
+  }
+
+  test("removeTrackedMessage returns published message before timeout and none after cleanup") {
+    val published =
+      MessagePublished("reply".getBytes(), sent = 1_000L, replyTimeout = 2_000L, Nil, null, null, "req", silentRequest = false)
+    val sent      = mutable.HashMap(KafkaMessageTrackerActor.makeTrackingKey("reply".getBytes()) -> published)
+
+    val beforeTimeout = KafkaMessageTrackerActor.removeTrackedMessage("reply".getBytes(), sent)
+    val afterTimeout  = KafkaMessageTrackerActor.removeTrackedMessage("reply".getBytes(), sent)
+
+    assert(beforeTimeout.contains(published))
+    assert(afterTimeout.isEmpty)
+  }
+
+  test("removeTimedOutMessages clears timed out entry so late replies are ignored") {
+    val published =
+      MessagePublished("reply".getBytes(), sent = 1_000L, replyTimeout = 2_000L, Nil, null, null, "req", silentRequest = false)
+    val sent      = mutable.HashMap(KafkaMessageTrackerActor.makeTrackingKey("reply".getBytes()) -> published)
+
+    val removed = KafkaMessageTrackerActor.removeTimedOutMessages(List(published), sent)
+    val late    = KafkaMessageTrackerActor.removeTrackedMessage("reply".getBytes(), sent)
+
+    assert(removed == List(published))
+    assert(late.isEmpty)
+  }
+}


### PR DESCRIPTION
Closes #58.

This PR adds regression coverage for the remaining high-risk parts of the request-reply lifecycle in the Gatling 3.11 line.

What is covered here:
- timeout selection logic
- timed-out message cleanup
- late replies being ignored after timeout cleanup

Why this is part of #58:
- consumer readiness before send is already covered by #63 / commit 9203513
- sender lifecycle / non-blocking path is already covered by KafkaSenderSpec from the #40 work
- this PR closes the remaining gap around timeout and late-reply behaviour in the tracker layer

Implementation notes:
- extracted small pure helper methods in `KafkaMessageTrackerActor` for tracking-key lookup and timeout cleanup
- added `KafkaMessageTrackerActorSpec` to exercise those cases without a heavyweight actor harness

Validation:
- `sbt --batch 'testOnly org.galaxio.gatling.kafka.client.KafkaMessageTrackerActorSpec org.galaxio.gatling.kafka.client.KafkaSenderSpec org.galaxio.gatling.kafka.client.TrackersPoolSpec org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionSpec'`
- `sbt scalafmtCheckAll`
- `sbt --batch 'Test / compile'`
