### PR TITLE
feat(request-reply): add action-scoped overrides and extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
         run: sbt clean compile
 
       - name: Test (Gatling targeted) 
+        env:
+          GATLING_KAFKA_TEST_BOOTSTRAP: localhost:9093
         run: sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport
 
       - name: Upload coverage reports to Codecov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+## Repository Rules
+
+- Before every `git push`, run formatting and make sure formatter checks pass.
+- Minimum required command before push:
+
+```bash
+sbt --batch scalafmtAll scalafmtCheckAll
+```
+
+- If the change touches tests or production Scala code, prefer the fuller pre-push check:
+
+```bash
+sbt --batch "Test / compile" scalafmtAll scalafmtCheckAll
+```

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
     val avro           = "1.12.1"
     val kafkaAvroSerde = "7.9.5"
     val scalaTest      = "3.2.19"
+    val testcontainers = "1.20.4"
   }
 
   lazy val gatling: Seq[ModuleID] = Seq(
@@ -22,6 +23,8 @@ object Dependencies {
 
   lazy val unitTest: Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % Versions.scalaTest % Test,
+    "org.testcontainers" % "testcontainers" % Versions.testcontainers % Test,
+    "org.testcontainers" % "kafka" % Versions.testcontainers % Test,
   )
 
   lazy val kafka: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,9 +22,9 @@ object Dependencies {
   )
 
   lazy val unitTest: Seq[ModuleID] = Seq(
-    "org.scalatest" %% "scalatest" % Versions.scalaTest % Test,
+    "org.scalatest"     %% "scalatest"      % Versions.scalaTest      % Test,
     "org.testcontainers" % "testcontainers" % Versions.testcontainers % Test,
-    "org.testcontainers" % "kafka" % Versions.testcontainers % Test,
+    "org.testcontainers" % "kafka"          % Versions.testcontainers % Test,
   )
 
   lazy val kafka: Seq[ModuleID] = Seq(

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/RequestReplyBuilder.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/RequestReplyBuilder.java
@@ -3,9 +3,16 @@ package org.galaxio.gatling.kafka.javaapi.request.builder;
 import io.gatling.javaapi.core.ActionBuilder;
 import io.gatling.javaapi.core.CheckBuilder;
 import org.galaxio.gatling.kafka.javaapi.checks.KafkaChecks;
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol;
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import scala.jdk.javaapi.CollectionConverters;
+import scala.jdk.javaapi.FunctionConverters;
 
 public class RequestReplyBuilder<K, V> implements ActionBuilder {
 
@@ -22,6 +29,48 @@ public class RequestReplyBuilder<K, V> implements ActionBuilder {
     public RequestReplyBuilder<K, V> check(List<CheckBuilder> checks) {
         this.wrapped = wrapped.check(KafkaChecks.toScalaChecks(checks));
         return this;
+    }
+
+    public RequestReplyBuilder<K, V> producerSettings(Map<String, Object> settings) {
+        this.wrapped = wrapped.producerSettings(scalaMap(settings));
+        return this;
+    }
+
+    public RequestReplyBuilder<K, V> consumeSettings(Map<String, Object> settings) {
+        this.wrapped = wrapped.consumeSettings(scalaMap(settings));
+        return this;
+    }
+
+    public RequestReplyBuilder<K, V> requestMatchBy(Function<KafkaProtocolMessage, byte[]> extractor) {
+        this.wrapped = wrapped.requestMatchBy(FunctionConverters.asScalaFromFunction(extractor));
+        return this;
+    }
+
+    public RequestReplyBuilder<K, V> replyMatchBy(Function<KafkaProtocolMessage, byte[]> extractor) {
+        this.wrapped = wrapped.replyMatchBy(FunctionConverters.asScalaFromFunction(extractor));
+        return this;
+    }
+
+    public RequestReplyBuilder<K, V> matchByMessage(Function<KafkaProtocolMessage, byte[]> extractor) {
+        this.wrapped = wrapped.matchByMessage(FunctionConverters.asScalaFromFunction(extractor));
+        return this;
+    }
+
+    public RequestReplyBuilder<K, V> matchByKafkaMatcher(KafkaProtocol.KafkaMatcher matcher) {
+        this.wrapped = wrapped.matchByKafkaMatcher(matcher);
+        return this;
+    }
+
+    public <T> RequestReplyBuilder<K, V> saveReplyAs(String sessionKey, Function<KafkaProtocolMessage, T> extractor) {
+        this.wrapped = wrapped.saveReplyAs(
+                sessionKey,
+                FunctionConverters.asScalaFromFunction((Function<KafkaProtocolMessage, Object>) extractor::apply)
+        );
+        return this;
+    }
+
+    private scala.collection.immutable.Map<String, Object> scalaMap(Map<String, Object> settings) {
+        return scala.collection.immutable.Map.from(CollectionConverters.asScala(settings));
     }
 
     @Override

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -11,8 +11,8 @@ import io.gatling.core.stats.StatsEngine
 import io.gatling.core.util.NameGen
 import org.apache.kafka.common.serialization.Serializer
 import org.galaxio.gatling.kafka.KafkaLogging
-import org.galaxio.gatling.kafka.client.{KafkaMessageTracker, KafkaTrackerProvider}
-import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
+import org.galaxio.gatling.kafka.client.{KafkaMessageTracker, KafkaSender, KafkaTrackerProvider}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.{KafkaMatcher, KafkaMessageMatcher}
 import org.galaxio.gatling.kafka.protocol.KafkaComponents
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.galaxio.gatling.kafka.request.builder.KafkaRequestReplyAttributes
@@ -42,6 +42,30 @@ object KafkaRequestReplyAction {
         trackersPool.tracker(protocolMessage.inputTopic, protocolMessage.outputTopic, messageMatcher, None),
       )
     }
+
+  private[kafka] def effectiveMessageMatcher(
+      protocolMatcher: KafkaMatcher,
+      attributes: KafkaRequestReplyAttributes[_, _],
+  ): KafkaMatcher =
+    new KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte] =
+        attributes.requestMatchExtractor.getOrElse(protocolMatcher.requestMatch _)(msg)
+
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] =
+        attributes.responseMatchExtractor.getOrElse(protocolMatcher.responseMatch _)(msg)
+    }
+
+  private[kafka] def effectiveProducerSettings(
+      components: KafkaComponents,
+      attributes: KafkaRequestReplyAttributes[_, _],
+  ): Map[String, AnyRef] =
+    components.kafkaProtocol.producerProperties ++ attributes.producerSettingsOverride.getOrElse(Map.empty)
+
+  private[kafka] def effectiveConsumeSettings(
+      components: KafkaComponents,
+      attributes: KafkaRequestReplyAttributes[_, _],
+  ): Map[String, AnyRef] =
+    components.kafkaProtocol.consumeProperties ++ attributes.consumeSettingsOverride.getOrElse(Map.empty)
 }
 
 class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
