### PR TITLE
fix(request): mark session failed on producer callback error

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
@@ -12,6 +12,11 @@ import org.apache.kafka.clients.producer._
 import org.galaxio.gatling.kafka.protocol.{KafkaComponents, KafkaProtocol}
 import org.galaxio.gatling.kafka.request.builder.KafkaAttributes
 
+object KafkaRequestAction {
+  private[actions] def nextSession(session: Session, exception: Exception): Session =
+    if (exception == null) session else session.markAsFailed
+}
+
 class KafkaRequestAction[K, V](
     val producer: KafkaProducer[K, V],
     val components: KafkaComponents,
@@ -92,8 +97,11 @@ class KafkaRequestAction[K, V](
           }
 
           coreComponents.throttler match {
-            case Some(th) if throttled => th.throttle(session.scenario, () => next ! session)
-            case _                     => next ! session
+            case Some(th) if throttled =>
+              val sessionAfterSend = KafkaRequestAction.nextSession(session, e)
+              th.throttle(session.scenario, () => next ! sessionAfterSend)
+            case _                     =>
+              next ! KafkaRequestAction.nextSession(session, e)
           }
 
         },

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestActionSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestActionSpec.scala
@@ -1,0 +1,42 @@
+package org.galaxio.gatling.kafka.actions
+
+import io.gatling.commons.stats.OK
+import io.gatling.core.action.Action
+import io.gatling.core.session.Session
+import org.scalatest.funsuite.AnyFunSuite
+
+class KafkaRequestActionSpec extends AnyFunSuite {
+
+  private def baseSession: Session =
+    Session("kafka-request", 1L, Map.empty, OK, Nil, Session.NothingOnExit, null)
+
+  test("nextSession keeps session successful when producer callback succeeds") {
+    val result = KafkaRequestAction.nextSession(baseSession, null)
+
+    assert(!result.isFailed)
+  }
+
+  test("nextSession marks session as failed when producer callback receives exception") {
+    val result = KafkaRequestAction.nextSession(baseSession, new RuntimeException("send failed"))
+
+    assert(result.isFailed)
+  }
+
+  test("failure session can be propagated to next action") {
+    @volatile var captured = Option.empty[Session]
+
+    val nextAction = new Action {
+      override def name: String = "capture-next"
+
+      override def !(session: Session): Unit =
+        execute(session)
+
+      override def execute(session: Session): Unit =
+        captured = Some(session)
+    }
+
+    nextAction ! KafkaRequestAction.nextSession(baseSession, new RuntimeException("send failed"))
+
+    assert(captured.exists(_.isFailed))
+  }
+}


### PR DESCRIPTION
## Summary
- mark Kafka send sessions as failed when the producer callback returns an exception
- add explicit regression coverage for failed session propagation
- document the expected `session.isFailed` usage in the linked issue

Closes #2