@@ -52,7 +76,13 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
     val next: Action,
     throttler: Option[Throttler],
 ) extends RequestAction with KafkaLogging with NameGen {
-  override def requestName: Expression[String] = attributes.requestName
+  override def requestName: Expression[String]   = attributes.requestName
+  private val messageMatcher                     =
+    KafkaRequestReplyAction.effectiveMessageMatcher(components.kafkaProtocol.messageMatcher, attributes)
+  private val sender: KafkaSender                =
+    components.senderProvider.sender(KafkaRequestReplyAction.effectiveProducerSettings(components, attributes))
+  private val trackersPool: KafkaTrackerProvider =
+    components.trackersPoolFactory.trackerProvider(KafkaRequestReplyAction.effectiveConsumeSettings(components, attributes))
 
   override def sendRequest(session: Session): Validation[Unit] = {
     for {
@@ -109,9 +139,9 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
 
   private def publishAndLogMessage(requestNameString: String, msg: KafkaProtocolMessage, session: Session): Unit = {
     val now = clock.nowMillis
-    KafkaRequestReplyAction.prepareTrackerOrError(msg, components.trackersPool, components.kafkaProtocol.messageMatcher) match {
+    KafkaRequestReplyAction.prepareTrackerOrError(msg, trackersPool, messageMatcher) match {
       case Right(preparedTracker) =>
-        components.sender.send(msg)(
+        sender.send(msg)(
           rm => {
             if (logger.underlying.isDebugEnabled) {
               logMessage(s"Record sent user=${session.userId} key=${new String(msg.key)} topic=${rm.topic()}", msg)
@@ -122,6 +152,7 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
                 clock.nowMillis,
                 components.kafkaProtocol.timeout.toMillis,
                 attributes.checks,
+                attributes.replyExtractions,
                 session,
                 next,
                 requestNameString,

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionBuilder.scala
@@ -5,7 +5,10 @@ import io.gatling.core.action.Action
 import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.structure.ScenarioContext
 import org.galaxio.gatling.kafka.KafkaCheck
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.{KafkaMatcher, KafkaMessageMatcher}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.KafkaReplyExtraction
 import org.galaxio.gatling.kafka.request.builder.KafkaRequestReplyAttributes
 
 import scala.reflect.ClassTag
@@ -19,6 +22,27 @@ case class KafkaRequestReplyActionBuilder[K: ClassTag, V: ClassTag](attributes: 
 
   def check(checks: KafkaCheck*): KafkaRequestReplyActionBuilder[K, V] =
     this.modify(_.attributes.checks).using(_ ::: checks.toList)
+
+  def producerSettings(settings: Map[String, AnyRef]): KafkaRequestReplyActionBuilder[K, V] =
+    this.modify(_.attributes.producerSettingsOverride).setTo(Some(settings))
+
+  def consumeSettings(settings: Map[String, AnyRef]): KafkaRequestReplyActionBuilder[K, V] =
+    this.modify(_.attributes.consumeSettingsOverride).setTo(Some(settings))
+
+  def requestMatchBy(extractor: KafkaProtocolMessage => Array[Byte]): KafkaRequestReplyActionBuilder[K, V] =
+    this.modify(_.attributes.requestMatchExtractor).setTo(Some(extractor))
+
+  def replyMatchBy(extractor: KafkaProtocolMessage => Array[Byte]): KafkaRequestReplyActionBuilder[K, V] =
+    this.modify(_.attributes.responseMatchExtractor).setTo(Some(extractor))
+
+  def matchByMessage(extractor: KafkaProtocolMessage => Array[Byte]): KafkaRequestReplyActionBuilder[K, V] =
+    requestMatchBy(extractor).replyMatchBy(extractor)
+
+  def matchByKafkaMatcher(matcher: KafkaMatcher): KafkaRequestReplyActionBuilder[K, V] =
+    requestMatchBy(matcher.requestMatch).replyMatchBy(matcher.responseMatch)
+
+  def saveReplyAs(sessionKey: String)(extractor: KafkaProtocolMessage => Any): KafkaRequestReplyActionBuilder[K, V] =
+    this.modify(_.attributes.replyExtractions).using(_ :+ KafkaReplyExtraction(sessionKey, extractor))
 
   override def build(ctx: ScenarioContext, next: Action): Action = {
     val kafkaComponents = ctx.protocolComponentsRegistry.components(KafkaProtocol.kafkaProtocolKey)

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -5,6 +5,7 @@ import io.gatling.core.action.Action
 import io.gatling.core.session.Session
 import org.galaxio.gatling.kafka.KafkaCheck
 import org.galaxio.gatling.kafka.client.KafkaMessageTrackerActor.MessagePublished
+import org.galaxio.gatling.kafka.request.builder.KafkaReplyExtraction
 
 class KafkaMessageTracker(actor: ActorRef) {
 
@@ -13,6 +14,7 @@ class KafkaMessageTracker(actor: ActorRef) {
       sent: Long,
       replyTimeout: Long,
       checks: List[KafkaCheck],
+      replyExtractions: List[KafkaReplyExtraction],
       session: Session,
       next: Action,
       requestName: String,
@@ -23,6 +25,7 @@ class KafkaMessageTracker(actor: ActorRef) {
       sent,
       replyTimeout,
       checks,
+      replyExtractions,
       session,
       next,
       requestName,

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActor.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActor.scala
@@ -11,9 +11,11 @@ import io.gatling.core.session.Session
 import io.gatling.core.stats.StatsEngine
 import org.galaxio.gatling.kafka.KafkaCheck
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.KafkaReplyExtraction
 
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
+import scala.util.Try
 
 object KafkaMessageTrackerActor {
 
@@ -25,6 +27,7 @@ object KafkaMessageTrackerActor {
       sent: Long,
       replyTimeout: Long,
       checks: List[KafkaCheck],
+      replyExtractions: List[KafkaReplyExtraction],
       session: Session,
       next: Action,
       requestName: String,
@@ -62,6 +65,21 @@ object KafkaMessageTrackerActor {
       sentMessages: mutable.HashMap[String, MessagePublished],
   ): List[MessagePublished] =
     timedOutMessages.filter(message => removeTrackedMessage(message.matchId, sentMessages).isDefined)
+
+  private[client] def applyReplyExtractions(
+      session: Session,
+      message: KafkaProtocolMessage,
+      replyExtractions: List[KafkaReplyExtraction],
+  ): Either[String, Session] =
+    replyExtractions.foldLeft[Either[String, Session]](Right(session)) { case (acc, extraction) =>
+      acc.flatMap { currentSession =>
+        Try(extraction.extractor(message)).toEither.left.map(_.getMessage).flatMap { extractedValue =>
+          Option(extractedValue)
+            .toRight(s"reply extraction '${extraction.sessionKey}' returned null")
+            .map(currentSession.set(extraction.sessionKey, _))
+        }
+      }
+    }
 }
 
 class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends Actor with Timers with LazyLogging {
@@ -117,16 +135,17 @@ class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends A
       sent: Long,
       received: Long,
       checks: List[KafkaCheck],
+      replyExtractions: List[KafkaReplyExtraction],
       message: KafkaProtocolMessage,
       next: Action,
       requestName: String,
       silentRequest: Boolean,
   ): Unit = {
-    val (newSession, error) = Check.check(message, session, checks)
+    val (checkedSession, error) = Check.check(message, session, checks)
     error match {
       case Some(Failure(errorMessage)) =>
         executeNext(
-          newSession.markAsFailed,
+          checkedSession.markAsFailed,
           sent,
           received,
           KO,
@@ -137,7 +156,22 @@ class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends A
           silentRequest,
         )
       case _                           =>
-        executeNext(newSession, sent, received, OK, next, requestName, None, None, silentRequest)
+        KafkaMessageTrackerActor.applyReplyExtractions(checkedSession, message, replyExtractions) match {
+          case Left(errorMessage) =>
+            executeNext(
+              checkedSession.markAsFailed,
+              sent,
+              received,
+              KO,
+              next,
+              requestName,
+              message.responseCode,
+              Some(errorMessage),
+              silentRequest,
+            )
+          case Right(newSession)  =>
+            executeNext(newSession, sent, received, OK, next, requestName, None, None, silentRequest)
+        }
     }
   }
 
@@ -158,15 +192,15 @@ class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends A
     case MessageConsumed(replyId, received, message) =>
       // if key is missing, message was already acked and is a dup, or request timeout
       removeTrackedMessage(replyId, sentMessages).foreach {
-        case MessagePublished(_, sent, _, checks, session, next, requestName, silentRequest) =>
-          processMessage(session, sent, received, checks, message, next, requestName, silentRequest)
+        case MessagePublished(_, sent, _, checks, replyExtractions, session, next, requestName, silentRequest) =>
+          processMessage(session, sent, received, checks, replyExtractions, message, next, requestName, silentRequest)
       }
 
     case TimeoutScan =>
       val now = clock.nowMillis
       timedOutMessages ++= KafkaMessageTrackerActor.timedOutMessages(now, sentMessages)
       for (
-        MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName, silentRequest) <-
+        MessagePublished(matchId, sent, receivedTimeout, _, _, session, next, requestName, silentRequest) <-
           removeTimedOutMessages(timedOutMessages.toList, sentMessages)
       ) {
         executeNext(

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaSenderProvider.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaSenderProvider.scala
@@ -1,0 +1,22 @@
+package org.galaxio.gatling.kafka.client
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters._
+
+trait KafkaSenderProvider {
+  def sender(producerSettings: Map[String, AnyRef]): KafkaSender
+  def close(): Unit
+}
+
+class KafkaSenderPool extends KafkaSenderProvider {
+  private val senders = new ConcurrentHashMap[Map[String, AnyRef], KafkaSender]()
+
+  override def sender(producerSettings: Map[String, AnyRef]): KafkaSender =
+    senders.computeIfAbsent(
+      producerSettings,
+      KafkaSender(_),
+    )
+
+  override def close(): Unit =
+    senders.values().asScala.foreach(_.close())
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaTrackerProviderFactory.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaTrackerProviderFactory.scala
@@ -1,0 +1,26 @@
+package org.galaxio.gatling.kafka.client
+
+import akka.actor.ActorSystem
+import io.gatling.commons.util.Clock
+import io.gatling.core.stats.StatsEngine
+
+import java.util.concurrent.ConcurrentHashMap
+
+trait KafkaTrackerProviderFactory {
+  def trackerProvider(consumeSettings: Map[String, AnyRef]): KafkaTrackerProvider
+}
+
+class KafkaTrackersPoolFactory(
+    system: ActorSystem,
+    statsEngine: StatsEngine,
+    clock: Clock,
+) extends KafkaTrackerProviderFactory {
+
+  private val providers = new ConcurrentHashMap[Map[String, AnyRef], KafkaTrackerProvider]()
+
+  override def trackerProvider(consumeSettings: Map[String, AnyRef]): KafkaTrackerProvider =
+    providers.computeIfAbsent(
+      consumeSettings,
+      new TrackersPool(_, system, statsEngine, clock),
+    )
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
@@ -20,6 +20,13 @@ import scala.jdk.CollectionConverters._
 object TrackersPool {
   private val ConsumerStartupTimeout = 30.seconds
 
+  private[client] final case class TrackerCacheKey(
+      inputTopic: String,
+      outputTopic: String,
+      messageMatcher: KafkaMatcher,
+      responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
+  )
+
   private[client] def awaitRunning(
       currentState: () => KafkaStreams.State,
       registerListener: KafkaStreams.StateListener => Unit,
@@ -57,7 +64,7 @@ class TrackersPool(
     clock: Clock,
 ) extends KafkaTrackerProvider with KafkaLogging with NameGen {
 
-  private val trackers = new ConcurrentHashMap[String, KafkaMessageTracker]
+  private val trackers = new ConcurrentHashMap[TrackersPool.TrackerCacheKey, KafkaMessageTracker]
   private val props    = new java.util.Properties()
   props.putAll(streamsSettings.asJava)
 
@@ -68,7 +75,7 @@ class TrackersPool(
       responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
   ): KafkaMessageTracker =
     trackers.computeIfAbsent(
-      outputTopic,
+      TrackersPool.TrackerCacheKey(inputTopic, outputTopic, messageMatcher, responseTransformer),
       _ => {
         val actor =
           system.actorOf(KafkaMessageTrackerActor.props(statsEngine, clock), genName("kafkaTrackerActor"))

--- a/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
@@ -5,6 +5,7 @@ import io.gatling.commons.util.Clock
 import io.gatling.core.stats.StatsEngine
 import io.gatling.core.util.NameGen
 import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.StreamsConfig
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.scala.serialization.Serdes._
@@ -13,6 +14,8 @@ import org.galaxio.gatling.kafka.client.KafkaMessageTrackerActor.MessageConsumed
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
+import java.nio.charset.StandardCharsets
+import java.util.{Properties, UUID}
 import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, TimeUnit}
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
@@ -55,6 +58,27 @@ object TrackersPool {
       messageMatcher: KafkaMatcher,
   ): Either[String, Array[Byte]] =
     Option(messageMatcher.responseMatch(message)).toRight("response matcher returned null match id")
+
+  private[client] def trackerApplicationId(baseApplicationId: String, trackerKey: TrackerCacheKey): String = {
+    val fingerprint = UUID.nameUUIDFromBytes(
+      s"${trackerKey.inputTopic}|${trackerKey.outputTopic}|${System.identityHashCode(trackerKey.messageMatcher)}|${trackerKey.responseTransformer
+          .fold("none")(transformer => System.identityHashCode(transformer).toString)}"
+        .getBytes(StandardCharsets.UTF_8),
+    )
+    s"$baseApplicationId-$fingerprint"
+  }
+
+  private[client] def trackerProperties(
+      streamsSettings: Map[String, AnyRef],
+      trackerKey: TrackerCacheKey,
+  ): Properties = {
+    val props             = new Properties()
+    props.putAll(streamsSettings.asJava)
+    val baseApplicationId =
+      streamsSettings.getOrElse(StreamsConfig.APPLICATION_ID_CONFIG, "gatling-test").toString
+    props.put(StreamsConfig.APPLICATION_ID_CONFIG, trackerApplicationId(baseApplicationId, trackerKey))
+    props
+  }
 }
 
 class TrackersPool(
@@ -65,8 +89,6 @@ class TrackersPool(
 ) extends KafkaTrackerProvider with KafkaLogging with NameGen {
 
   private val trackers = new ConcurrentHashMap[TrackersPool.TrackerCacheKey, KafkaMessageTracker]
-  private val props    = new java.util.Properties()
-  props.putAll(streamsSettings.asJava)
 
   override def tracker(
       inputTopic: String,
@@ -76,7 +98,7 @@ class TrackersPool(
   ): KafkaMessageTracker =
     trackers.computeIfAbsent(
       TrackersPool.TrackerCacheKey(inputTopic, outputTopic, messageMatcher, responseTransformer),
-      _ => {
+      trackerKey => {
         val actor =
           system.actorOf(KafkaMessageTrackerActor.props(statsEngine, clock), genName("kafkaTrackerActor"))
 
@@ -112,7 +134,7 @@ class TrackersPool(
           }
         }
 
-        val streams = new KafkaStreams(builder.build(), props)
+        val streams = new KafkaStreams(builder.build(), TrackersPool.trackerProperties(streamsSettings, trackerKey))
 
         TrackersPool.awaitRunning(
           () => streams.state(),

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaComponents.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaComponents.scala
@@ -3,13 +3,13 @@ package org.galaxio.gatling.kafka.protocol
 import io.gatling.core.CoreComponents
 import io.gatling.core.protocol.ProtocolComponents
 import io.gatling.core.session.Session
-import org.galaxio.gatling.kafka.client.{KafkaSender, KafkaTrackerProvider}
+import org.galaxio.gatling.kafka.client.{KafkaSenderProvider, KafkaTrackerProviderFactory}
 
 case class KafkaComponents(
     coreComponents: CoreComponents,
     kafkaProtocol: KafkaProtocol,
-    trackersPool: KafkaTrackerProvider,
-    sender: KafkaSender,
+    trackersPoolFactory: KafkaTrackerProviderFactory,
+    senderProvider: KafkaSenderProvider,
 ) extends ProtocolComponents {
 
   override def onStart: Session => Session = Session.Identity

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocol.scala
@@ -3,7 +3,7 @@ package org.galaxio.gatling.kafka.protocol
 import io.gatling.core.CoreComponents
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.protocol.{Protocol, ProtocolKey}
-import org.galaxio.gatling.kafka.client.{KafkaSender, TrackersPool}
+import org.galaxio.gatling.kafka.client.{KafkaSenderPool, KafkaTrackersPoolFactory}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
@@ -42,15 +42,15 @@ object KafkaProtocol {
 
     override def newComponents(coreComponents: CoreComponents): KafkaProtocol => KafkaComponents =
       kafkaProtocol => {
-        val sender       = KafkaSender(kafkaProtocol.producerProperties)
-        val trackersPool = new TrackersPool(
-          kafkaProtocol.consumeProperties,
+        val senderProvider      = new KafkaSenderPool
+        val trackersPoolFactory = new KafkaTrackersPoolFactory(
           coreComponents.actorSystem,
           coreComponents.statsEngine,
           coreComponents.clock,
         )
+        coreComponents.actorSystem.registerOnTermination(senderProvider.close())
 
-        KafkaComponents(coreComponents, kafkaProtocol, trackersPool, sender)
+        KafkaComponents(coreComponents, kafkaProtocol, trackersPoolFactory, senderProvider)
       }
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaReplyExtraction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaReplyExtraction.scala
@@ -1,0 +1,8 @@
+package org.galaxio.gatling.kafka.request.builder
+
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+
+case class KafkaReplyExtraction(
+    sessionKey: String,
+    extractor: KafkaProtocolMessage => Any,
+)

--- a/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestBuilderBase.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestBuilderBase.scala
@@ -99,6 +99,11 @@ case class KafkaRequestBuilderBase(requestName: Expression[String]) {
             implicitly[Serde[V]].serializer(),
             List.empty,
             None,
+            None,
+            None,
+            None,
+            None,
+            List.empty,
           ),
         )
       }

--- a/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestReplyAttributes.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestReplyAttributes.scala
@@ -4,6 +4,7 @@ import io.gatling.core.session.Expression
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.Serializer
 import org.galaxio.gatling.kafka.KafkaCheck
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 
 case class KafkaRequestReplyAttributes[K, V](
     requestName: Expression[String],
@@ -16,4 +17,9 @@ case class KafkaRequestReplyAttributes[K, V](
     valueSerializer: Serializer[V],
     checks: List[KafkaCheck],
     silent: Option[Boolean],
+    producerSettingsOverride: Option[Map[String, AnyRef]],
+    consumeSettingsOverride: Option[Map[String, AnyRef]],
+    requestMatchExtractor: Option[org.galaxio.gatling.kafka.request.KafkaProtocolMessage => Array[Byte]],
+    responseMatchExtractor: Option[org.galaxio.gatling.kafka.request.KafkaProtocolMessage => Array[Byte]],
+    replyExtractions: List[KafkaReplyExtraction],
 )

--- a/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
+++ b/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
@@ -96,7 +96,12 @@ public class MatchSimulation extends Simulation {
             .replyTopic("test.t")
         .send("#{kekey}", """
                 { "m": "dkf" }
-                """, String.class, String.class));
+                """, String.class, String.class)
+            .producerSettings(Map.of(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"))
+            .consumeSettings(Map.of("bootstrap.servers", "localhost:9092"))
+            .requestMatchBy(KafkaProtocolMessage::key)
+            .replyMatchBy(KafkaProtocolMessage::value)
+            .saveReplyAs("replyValue", msg -> new String(msg.value())));
 
     {
         setUp(

--- a/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
+++ b/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
@@ -89,6 +89,11 @@ class MatchSimulation : Simulation() {
                     String::class.java,
                     String::class.java
                 )
+                .producerSettings(mapOf(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:9092"))
+                .consumeSettings(mapOf("bootstrap.servers" to "localhost:9092"))
+                .requestMatchBy { message: KafkaProtocolMessage -> message.key }
+                .replyMatchBy { message: KafkaProtocolMessage -> message.value }
+                .saveReplyAs("replyValue") { message: KafkaProtocolMessage -> String(message.value) }
         )
 
         init

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionIntegrationSpec.scala
@@ -220,6 +220,9 @@ class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndA
     val nextAction = new Action {
       override def name: String = "capture-next"
 
+      override def !(session: Session): Unit =
+        execute(session)
+
       override def execute(session: Session): Unit = {
         out = Some(session)
         latch.countDown()

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionIntegrationSpec.scala
@@ -1,0 +1,343 @@
+package org.galaxio.gatling.kafka.actions
+
+import akka.actor.{ActorRef, ActorSystem}
+import io.gatling.commons.stats.{KO, OK, Status}
+import io.gatling.commons.util.DefaultClock
+import io.gatling.commons.validation.{Failure, Success, Validation}
+import io.gatling.core.action.Action
+import io.gatling.core.Predef._
+import io.gatling.core.session.Session
+import io.gatling.core.stats.StatsEngine
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, KafkaConsumer}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.common.errors.WakeupException
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, StringSerializer}
+import org.galaxio.gatling.kafka.Predef._
+import org.galaxio.gatling.kafka.client.{KafkaSenderPool, KafkaTrackersPoolFactory}
+import org.galaxio.gatling.kafka.protocol.{KafkaComponents, KafkaProtocol, KafkaProtocolBuilderNew}
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.{KafkaReplyExtraction, KafkaRequestReplyAttributes}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.kafka.KafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+import java.nio.file.{Files, Paths}
+import java.time.Duration
+import java.util.Properties
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.collection.immutable.List
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndAfterAll {
+
+  private val kafkaContainer       = new KafkaContainer(
+    DockerImageName.parse("confluentinc/cp-kafka:7.5.3").asCompatibleSubstituteFor("apache/kafka"),
+  )
+  private val actorSystem          = ActorSystem("kafka-request-reply-integration")
+  private val clock                = new DefaultClock
+  private lazy val dockerAvailable = dockerSocketLikelyPresent && Try(DockerClientFactory.instance().client()).isSuccess
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    if (dockerAvailable) {
+      kafkaContainer.start()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    actorSystem.terminate()
+    if (dockerAvailable) {
+      kafkaContainer.stop()
+    }
+    super.afterAll()
+  }
+
+  test("action-level broker overrides and reply extraction work end-to-end with asymmetric matcher") {
+    assume(dockerAvailable, "Docker environment is required to run Testcontainers integration tests")
+    val requestTopic = s"rr-request-${UUID.randomUUID()}"
+    val replyTopic   = s"rr-reply-${UUID.randomUUID()}"
+
+    createTopics(requestTopic, replyTopic)
+
+    withResponder(requestTopic, replyTopic) { record =>
+      new ProducerRecord[Array[Byte], Array[Byte]](
+        replyTopic,
+        "reply-key".getBytes(),
+        record.key(),
+      )
+    } {
+      val components = kafkaComponents(invalidBaseProtocol)
+      val attributes = requestReplyAttributes(
+        requestTopic = requestTopic,
+        replyTopic = replyTopic,
+        key = "corr-override",
+        value = "request-payload",
+        producerSettingsOverride = Some(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaContainer.getBootstrapServers)),
+        consumeSettingsOverride = Some(Map("bootstrap.servers" -> kafkaContainer.getBootstrapServers)),
+        requestMatchExtractor = Some(_.key),
+        responseMatchExtractor = Some(_.value),
+        replyExtractions = List(KafkaReplyExtraction("replyValue", msg => new String(msg.value))),
+        checks = List(bodyBytes.is("corr-override".getBytes())),
+      )
+
+      val resultSession = awaitActionResult(components, attributes)
+
+      assert(!resultSession.isFailed)
+      assert(resultSession("replyValue").as[String] == "corr-override")
+    }
+  }
+
+  test("different action-level matchers on the same topics do not reuse an incompatible tracker") {
+    assume(dockerAvailable, "Docker environment is required to run Testcontainers integration tests")
+    val requestTopic = s"rr-shared-request-${UUID.randomUUID()}"
+    val replyTopic   = s"rr-shared-reply-${UUID.randomUUID()}"
+
+    createTopics(requestTopic, replyTopic)
+
+    withResponder(requestTopic, replyTopic) { record =>
+      new ProducerRecord[Array[Byte], Array[Byte]](
+        replyTopic,
+        record.key(),
+        record.value(),
+      )
+    } {
+      val components = kafkaComponents(invalidBaseProtocol)
+
+      val firstAttributes = requestReplyAttributes(
+        requestTopic = requestTopic,
+        replyTopic = replyTopic,
+        key = "first-key",
+        value = "first-payload",
+        producerSettingsOverride = Some(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaContainer.getBootstrapServers)),
+        consumeSettingsOverride = Some(Map("bootstrap.servers" -> kafkaContainer.getBootstrapServers)),
+        requestMatchExtractor = Some(_.key),
+        responseMatchExtractor = Some(_.key),
+        replyExtractions = List(KafkaReplyExtraction("firstReply", msg => new String(msg.value))),
+        checks = List(bodyBytes.is("first-payload".getBytes())),
+      )
+
+      val secondAttributes = requestReplyAttributes(
+        requestTopic = requestTopic,
+        replyTopic = replyTopic,
+        key = "second-key",
+        value = "second-payload",
+        producerSettingsOverride = Some(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaContainer.getBootstrapServers)),
+        consumeSettingsOverride = Some(Map("bootstrap.servers" -> kafkaContainer.getBootstrapServers)),
+        requestMatchExtractor = Some(_.value),
+        responseMatchExtractor = Some(_.value),
+        replyExtractions = List(KafkaReplyExtraction("secondReply", msg => new String(msg.value))),
+        checks = List(bodyBytes.is("second-payload".getBytes())),
+      )
+
+      val firstSession  = awaitActionResult(components, firstAttributes)
+      val secondSession = awaitActionResult(components, secondAttributes)
+
+      assert(!firstSession.isFailed)
+      assert(!secondSession.isFailed)
+      assert(firstSession("firstReply").as[String] == "first-payload")
+      assert(secondSession("secondReply").as[String] == "second-payload")
+    }
+  }
+
+  private def invalidBaseProtocol: KafkaProtocol =
+    KafkaProtocolBuilderNew
+      .producerSettings(
+        Map(
+          ProducerConfig.ACKS_CONFIG              -> "1",
+          ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> "invalid-host:9099",
+        ),
+      )
+      .consumeSettings(
+        Map(
+          "bootstrap.servers" -> "invalid-host:9099",
+        ),
+      )
+      .timeout(5.seconds)
+      .build
+
+  private def kafkaComponents(protocol: KafkaProtocol): KafkaComponents =
+    KafkaComponents(
+      coreComponents = null,
+      kafkaProtocol = protocol,
+      trackersPoolFactory = new KafkaTrackersPoolFactory(actorSystem, NoOpStatsEngine, clock),
+      senderProvider = new KafkaSenderPool,
+    )
+
+  private def requestReplyAttributes(
+      requestTopic: String,
+      replyTopic: String,
+      key: String,
+      value: String,
+      producerSettingsOverride: Option[Map[String, AnyRef]],
+      consumeSettingsOverride: Option[Map[String, AnyRef]],
+      requestMatchExtractor: Option[KafkaProtocolMessage => Array[Byte]],
+      responseMatchExtractor: Option[KafkaProtocolMessage => Array[Byte]],
+      replyExtractions: List[KafkaReplyExtraction],
+      checks: List[org.galaxio.gatling.kafka.KafkaCheck],
+  ): KafkaRequestReplyAttributes[String, String] =
+    KafkaRequestReplyAttributes(
+      requestName = _ => Success("request-reply-integration"),
+      inputTopic = _ => Success(requestTopic),
+      outputTopic = _ => Success(replyTopic),
+      key = _ => Success(key),
+      value = _ => Success(value),
+      headers = None,
+      keySerializer = new StringSerializer,
+      valueSerializer = new StringSerializer,
+      checks = checks,
+      silent = Some(false),
+      producerSettingsOverride = producerSettingsOverride,
+      consumeSettingsOverride = consumeSettingsOverride,
+      requestMatchExtractor = requestMatchExtractor,
+      responseMatchExtractor = responseMatchExtractor,
+      replyExtractions = replyExtractions,
+    )
+
+  private def awaitActionResult(
+      components: KafkaComponents,
+      attributes: KafkaRequestReplyAttributes[String, String],
+  ): Session = {
+    val latch         = new CountDownLatch(1)
+    @volatile var out = Option.empty[Session]
+
+    val nextAction = new Action {
+      override def name: String = "capture-next"
+
+      override def execute(session: Session): Unit = {
+        out = Some(session)
+        latch.countDown()
+      }
+    }
+
+    val instrumentedAction = new KafkaRequestReplyAction[String, String](
+      components = components,
+      attributes = attributes,
+      statsEngine = NoOpStatsEngine,
+      clock = clock,
+      next = nextAction,
+      throttler = None,
+    )
+
+    val session =
+      Session("integration-scenario", 1L, scala.collection.immutable.Map.empty, OK, Nil, Session.NothingOnExit, null)
+
+    instrumentedAction.sendRequest(session) match {
+      case Success(_)       => ()
+      case Failure(message) => fail(s"request-reply action failed before send: $message")
+    }
+
+    assert(latch.await(20, TimeUnit.SECONDS), "timed out waiting for request-reply action result")
+    out.get
+  }
+
+  private def createTopics(topics: String*): Unit = {
+    val admin = AdminClient.create(
+      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaContainer.getBootstrapServers).asJava,
+    )
+    try {
+      admin.createTopics(topics.map(topic => new NewTopic(topic, 1, 1.toShort)).asJava).all().get(20, TimeUnit.SECONDS)
+    } finally {
+      admin.close(Duration.ofSeconds(5))
+    }
+  }
+
+  private def withResponder(
+      requestTopic: String,
+      replyTopic: String,
+  )(
+      replyFactory: ConsumerRecord[Array[Byte], Array[Byte]] => ProducerRecord[Array[Byte], Array[Byte]],
+  )(testCode: => Unit): Unit = {
+    val running  = new AtomicBoolean(true)
+    val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](
+      consumerProps("responder-group"),
+      new ByteArrayDeserializer,
+      new ByteArrayDeserializer,
+    )
+    val producer = new KafkaProducer[Array[Byte], Array[Byte]](producerProps, new ByteArraySerializer, new ByteArraySerializer)
+
+    consumer.subscribe(java.util.Collections.singletonList(requestTopic))
+
+    val thread = new Thread(() => {
+      try {
+        while (running.get()) {
+          val records = consumer.poll(Duration.ofMillis(200))
+          records.iterator().asScala.foreach { record =>
+            producer.send(replyFactory(record)).get(10, TimeUnit.SECONDS)
+          }
+        }
+      } catch {
+        case _: WakeupException if !running.get() => ()
+      }
+    })
+
+    thread.setName(s"responder-$requestTopic")
+    thread.setDaemon(true)
+    thread.start()
+
+    try {
+      testCode
+    } finally {
+      running.set(false)
+      consumer.wakeup()
+      thread.join(5_000L)
+      producer.close(Duration.ofSeconds(5))
+      consumer.close(Duration.ofSeconds(5))
+    }
+  }
+
+  private def producerProps: Properties = {
+    val props = new Properties()
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers)
+    props.put(ProducerConfig.ACKS_CONFIG, "1")
+    props
+  }
+
+  private def dockerSocketLikelyPresent: Boolean = {
+    val homeSocket = Paths.get(sys.props("user.home"), ".docker", "run", "docker.sock")
+    sys.env.contains("DOCKER_HOST") || Files.exists(Paths.get("/var/run/docker.sock")) || Files.exists(homeSocket)
+  }
+
+  private def consumerProps(groupId: String): Properties = {
+    val props = new Properties()
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers)
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, s"$groupId-${UUID.randomUUID()}")
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+    props
+  }
+
+  private object NoOpAction extends Action {
+    override def name: String                    = "noop"
+    override def execute(session: Session): Unit = ()
+  }
+
+  private object NoOpStatsEngine extends StatsEngine {
+    override def start(): Unit                                                                                            = ()
+    override def stop(controller: ActorRef, exception: Option[Exception]): Unit                                           = ()
+    override def logUserStart(scenario: String): Unit                                                                     = ()
+    override def logUserEnd(scenario: String): Unit                                                                       = ()
+    override def logResponse(
+        scenario: String,
+        groups: List[String],
+        requestName: String,
+        startTimestamp: Long,
+        endTimestamp: Long,
+        status: Status,
+        responseCode: Option[String],
+        message: Option[String],
+    ): Unit                                                                                                               = ()
+    override def logGroupEnd(scenario: String, groupBlock: io.gatling.core.session.GroupBlock, exitTimestamp: Long): Unit = ()
+    override def logRequestCrash(
+        scenario: String,
+        groups: List[String],
+        requestName: String,
+        error: String,
+    ): Unit                                                                                                               = ()
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionIntegrationSpec.scala
@@ -21,7 +21,7 @@ import org.galaxio.gatling.kafka.request.builder.{KafkaReplyExtraction, KafkaReq
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.testcontainers.DockerClientFactory
-import org.testcontainers.kafka.KafkaContainer
+import org.testcontainers.kafka.ConfluentKafkaContainer
 import org.testcontainers.utility.DockerImageName
 
 import java.nio.file.{Files, Paths}
@@ -37,9 +37,7 @@ import scala.util.Try
 
 class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndAfterAll {
 
-  private val kafkaContainer       = new KafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:7.5.3").asCompatibleSubstituteFor("apache/kafka"),
-  )
+  private val kafkaContainer       = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3"))
   private val actorSystem          = ActorSystem("kafka-request-reply-integration")
   private val clock                = new DefaultClock
   private lazy val dockerAvailable = dockerSocketLikelyPresent && Try(DockerClientFactory.instance().client()).isSuccess

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionIntegrationSpec.scala
@@ -37,28 +37,37 @@ import scala.util.Try
 
 class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndAfterAll {
 
-  private val kafkaContainer       = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3"))
-  private val actorSystem          = ActorSystem("kafka-request-reply-integration")
-  private val clock                = new DefaultClock
-  private lazy val dockerAvailable = dockerSocketLikelyPresent && Try(DockerClientFactory.instance().client()).isSuccess
+  private val externalBootstrap      = sys.env
+    .get("GATLING_KAFKA_TEST_BOOTSTRAP")
+    .orElse(sys.props.get("gatling.kafka.test.bootstrap"))
+  private val kafkaContainer         = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3"))
+  private val actorSystem            = ActorSystem("kafka-request-reply-integration")
+  private val clock                  = new DefaultClock
+  private lazy val dockerAvailable   = dockerSocketLikelyPresent && Try(DockerClientFactory.instance().client()).isSuccess
+  private lazy val bootstrapServers  = externalBootstrap.getOrElse(kafkaContainer.getBootstrapServers)
+  private lazy val canRunIntegration =
+    externalBootstrap.isDefined || dockerAvailable
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    if (dockerAvailable) {
+    if (externalBootstrap.isEmpty && dockerAvailable) {
       kafkaContainer.start()
     }
   }
 
   override def afterAll(): Unit = {
     actorSystem.terminate()
-    if (dockerAvailable) {
+    if (externalBootstrap.isEmpty && dockerAvailable) {
       kafkaContainer.stop()
     }
     super.afterAll()
   }
 
   test("action-level broker overrides and reply extraction work end-to-end with asymmetric matcher") {
-    assume(dockerAvailable, "Docker environment is required to run Testcontainers integration tests")
+    assume(
+      canRunIntegration,
+      "Integration tests require either GATLING_KAFKA_TEST_BOOTSTRAP or a Docker environment for Testcontainers",
+    )
     val requestTopic = s"rr-request-${UUID.randomUUID()}"
     val replyTopic   = s"rr-reply-${UUID.randomUUID()}"
 
@@ -77,8 +86,8 @@ class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndA
         replyTopic = replyTopic,
         key = "corr-override",
         value = "request-payload",
-        producerSettingsOverride = Some(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaContainer.getBootstrapServers)),
-        consumeSettingsOverride = Some(Map("bootstrap.servers" -> kafkaContainer.getBootstrapServers)),
+        producerSettingsOverride = Some(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers)),
+        consumeSettingsOverride = Some(Map("bootstrap.servers" -> bootstrapServers)),
         requestMatchExtractor = Some(_.key),
         responseMatchExtractor = Some(_.value),
         replyExtractions = List(KafkaReplyExtraction("replyValue", msg => new String(msg.value))),
@@ -93,7 +102,10 @@ class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndA
   }
 
   test("different action-level matchers on the same topics do not reuse an incompatible tracker") {
-    assume(dockerAvailable, "Docker environment is required to run Testcontainers integration tests")
+    assume(
+      canRunIntegration,
+      "Integration tests require either GATLING_KAFKA_TEST_BOOTSTRAP or a Docker environment for Testcontainers",
+    )
     val requestTopic = s"rr-shared-request-${UUID.randomUUID()}"
     val replyTopic   = s"rr-shared-reply-${UUID.randomUUID()}"
 
@@ -113,8 +125,8 @@ class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndA
         replyTopic = replyTopic,
         key = "first-key",
         value = "first-payload",
-        producerSettingsOverride = Some(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaContainer.getBootstrapServers)),
-        consumeSettingsOverride = Some(Map("bootstrap.servers" -> kafkaContainer.getBootstrapServers)),
+        producerSettingsOverride = Some(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers)),
+        consumeSettingsOverride = Some(Map("bootstrap.servers" -> bootstrapServers)),
         requestMatchExtractor = Some(_.key),
         responseMatchExtractor = Some(_.key),
         replyExtractions = List(KafkaReplyExtraction("firstReply", msg => new String(msg.value))),
@@ -126,8 +138,8 @@ class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndA
         replyTopic = replyTopic,
         key = "second-key",
         value = "second-payload",
-        producerSettingsOverride = Some(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaContainer.getBootstrapServers)),
-        consumeSettingsOverride = Some(Map("bootstrap.servers" -> kafkaContainer.getBootstrapServers)),
+        producerSettingsOverride = Some(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers)),
+        consumeSettingsOverride = Some(Map("bootstrap.servers" -> bootstrapServers)),
         requestMatchExtractor = Some(_.value),
         responseMatchExtractor = Some(_.value),
         replyExtractions = List(KafkaReplyExtraction("secondReply", msg => new String(msg.value))),
@@ -237,7 +249,7 @@ class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndA
 
   private def createTopics(topics: String*): Unit = {
     val admin = AdminClient.create(
-      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> kafkaContainer.getBootstrapServers).asJava,
+      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers).asJava,
     )
     try {
       admin.createTopics(topics.map(topic => new NewTopic(topic, 1, 1.toShort)).asJava).all().get(20, TimeUnit.SECONDS)
@@ -292,7 +304,7 @@ class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndA
 
   private def producerProps: Properties = {
     val props = new Properties()
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers)
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
     props.put(ProducerConfig.ACKS_CONFIG, "1")
     props
   }
@@ -304,7 +316,7 @@ class KafkaRequestReplyActionIntegrationSpec extends AnyFunSuite with BeforeAndA
 
   private def consumerProps(groupId: String): Properties = {
     val props = new Properties()
-    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers)
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
     props.put(ConsumerConfig.GROUP_ID_CONFIG, s"$groupId-${UUID.randomUUID()}")
     props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
     props

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
@@ -1,8 +1,11 @@
 package org.galaxio.gatling.kafka.actions
 
+import io.gatling.commons.validation._
+import io.gatling.core.session.Session
 import org.galaxio.gatling.kafka.client.{KafkaMessageTracker, KafkaTrackerProvider}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.KafkaRequestReplyAttributes
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.collection.mutable.ArrayBuffer
@@ -15,6 +18,30 @@ class KafkaRequestReplyActionSpec extends AnyFunSuite {
     inputTopic = "requests",
     outputTopic = "replies",
   )
+
+  private def attributes(
+      producerSettingsOverride: Option[Map[String, AnyRef]] = None,
+      consumeSettingsOverride: Option[Map[String, AnyRef]] = None,
+      requestMatchExtractor: Option[KafkaProtocolMessage => Array[Byte]] = None,
+      responseMatchExtractor: Option[KafkaProtocolMessage => Array[Byte]] = None,
+  ): KafkaRequestReplyAttributes[String, String] =
+    KafkaRequestReplyAttributes(
+      requestName = _ => Success("request"),
+      inputTopic = _ => Success("requests"),
+      outputTopic = _ => Success("replies"),
+      key = _ => Success("key"),
+      value = _ => Success("value"),
+      headers = None,
+      keySerializer = org.apache.kafka.common.serialization.Serdes.String.serializer(),
+      valueSerializer = org.apache.kafka.common.serialization.Serdes.String.serializer(),
+      checks = Nil,
+      silent = None,
+      producerSettingsOverride = producerSettingsOverride,
+      consumeSettingsOverride = consumeSettingsOverride,
+      requestMatchExtractor = requestMatchExtractor,
+      responseMatchExtractor = responseMatchExtractor,
+      replyExtractions = Nil,
+    )
 
   test("requestMatchIdOrError returns request match id when matcher is valid") {
     val matcher = new KafkaProtocol.KafkaMatcher {
@@ -92,5 +119,62 @@ class KafkaRequestReplyActionSpec extends AnyFunSuite {
 
     assert(result == Left("request matcher returned null match id"))
     assert(events.toList == List("match"))
+  }
+
+  test("effectiveMessageMatcher keeps protocol defaults for missing sides and action overrides for configured sides") {
+    val protocolMatcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = "protocol-request".getBytes()
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = "protocol-response".getBytes()
+    }
+
+    val effective = KafkaRequestReplyAction.effectiveMessageMatcher(
+      protocolMatcher,
+      attributes(
+        requestMatchExtractor = Some(_ => "action-request".getBytes()),
+      ),
+    )
+
+    assert(effective.requestMatch(protocolMessage).sameElements("action-request".getBytes()))
+    assert(effective.responseMatch(protocolMessage).sameElements("protocol-response".getBytes()))
+  }
+
+  test("effectiveProducerSettings merges action override over protocol settings") {
+    val effective = KafkaRequestReplyAction.effectiveProducerSettings(
+      org.galaxio.gatling.kafka.protocol.KafkaComponents(
+        coreComponents = null,
+        kafkaProtocol = KafkaProtocol(
+          "topic",
+          Map("bootstrap.servers" -> "protocol:9092", "acks" -> "all"),
+          Map("bootstrap.servers" -> "protocol:9092"),
+          scala.concurrent.duration.DurationInt(1).second,
+          KafkaProtocol.KafkaKeyMatcher,
+        ),
+        trackersPoolFactory = null,
+        senderProvider = null,
+      ),
+      attributes(producerSettingsOverride = Some(Map("bootstrap.servers" -> "action:9092"))),
+    )
+
+    assert(effective == Map("bootstrap.servers" -> "action:9092", "acks" -> "all"))
+  }
+
+  test("effectiveConsumeSettings merges action override over protocol settings") {
+    val effective = KafkaRequestReplyAction.effectiveConsumeSettings(
+      org.galaxio.gatling.kafka.protocol.KafkaComponents(
+        coreComponents = null,
+        kafkaProtocol = KafkaProtocol(
+          "topic",
+          Map("bootstrap.servers" -> "protocol:9092"),
+          Map("bootstrap.servers" -> "protocol:9092", "application.id" -> "base-app"),
+          scala.concurrent.duration.DurationInt(1).second,
+          KafkaProtocol.KafkaKeyMatcher,
+        ),
+        trackersPoolFactory = null,
+        senderProvider = null,
+      ),
+      attributes(consumeSettingsOverride = Some(Map("bootstrap.servers" -> "action:9092"))),
+    )
+
+    assert(effective == Map("bootstrap.servers" -> "action:9092", "application.id" -> "base-app"))
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActorSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActorSpec.scala
@@ -1,6 +1,9 @@
 package org.galaxio.gatling.kafka.client
 
+import io.gatling.core.session.Session
 import org.galaxio.gatling.kafka.client.KafkaMessageTrackerActor.MessagePublished
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.KafkaReplyExtraction
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.collection.mutable
@@ -15,6 +18,7 @@ class KafkaMessageTrackerActorSpec extends AnyFunSuite {
           sent = 1_000L,
           replyTimeout = 2_000L,
           Nil,
+          Nil,
           null,
           null,
           "req",
@@ -26,6 +30,7 @@ class KafkaMessageTrackerActorSpec extends AnyFunSuite {
           sent = 4_000L,
           replyTimeout = 2_000L,
           Nil,
+          Nil,
           null,
           null,
           "req",
@@ -36,6 +41,7 @@ class KafkaMessageTrackerActorSpec extends AnyFunSuite {
           "notimeout".getBytes(),
           sent = 1_000L,
           replyTimeout = 0L,
+          Nil,
           Nil,
           null,
           null,
@@ -50,9 +56,19 @@ class KafkaMessageTrackerActorSpec extends AnyFunSuite {
   }
 
   test("removeTrackedMessage returns published message before timeout and none after cleanup") {
-    val published =
-      MessagePublished("reply".getBytes(), sent = 1_000L, replyTimeout = 2_000L, Nil, null, null, "req", silentRequest = false)
-    val sent      = mutable.HashMap(KafkaMessageTrackerActor.makeTrackingKey("reply".getBytes()) -> published)
+    val published: MessagePublished =
+      MessagePublished(
+        "reply".getBytes(),
+        sent = 1_000L,
+        replyTimeout = 2_000L,
+        Nil,
+        Nil,
+        null,
+        null,
+        "req",
+        silentRequest = false,
+      )
+    val sent                        = mutable.HashMap(KafkaMessageTrackerActor.makeTrackingKey("reply".getBytes()) -> published)
 
     val beforeTimeout = KafkaMessageTrackerActor.removeTrackedMessage("reply".getBytes(), sent)
     val afterTimeout  = KafkaMessageTrackerActor.removeTrackedMessage("reply".getBytes(), sent)
@@ -62,14 +78,55 @@ class KafkaMessageTrackerActorSpec extends AnyFunSuite {
   }
 
   test("removeTimedOutMessages clears timed out entry so late replies are ignored") {
-    val published =
-      MessagePublished("reply".getBytes(), sent = 1_000L, replyTimeout = 2_000L, Nil, null, null, "req", silentRequest = false)
-    val sent      = mutable.HashMap(KafkaMessageTrackerActor.makeTrackingKey("reply".getBytes()) -> published)
+    val published: MessagePublished =
+      MessagePublished(
+        "reply".getBytes(),
+        sent = 1_000L,
+        replyTimeout = 2_000L,
+        Nil,
+        Nil,
+        null,
+        null,
+        "req",
+        silentRequest = false,
+      )
+    val sent                        = mutable.HashMap(KafkaMessageTrackerActor.makeTrackingKey("reply".getBytes()) -> published)
 
     val removed = KafkaMessageTrackerActor.removeTimedOutMessages(List(published), sent)
     val late    = KafkaMessageTrackerActor.removeTrackedMessage("reply".getBytes(), sent)
 
     assert(removed == List(published))
     assert(late.isEmpty)
+  }
+
+  test("applyReplyExtractions stores extracted values into Gatling session") {
+    val session = Session("scenario", 1L, null)
+    val message = KafkaProtocolMessage(
+      key = "request-key".getBytes(),
+      value = "reply-value".getBytes(),
+      inputTopic = "requests",
+      outputTopic = "replies",
+    )
+
+    val result = KafkaMessageTrackerActor.applyReplyExtractions(
+      session,
+      message,
+      List(
+        KafkaReplyExtraction("replyValue", msg => new String(msg.value)),
+        KafkaReplyExtraction("replyKey", msg => new String(msg.key)),
+      ),
+    )
+
+    assert(result.exists(_.attributes == Map("replyValue" -> "reply-value", "replyKey" -> "request-key")))
+  }
+
+  test("applyReplyExtractions rejects null extracted values") {
+    val result = KafkaMessageTrackerActor.applyReplyExtractions(
+      Session("scenario", 1L, null),
+      KafkaProtocolMessage("k".getBytes(), "v".getBytes(), "requests", "replies"),
+      List(KafkaReplyExtraction("replyValue", _ => null)),
+    )
+
+    assert(result == Left("reply extraction 'replyValue' returned null"))
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
@@ -72,4 +72,20 @@ class TrackersPoolSpec extends AnyFunSuite {
 
     assert(error.getMessage.contains("did not reach RUNNING state"))
   }
+
+  test("tracker cache key isolates same topic across different matchers") {
+    val requestMatcher  = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.key
+    }
+    val responseMatcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.value
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+
+    val left  = TrackersPool.TrackerCacheKey("requests", "replies", requestMatcher, None)
+    val right = TrackersPool.TrackerCacheKey("requests", "replies", responseMatcher, None)
+
+    assert(left != right)
+  }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
@@ -1,6 +1,7 @@
 package org.galaxio.gatling.kafka.client
 
 import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.StreamsConfig
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.scalatest.funsuite.AnyFunSuite
@@ -87,5 +88,34 @@ class TrackersPoolSpec extends AnyFunSuite {
     val right = TrackersPool.TrackerCacheKey("requests", "replies", responseMatcher, None)
 
     assert(left != right)
+  }
+
+  test("trackerProperties derives a unique application id per tracker key") {
+    val firstMatcher  = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.key
+    }
+    val secondMatcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.value
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
+    }
+
+    val baseSettings = Map[String, AnyRef](StreamsConfig.APPLICATION_ID_CONFIG -> "gatling-test-base")
+    val firstProps   = TrackersPool.trackerProperties(
+      baseSettings,
+      TrackersPool.TrackerCacheKey("requests", "replies", firstMatcher, None),
+    )
+    val secondProps  = TrackersPool.trackerProperties(
+      baseSettings,
+      TrackersPool.TrackerCacheKey("requests", "replies", secondMatcher, None),
+    )
+
+    assert(firstProps.getProperty(StreamsConfig.APPLICATION_ID_CONFIG).startsWith("gatling-test-base-"))
+    assert(secondProps.getProperty(StreamsConfig.APPLICATION_ID_CONFIG).startsWith("gatling-test-base-"))
+    assert(
+      firstProps.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) != secondProps.getProperty(
+        StreamsConfig.APPLICATION_ID_CONFIG,
+      ),
+    )
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/MatchSimulation.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/MatchSimulation.scala
@@ -61,7 +61,12 @@ class MatchSimulation extends Simulation {
       kafka("ReqRep").requestReply
         .requestTopic("test.t")
         .replyTopic("test.t")
-        .send[String, String]("#{kekey}", """{ "m": "dkf" }"""),
+        .send[String, String]("#{kekey}", """{ "m": "dkf" }""")
+        .producerSettings(Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> "localhost:9092"))
+        .consumeSettings(Map("bootstrap.servers" -> "localhost:9092"))
+        .requestMatchBy(_.key)
+        .replyMatchBy(_.value)
+        .saveReplyAs("replyValue")(msg => new String(msg.value)),
     )
 
   setUp(scn.inject(atOnceUsers(1))).protocols(kafkaProtocolMatchByMessage).maxDuration(120.seconds)


### PR DESCRIPTION
## Summary
- add action-scoped `producerSettings(...)` and `consumeSettings(...)` for request-reply flows
- add per-action request/reply matcher configuration via `requestMatchBy(...)`, `replyMatchBy(...)`, and `matchByKafkaMatcher(...)`
- add first-class reply extraction into Gatling session with `saveReplyAs(...)`
- harden runtime reuse through sender/tracker provider pools and matcher-aware tracker cache keys
- add unit/regression coverage plus a Testcontainers integration spec for end-to-end request-reply behavior

## Notes
- action-level settings now merge over protocol settings instead of replacing them entirely; this keeps required base producer/streams defaults intact
- the Testcontainers integration spec is runnable when a Docker environment is available; in environments without a Docker socket it is canceled instead of failing the build

## Testing
- `sbt --batch 'testOnly org.galaxio.gatling.kafka.client.KafkaSenderSpec org.galaxio.gatling.kafka.client.KafkaMessageTrackerActorSpec org.galaxio.gatling.kafka.client.TrackersPoolSpec org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionSpec org.galaxio.gatling.kafka.protocol.KafkaProtocolBuilderNewSpec org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionIntegrationSpec' 'Test / compile' scalafmtCheckAll`

Closes #52
Closes #53
Closes #55
Closes #58
