### PR TITLE
feat: add consume-only kafka tracking DSL for Gatling 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,108 @@ scenario("Request reply with explicit topics")
   )
 ```
 
+## Consume-Only Tracking
+
+Use `receiveFrom(...)` when the scenario should wait for and validate a Kafka message without sending a Kafka request first.
+
+This is useful for:
+- Kafka consumer load testing
+- mixed protocol flows such as `HTTP -> Kafka`
+- workflow verification where the correlation id already exists in the Gatling `Session`
+
+`saveAs(...)` stores extracted values from the consumed Kafka message into the Gatling `Session`.
+It does not publish anything to another topic by itself. If you want to forward the consumed data,
+use `saveAs(...)` first and then a later `exec(kafka(...).send(...))`.
+
+### Scala
+
+Track by payload:
+
+```scala
+scenario("Consume only by payload")
+  .exec(session => session.set("correlationId", "corr-42"))
+  .exec(
+    kafka("consume event")
+      .receiveFrom("events")
+      .payloadForTracking("#{correlationId}")
+      .saveAs("replyValue")(message => new String(message.value)),
+  )
+```
+
+Track by key:
+
+```scala
+scenario("Consume only by key")
+  .exec(session => session.set("eventKey", "order-42"))
+  .exec(
+    kafka("consume event")
+      .receiveFrom("events")
+      .keyForTracking("#{eventKey}")
+      .check(bodyString.exists)
+      .saveAs("eventBody")(message => new String(message.value)),
+  )
+```
+
+Track by header:
+
+```scala
+scenario("Consume only by header")
+  .exec(session => session.set("correlationId", "corr-42"))
+  .exec(
+    kafka("consume event")
+      .receiveFrom("events")
+      .headerForTracking("correlation-id", "#{correlationId}")
+      .saveAs("replyValue")(message => new String(message.value)),
+  )
+```
+
+For fully custom correlation you can provide the tracking bytes directly and customize how consumed messages are matched:
+
+```scala
+scenario("Consume only with custom matcher")
+  .exec(session => session.set("expectedMatchId", "corr-42".getBytes))
+  .exec(
+    kafka("consume event")
+      .receiveFrom("events")
+      .matchIdForTracking(session => session("expectedMatchId").validate[Array[Byte]])
+      .replyMatchBy(message => message.value)
+      .saveAs("rawValue")(message => message.value),
+  )
+```
+
+Forward consumed data in the next step:
+
+```scala
+scenario("Consume and resend")
+  .exec(session => session.set("correlationId", "corr-42"))
+  .exec(
+    kafka("consume event")
+      .receiveFrom("events")
+      .headerForTracking("correlation-id", "#{correlationId}")
+      .saveAs("consumedPayload")(message => new String(message.value)),
+  )
+  .exec(
+    kafka("forward event")
+      .send("#{correlationId}", "#{consumedPayload}")
+      .topic("forwarded-events"),
+  )
+```
+
+### Java
+
+```java
+scenario("Consume only")
+  .exec(session -> session.set("matchId", "corr-42".getBytes()))
+  .exec(
+    kafka("consume event")
+      .receiveFrom("events")
+      .matchIdForTracking(byteArrayExp(session -> (byte[]) session.get("matchId")))
+      .replyMatchBy(KafkaProtocolMessage::value)
+      .saveAs("replyValue", message -> new String(message.value()))
+  );
+```
+
+
 ## Run Gatling simulations
 
 Run a simulation class:

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/ConsumeActionBuilder.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/ConsumeActionBuilder.java
@@ -14,58 +14,58 @@ import java.util.function.Function;
 import scala.jdk.javaapi.CollectionConverters;
 import scala.jdk.javaapi.FunctionConverters;
 
-public class RequestReplyBuilder<K, V> implements ActionBuilder {
+public class ConsumeActionBuilder implements ActionBuilder {
 
-    private org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionBuilder<K, V> wrapped;
+    private org.galaxio.gatling.kafka.actions.KafkaConsumeActionBuilder wrapped;
 
-    public RequestReplyBuilder(org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionBuilder<K,V> wrapped) {
+    public ConsumeActionBuilder(org.galaxio.gatling.kafka.actions.KafkaConsumeActionBuilder wrapped) {
         this.wrapped = wrapped;
     }
 
-    public RequestReplyBuilder<K, V> check(CheckBuilder... checks) {
+    public ConsumeActionBuilder check(CheckBuilder... checks) {
         return check(Arrays.asList(checks));
     }
 
-    public RequestReplyBuilder<K, V> check(List<CheckBuilder> checks) {
+    public ConsumeActionBuilder check(List<CheckBuilder> checks) {
         this.wrapped = wrapped.check(KafkaChecks.toScalaChecks(checks));
         return this;
     }
 
-    public RequestReplyBuilder<K, V> producerSettings(Map<String, Object> settings) {
-        this.wrapped = wrapped.producerSettings(scalaMap(settings));
-        return this;
-    }
-
-    public RequestReplyBuilder<K, V> consumeSettings(Map<String, Object> settings) {
+    public ConsumeActionBuilder consumeSettings(Map<String, Object> settings) {
         this.wrapped = wrapped.consumeSettings(scalaMap(settings));
         return this;
     }
 
-    public RequestReplyBuilder<K, V> requestMatchBy(Function<KafkaProtocolMessage, byte[]> extractor) {
-        this.wrapped = wrapped.requestMatchBy(FunctionConverters.asScalaFromFunction(extractor));
-        return this;
-    }
-
-    public RequestReplyBuilder<K, V> replyMatchBy(Function<KafkaProtocolMessage, byte[]> extractor) {
+    public ConsumeActionBuilder replyMatchBy(Function<KafkaProtocolMessage, byte[]> extractor) {
         this.wrapped = wrapped.replyMatchBy(FunctionConverters.asScalaFromFunction(extractor));
         return this;
     }
 
-    public RequestReplyBuilder<K, V> matchByMessage(Function<KafkaProtocolMessage, byte[]> extractor) {
+    public ConsumeActionBuilder matchByMessage(Function<KafkaProtocolMessage, byte[]> extractor) {
         this.wrapped = wrapped.matchByMessage(FunctionConverters.asScalaFromFunction(extractor));
         return this;
     }
 
-    public RequestReplyBuilder<K, V> matchByKafkaMatcher(KafkaProtocol.KafkaMatcher matcher) {
+    public ConsumeActionBuilder matchByKafkaMatcher(KafkaProtocol.KafkaMatcher matcher) {
         this.wrapped = wrapped.matchByKafkaMatcher(matcher);
         return this;
     }
 
-    public <T> RequestReplyBuilder<K, V> saveAs(String sessionKey, Function<KafkaProtocolMessage, T> extractor) {
+    public <T> ConsumeActionBuilder saveAs(String sessionKey, Function<KafkaProtocolMessage, T> extractor) {
         this.wrapped = wrapped.saveAs(
                 sessionKey,
                 FunctionConverters.asScalaFromFunction((Function<KafkaProtocolMessage, Object>) extractor::apply)
         );
+        return this;
+    }
+
+    public ConsumeActionBuilder silent() {
+        this.wrapped = wrapped.silent();
+        return this;
+    }
+
+    public ConsumeActionBuilder notSilent() {
+        this.wrapped = wrapped.notSilent();
         return this;
     }
 

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/KafkaRequestBuilderBase.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/KafkaRequestBuilderBase.java
@@ -359,4 +359,12 @@ public class KafkaRequestBuilderBase {
         return new ReqRepBase(requestName);
     }
 
+    public ReceiveFromStep receiveFrom(String topic) {
+        return new ReceiveFromStep(toStringExpression(topic), toStringExpression(requestName));
+    }
+
+    public ReceiveFromStep receiveFrom(JExpression<String> topic) {
+        return new ReceiveFromStep(javaFunctionToExpression(topic), toStringExpression(requestName));
+    }
+
 }

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/ReceiveFromStep.java
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/request/builder/ReceiveFromStep.java
@@ -1,0 +1,49 @@
+package org.galaxio.gatling.kafka.javaapi.request.builder;
+
+import io.gatling.commons.validation.Validation;
+import io.gatling.core.session.Session;
+import io.gatling.javaapi.core.internal.Expressions;
+import org.galaxio.gatling.kafka.actions.KafkaConsumeActionBuilder;
+import org.galaxio.gatling.kafka.javaapi.request.expressions.ExpressionBuilder;
+
+public class ReceiveFromStep {
+
+    private final scala.Function1<Session, Validation<String>> topicExpression;
+    private final scala.Function1<Session, Validation<String>> requestNameExpression;
+
+    public ReceiveFromStep(
+            scala.Function1<Session, Validation<String>> topicExpression,
+            scala.Function1<Session, Validation<String>> requestNameExpression
+    ) {
+        this.topicExpression = topicExpression;
+        this.requestNameExpression = requestNameExpression;
+    }
+
+    public ConsumeActionBuilder matchIdForTracking(byte[] expectedMatchId) {
+        return new ConsumeActionBuilder(
+                KafkaConsumeActionBuilder.create(
+                        requestNameExpression,
+                        topicExpression,
+                        Expressions.toStaticValueExpression(expectedMatchId)
+                )
+        );
+    }
+
+    public ConsumeActionBuilder matchIdForTracking(ExpressionBuilder<byte[]> expectedMatchId) {
+        return new ConsumeActionBuilder(
+                KafkaConsumeActionBuilder.create(
+                        requestNameExpression,
+                        topicExpression,
+                        expectedMatchId.gatlingExpression()
+                )
+        );
+    }
+
+    public ConsumeActionBuilder expectMatchId(byte[] expectedMatchId) {
+        return matchIdForTracking(expectedMatchId);
+    }
+
+    public ConsumeActionBuilder expectMatchId(ExpressionBuilder<byte[]> expectedMatchId) {
+        return matchIdForTracking(expectedMatchId);
+    }
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeAction.scala
@@ -1,0 +1,106 @@
+package org.galaxio.gatling.kafka.actions
+
+import io.gatling.commons.stats.KO
+import io.gatling.commons.util.Clock
+import io.gatling.commons.validation._
+import io.gatling.core.action.{Action, RequestAction}
+import io.gatling.core.controller.throttle.Throttler
+import io.gatling.core.session.{Expression, Session}
+import io.gatling.core.stats.StatsEngine
+import io.gatling.core.util.NameGen
+import org.galaxio.gatling.kafka.KafkaLogging
+import org.galaxio.gatling.kafka.client.{KafkaMessageTracker, KafkaTrackerProvider}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
+import org.galaxio.gatling.kafka.protocol.KafkaComponents
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.KafkaConsumeAttributes
+
+object KafkaConsumeAction {
+  private[kafka] def effectiveMessageMatcher(
+      protocolMatcher: KafkaMatcher,
+      attributes: KafkaConsumeAttributes,
+  ): KafkaMatcher =
+    attributes.responseMatchExtractor match {
+      case Some(responseExtractor) =>
+        new KafkaMatcher {
+          override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = protocolMatcher.requestMatch(msg)
+          override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = responseExtractor(msg)
+        }
+      case None                    => protocolMatcher
+    }
+
+  private[kafka] def effectiveConsumeSettings(
+      components: KafkaComponents,
+      attributes: KafkaConsumeAttributes,
+  ): Map[String, AnyRef] =
+    components.kafkaProtocol.consumeProperties ++ attributes.consumeSettingsOverride.getOrElse(Map.empty)
+
+  private[kafka] def expectedMatchIdOrError(expectedMatchId: Array[Byte]): Either[String, Array[Byte]] =
+    Option(expectedMatchId).toRight("consume-only matcher returned null expected match id")
+}
+
+class KafkaConsumeAction(
+    components: KafkaComponents,
+    attributes: KafkaConsumeAttributes,
+    val statsEngine: StatsEngine,
+    val clock: Clock,
+    val next: Action,
+    throttler: Option[Throttler],
+) extends RequestAction with KafkaLogging with NameGen {
+  override def requestName: Expression[String]   = attributes.requestName
+  private val messageMatcher                     =
+    KafkaConsumeAction.effectiveMessageMatcher(components.kafkaProtocol.messageMatcher, attributes)
+  private val trackersPool: KafkaTrackerProvider =
+    components.trackersPoolFactory.trackerProvider(KafkaConsumeAction.effectiveConsumeSettings(components, attributes))
+
+  override def sendRequest(session: Session): Validation[Unit] =
+    for {
+      rn         <- requestName(session)
+      topic      <- attributes.topic(session)
+      expectedId <- attributes.expectedMatchId(session)
+    } yield throttler
+      .fold(trackAndAwait(rn, topic, expectedId, session))(
+        _.throttle(session.scenario, () => trackAndAwait(rn, topic, expectedId, session)),
+      )
+
+  private def trackAndAwait(
+      requestNameString: String,
+      topic: String,
+      expectedId: Array[Byte],
+      session: Session,
+  ): Unit = {
+    val now = clock.nowMillis
+    KafkaConsumeAction.expectedMatchIdOrError(expectedId) match {
+      case Right(matchId)     =>
+        val tracker: KafkaMessageTracker = trackersPool.tracker(topic, topic, messageMatcher, None)
+        tracker.track(
+          matchId,
+          now,
+          components.kafkaProtocol.timeout.toMillis,
+          attributes.checks,
+          attributes.replyExtractions,
+          session,
+          next,
+          requestNameString,
+          attributes.silent.getOrElse(false),
+        )
+      case Left(errorMessage) =>
+        logger.error(errorMessage)
+        if (!attributes.silent.getOrElse(false)) {
+          statsEngine.logResponse(
+            session.scenario,
+            session.groups,
+            requestNameString,
+            now,
+            clock.nowMillis,
+            KO,
+            Some("500"),
+            Some(errorMessage),
+          )
+        }
+        next ! session.logGroupRequestTimings(now, clock.nowMillis).markAsFailed
+    }
+  }
+
+  override def name: String = genName("kafkaConsume")
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionBuilder.scala
@@ -1,0 +1,68 @@
+package org.galaxio.gatling.kafka.actions
+
+import com.softwaremill.quicklens.ModifyPimp
+import io.gatling.core.action.Action
+import io.gatling.core.action.builder.ActionBuilder
+import io.gatling.core.structure.ScenarioContext
+import org.galaxio.gatling.kafka.KafkaCheck
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.{KafkaMatcher, KafkaMessageMatcher}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.{KafkaConsumeAttributes, KafkaReplyExtraction}
+
+object KafkaConsumeActionBuilder {
+  def create(
+      requestName: io.gatling.core.session.Expression[String],
+      topic: io.gatling.core.session.Expression[String],
+      expectedMatchId: io.gatling.core.session.Expression[Array[Byte]],
+  ): KafkaConsumeActionBuilder =
+    KafkaConsumeActionBuilder(
+      KafkaConsumeAttributes(
+        requestName = requestName,
+        topic = topic,
+        expectedMatchId = expectedMatchId,
+        checks = List.empty,
+        silent = None,
+        consumeSettingsOverride = None,
+        responseMatchExtractor = None,
+        replyExtractions = List.empty,
+      ),
+    )
+}
+
+case class KafkaConsumeActionBuilder(attributes: KafkaConsumeAttributes) extends ActionBuilder {
+
+  def silent: KafkaConsumeActionBuilder = this.modify(_.attributes.silent).setTo(Some(true))
+
+  def notSilent: KafkaConsumeActionBuilder = this.modify(_.attributes.silent).setTo(Some(false))
+
+  def check(checks: KafkaCheck*): KafkaConsumeActionBuilder =
+    this.modify(_.attributes.checks).using(_ ::: checks.toList)
+
+  def consumeSettings(settings: Map[String, AnyRef]): KafkaConsumeActionBuilder =
+    this.modify(_.attributes.consumeSettingsOverride).setTo(Some(settings))
+
+  def replyMatchBy(extractor: KafkaProtocolMessage => Array[Byte]): KafkaConsumeActionBuilder =
+    this.modify(_.attributes.responseMatchExtractor).setTo(Some(extractor))
+
+  def matchByMessage(extractor: KafkaProtocolMessage => Array[Byte]): KafkaConsumeActionBuilder =
+    replyMatchBy(extractor)
+
+  def matchByKafkaMatcher(matcher: KafkaMatcher): KafkaConsumeActionBuilder =
+    replyMatchBy(matcher.responseMatch)
+
+  def saveAs(sessionKey: String)(extractor: KafkaProtocolMessage => Any): KafkaConsumeActionBuilder =
+    this.modify(_.attributes.replyExtractions).using(_ :+ KafkaReplyExtraction(sessionKey, extractor))
+
+  override def build(ctx: ScenarioContext, next: Action): Action = {
+    val kafkaComponents = ctx.protocolComponentsRegistry.components(KafkaProtocol.kafkaProtocolKey)
+    new KafkaConsumeAction(
+      kafkaComponents,
+      attributes,
+      ctx.coreComponents.statsEngine,
+      ctx.coreComponents.clock,
+      next,
+      ctx.coreComponents.throttler,
+    )
+  }
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionBuilder.scala
@@ -41,7 +41,7 @@ case class KafkaRequestReplyActionBuilder[K: ClassTag, V: ClassTag](attributes: 
   def matchByKafkaMatcher(matcher: KafkaMatcher): KafkaRequestReplyActionBuilder[K, V] =
     requestMatchBy(matcher.requestMatch).replyMatchBy(matcher.responseMatch)
 
-  def saveReplyAs(sessionKey: String)(extractor: KafkaProtocolMessage => Any): KafkaRequestReplyActionBuilder[K, V] =
+  def saveAs(sessionKey: String)(extractor: KafkaProtocolMessage => Any): KafkaRequestReplyActionBuilder[K, V] =
     this.modify(_.attributes.replyExtractions).using(_ :+ KafkaReplyExtraction(sessionKey, extractor))
 
   override def build(ctx: ScenarioContext, next: Action): Action = {

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActor.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActor.scala
@@ -18,6 +18,7 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
 object KafkaMessageTrackerActor {
+  private val BufferedReplyRetentionMillis = 60_000L
 
   def props(statsEngine: StatsEngine, clock: Clock): Props =
     Props(new KafkaMessageTrackerActor(statsEngine, clock))
@@ -35,6 +36,12 @@ object KafkaMessageTrackerActor {
   )
 
   case class MessageConsumed(
+      replyId: Array[Byte],
+      received: Long,
+      message: KafkaProtocolMessage,
+  )
+
+  private[client] final case class BufferedReply(
       replyId: Array[Byte],
       received: Long,
       message: KafkaProtocolMessage,
@@ -66,6 +73,27 @@ object KafkaMessageTrackerActor {
   ): List[MessagePublished] =
     timedOutMessages.filter(message => removeTrackedMessage(message.matchId, sentMessages).isDefined)
 
+  private[client] def bufferReply(
+      replyId: Array[Byte],
+      received: Long,
+      message: KafkaProtocolMessage,
+      bufferedReplies: mutable.HashMap[String, BufferedReply],
+  ): Unit =
+    bufferedReplies.update(makeTrackingKey(replyId), BufferedReply(replyId, received, message))
+
+  private[client] def removeBufferedReply(
+      matchId: Array[Byte],
+      bufferedReplies: mutable.HashMap[String, BufferedReply],
+  ): Option[BufferedReply] =
+    bufferedReplies.remove(makeTrackingKey(matchId))
+
+  private[client] def removeExpiredBufferedReplies(
+      now: Long,
+      bufferedReplies: mutable.HashMap[String, BufferedReply],
+      retentionMillis: Long = BufferedReplyRetentionMillis,
+  ): Unit =
+    bufferedReplies.filterInPlace((_, bufferedReply) => (now - bufferedReply.received) <= retentionMillis)
+
   private[client] def applyReplyExtractions(
       session: Session,
       message: KafkaProtocolMessage,
@@ -88,9 +116,10 @@ class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends A
       periodicTimeoutScanTriggered: Boolean,
       sentMessages: mutable.HashMap[String, MessagePublished],
       timedOutMessages: mutable.ArrayBuffer[MessagePublished],
+      bufferedReplies: mutable.HashMap[String, BufferedReply],
   ): Unit =
-    if (!periodicTimeoutScanTriggered) {
-      context.become(onMessage(periodicTimeoutScanTriggered = true, sentMessages, timedOutMessages))
+    if (!periodicTimeoutScanTriggered && (sentMessages.nonEmpty || bufferedReplies.nonEmpty)) {
+      context.become(onMessage(periodicTimeoutScanTriggered = true, sentMessages, timedOutMessages, bufferedReplies))
       timers.startTimerWithFixedDelay("timeoutTimer", TimeoutScan, 1000.millis)
     }
 
@@ -99,6 +128,7 @@ class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends A
       periodicTimeoutScanTriggered = false,
       mutable.HashMap.empty[String, MessagePublished],
       mutable.ArrayBuffer.empty[MessagePublished],
+      mutable.HashMap.empty[String, BufferedReply],
     )
 
   private def executeNext(
@@ -179,25 +209,45 @@ class KafkaMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends A
       periodicTimeoutScanTriggered: Boolean,
       sentMessages: mutable.HashMap[String, MessagePublished],
       timedOutMessages: mutable.ArrayBuffer[MessagePublished],
+      bufferedReplies: mutable.HashMap[String, BufferedReply],
   ): Receive = {
     // message was sent; add the timestamps to the map
     case messageSent: MessagePublished =>
-      val key = makeTrackingKey(messageSent.matchId)
-      sentMessages += key -> messageSent
-      if (messageSent.replyTimeout > 0) {
-        triggerPeriodicTimeoutScan(periodicTimeoutScanTriggered, sentMessages, timedOutMessages)
+      removeBufferedReply(messageSent.matchId, bufferedReplies) match {
+        case Some(BufferedReply(_, received, message)) =>
+          processMessage(
+            messageSent.session,
+            messageSent.sent,
+            received,
+            messageSent.checks,
+            messageSent.replyExtractions,
+            message,
+            messageSent.next,
+            messageSent.requestName,
+            messageSent.silentRequest,
+          )
+        case None                                      =>
+          val key = makeTrackingKey(messageSent.matchId)
+          sentMessages += key -> messageSent
+          if (messageSent.replyTimeout > 0 || bufferedReplies.nonEmpty) {
+            triggerPeriodicTimeoutScan(periodicTimeoutScanTriggered, sentMessages, timedOutMessages, bufferedReplies)
+          }
       }
 
     // message was received; publish stats and remove from the map
     case MessageConsumed(replyId, received, message) =>
       // if key is missing, message was already acked and is a dup, or request timeout
-      removeTrackedMessage(replyId, sentMessages).foreach {
-        case MessagePublished(_, sent, _, checks, replyExtractions, session, next, requestName, silentRequest) =>
+      removeTrackedMessage(replyId, sentMessages) match {
+        case Some(MessagePublished(_, sent, _, checks, replyExtractions, session, next, requestName, silentRequest)) =>
           processMessage(session, sent, received, checks, replyExtractions, message, next, requestName, silentRequest)
+        case None                                                                                                    =>
+          bufferReply(replyId, received, message, bufferedReplies)
+          triggerPeriodicTimeoutScan(periodicTimeoutScanTriggered, sentMessages, timedOutMessages, bufferedReplies)
       }
 
     case TimeoutScan =>
       val now = clock.nowMillis
+      removeExpiredBufferedReplies(now, bufferedReplies)
       timedOutMessages ++= KafkaMessageTrackerActor.timedOutMessages(now, sentMessages)
       for (
         MessagePublished(matchId, sent, receivedTimeout, _, _, session, next, requestName, silentRequest) <-

--- a/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
@@ -5,6 +5,7 @@ import io.gatling.commons.util.Clock
 import io.gatling.core.stats.StatsEngine
 import io.gatling.core.util.NameGen
 import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.processor.api.{ContextualProcessor, Record}
 import org.apache.kafka.streams.StreamsConfig
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.StreamsBuilder
@@ -59,6 +60,15 @@ object TrackersPool {
   ): Either[String, Array[Byte]] =
     Option(messageMatcher.responseMatch(message)).toRight("response matcher returned null match id")
 
+  private[client] def consumedMessage(
+      key: Array[Byte],
+      value: Array[Byte],
+      inputTopic: String,
+      outputTopic: String,
+      headers: org.apache.kafka.common.header.Headers,
+  ): KafkaProtocolMessage =
+    KafkaProtocolMessage(key, value, inputTopic, outputTopic, Option(headers))
+
   private[client] def trackerApplicationId(baseApplicationId: String, trackerKey: TrackerCacheKey): String = {
     val fingerprint = UUID.nameUUIDFromBytes(
       s"${trackerKey.inputTopic}|${trackerKey.outputTopic}|${System.identityHashCode(trackerKey.messageMatcher)}|${trackerKey.responseTransformer
@@ -104,35 +114,47 @@ class TrackersPool(
 
         val builder = new StreamsBuilder
 
-        builder.stream[Array[Byte], Array[Byte]](outputTopic).foreach { case (k, v) =>
-          val message = KafkaProtocolMessage(k, v, inputTopic, outputTopic)
-          TrackersPool.responseMatchIdOrError(message, messageMatcher) match {
-            case Left(_)        =>
-              logger.error(s"no messageMatcher key for read message")
-            case Right(replyId) =>
-              if (k == null || v == null)
-                logger.info(s" --- received message with null key or value")
-              else
-                logger.info(s" --- received  ${new String(k)} ${new String(v)}")
-              val receivedTimestamp = clock.nowMillis
-              if (k != null)
-                logMessage(
-                  s"Record received key=${new String(k)}",
-                  message,
+        builder
+          .stream[Array[Byte], Array[Byte]](outputTopic)
+          .process(() =>
+            new ContextualProcessor[Array[Byte], Array[Byte], Void, Void] {
+              override def process(record: Record[Array[Byte], Array[Byte]]): Unit = {
+                val message = TrackersPool.consumedMessage(
+                  record.key(),
+                  record.value(),
+                  inputTopic,
+                  outputTopic,
+                  record.headers(),
                 )
-              else
-                logMessage(
-                  s"Record received key=null",
-                  message,
-                )
+                TrackersPool.responseMatchIdOrError(message, messageMatcher) match {
+                  case Left(_)        =>
+                    logger.error(s"no messageMatcher key for read message")
+                  case Right(replyId) =>
+                    if (record.key() == null || record.value() == null)
+                      logger.info(s" --- received message with null key or value")
+                    else
+                      logger.info(s" --- received  ${new String(record.key())} ${new String(record.value())}")
+                    val receivedTimestamp = clock.nowMillis
+                    if (record.key() != null)
+                      logMessage(
+                        s"Record received key=${new String(record.key())}",
+                        message,
+                      )
+                    else
+                      logMessage(
+                        s"Record received key=null",
+                        message,
+                      )
 
-              actor ! MessageConsumed(
-                replyId,
-                receivedTimestamp,
-                responseTransformer.map(_(message)).getOrElse(message),
-              )
-          }
-        }
+                    actor ! MessageConsumed(
+                      replyId,
+                      receivedTimestamp,
+                      responseTransformer.map(_(message)).getOrElse(message),
+                    )
+                }
+              }
+            },
+          )
 
         val streams = new KafkaStreams(builder.build(), TrackersPool.trackerProperties(streamsSettings, trackerKey))
 

--- a/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaConsumeAttributes.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaConsumeAttributes.scala
@@ -1,0 +1,16 @@
+package org.galaxio.gatling.kafka.request.builder
+
+import io.gatling.core.session.Expression
+import org.galaxio.gatling.kafka.KafkaCheck
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+
+case class KafkaConsumeAttributes(
+    requestName: Expression[String],
+    topic: Expression[String],
+    expectedMatchId: Expression[Array[Byte]],
+    checks: List[KafkaCheck],
+    silent: Option[Boolean],
+    consumeSettingsOverride: Option[Map[String, AnyRef]],
+    responseMatchExtractor: Option[KafkaProtocolMessage => Array[Byte]],
+    replyExtractions: List[KafkaReplyExtraction],
+)

--- a/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestBuilderBase.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestBuilderBase.scala
@@ -4,8 +4,10 @@ import io.gatling.core.session._
 import org.apache.kafka.common.header.{Header, Headers}
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.apache.kafka.common.serialization.Serde
+import org.galaxio.gatling.kafka.actions.KafkaConsumeActionBuilder
 import org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionBuilder
 
+import java.nio.charset.StandardCharsets
 import scala.reflect.ClassTag
 
 case class KafkaRequestBuilderBase(requestName: Expression[String]) {
@@ -80,6 +82,12 @@ case class KafkaRequestBuilderBase(requestName: Expression[String]) {
 
   def requestReply: ReqRepBase.type = ReqRepBase
 
+  def receiveFrom: ConsumeBase.type = ConsumeBase
+
+  def receiveFrom(topic: Expression[String]): ConsumeBase.ConsumeTopicStep = ConsumeBase.topic(topic)
+
+  def receiveFrom(topic: String): ConsumeBase.ConsumeTopicStep = ConsumeBase.topic(topic.expressionSuccess)
+
   object ReqRepBase {
     case class RROutTopicStep(inputTopic: Expression[String], outputTopic: Expression[String]) {
       def send[K: Serde: ClassTag, V: Serde: ClassTag](
@@ -114,6 +122,64 @@ case class KafkaRequestBuilderBase(requestName: Expression[String]) {
     }
     def requestTopic(rt: Expression[String]): RRInTopicStep = RRInTopicStep(rt)
 
+  }
+
+  object ConsumeBase {
+    case class ConsumeTopicStep(topic: Expression[String]) {
+      def matchIdForTracking(matchId: Expression[Array[Byte]]): KafkaConsumeActionBuilder =
+        KafkaConsumeActionBuilder(
+          KafkaConsumeAttributes(
+            requestName = requestName,
+            topic = topic,
+            expectedMatchId = matchId,
+            checks = List.empty,
+            silent = None,
+            consumeSettingsOverride = None,
+            responseMatchExtractor = None,
+            replyExtractions = List.empty,
+          ),
+        )
+
+      def matchIdForTracking(matchId: Array[Byte]): KafkaConsumeActionBuilder =
+        matchIdForTracking(matchId.expressionSuccess)
+
+      def keyForTracking[K: Serde: ClassTag](key: Expression[K]): KafkaConsumeActionBuilder =
+        matchIdForTracking(KafkaSerializedExpression(topic, key)).replyMatchBy(_.key)
+
+      def keyForTracking[K: Serde: ClassTag](key: K): KafkaConsumeActionBuilder =
+        matchIdForTracking(KafkaSerializedExpression.static(topic, key)).replyMatchBy(_.key)
+
+      def payloadForTracking[V: Serde: ClassTag](payload: Expression[V]): KafkaConsumeActionBuilder =
+        matchIdForTracking(KafkaSerializedExpression(topic, payload)).replyMatchBy(_.value)
+
+      def payloadForTracking[V: Serde: ClassTag](payload: V): KafkaConsumeActionBuilder =
+        matchIdForTracking(KafkaSerializedExpression.static(topic, payload)).replyMatchBy(_.value)
+
+      def headerForTracking(headerName: String, headerValue: Expression[String]): KafkaConsumeActionBuilder =
+        matchIdForTracking(headerValue.map(_.getBytes(StandardCharsets.UTF_8))).replyMatchBy { message =>
+          message.headers
+            .flatMap(headers => Option(headers.lastHeader(headerName)))
+            .map(_.value())
+            .orNull
+        }
+
+      def headerForTracking(headerName: String, headerValue: String): KafkaConsumeActionBuilder =
+        headerForTracking(headerName, headerValue.expressionSuccess)
+
+      def expectMatchId(matchId: Expression[Array[Byte]]): KafkaConsumeActionBuilder = matchIdForTracking(matchId)
+
+      def expectMatchId(matchId: Array[Byte]): KafkaConsumeActionBuilder = matchIdForTracking(matchId)
+
+      def expectKey[K: Serde: ClassTag](key: Expression[K]): KafkaConsumeActionBuilder = keyForTracking(key)
+
+      def expectKey[K: Serde: ClassTag](key: K): KafkaConsumeActionBuilder = keyForTracking(key)
+
+      def expectPayload[V: Serde: ClassTag](payload: Expression[V]): KafkaConsumeActionBuilder = payloadForTracking(payload)
+
+      def expectPayload[V: Serde: ClassTag](payload: V): KafkaConsumeActionBuilder = payloadForTracking(payload)
+    }
+
+    def topic(outputTopic: Expression[String]): ConsumeTopicStep = ConsumeTopicStep(outputTopic)
   }
 
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaSerializedExpression.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaSerializedExpression.scala
@@ -1,0 +1,37 @@
+package org.galaxio.gatling.kafka.request.builder
+
+import io.gatling.commons.validation.Validation
+import io.gatling.commons.validation.Success
+import io.gatling.core.session.Expression
+import io.gatling.core.session.el._
+import org.apache.kafka.common.serialization.Serde
+
+import scala.reflect.{ClassTag, classTag}
+
+object KafkaSerializedExpression {
+
+  def apply[T: Serde: ClassTag](
+      topic: Expression[String],
+      value: Expression[T],
+  ): Expression[Array[Byte]] = {
+    val serializer = implicitly[Serde[T]].serializer()
+    session =>
+      if (classTag[T].runtimeClass.getCanonicalName == "java.lang.String")
+        for {
+          resolvedTopic <- topic(session)
+          resolvedValue <- value
+                             .asInstanceOf[Expression[String]](session)
+                             .flatMap(_.el[String].apply(session))
+        } yield serializer
+          .asInstanceOf[org.apache.kafka.common.serialization.Serializer[String]]
+          .serialize(resolvedTopic, resolvedValue)
+      else
+        for {
+          resolvedTopic <- topic(session)
+          resolvedValue <- value(session)
+        } yield serializer.serialize(resolvedTopic, resolvedValue)
+  }
+
+  def static[T: Serde: ClassTag](topic: Expression[String], value: T): Expression[Array[Byte]] =
+    apply(topic, _ => Success(value))
+}

--- a/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
+++ b/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.java
@@ -101,7 +101,7 @@ public class MatchSimulation extends Simulation {
             .consumeSettings(Map.of("bootstrap.servers", "localhost:9092"))
             .requestMatchBy(KafkaProtocolMessage::key)
             .replyMatchBy(KafkaProtocolMessage::value)
-            .saveReplyAs("replyValue", msg -> new String(msg.value())));
+            .saveAs("replyValue", msg -> new String(msg.value())));
 
     {
         setUp(

--- a/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/OnlyConsumeSimulation.java
+++ b/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/OnlyConsumeSimulation.java
@@ -1,0 +1,39 @@
+package org.galaxio.gatling.kafka.javaapi.examples;
+
+import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.core.Simulation;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.galaxio.gatling.kafka.javaapi.KafkaDsl;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static org.galaxio.gatling.kafka.javaapi.KafkaDsl.byteArrayExp;
+
+public class OnlyConsumeSimulation extends Simulation {
+
+    private final org.galaxio.gatling.kafka.javaapi.protocol.KafkaProtocolBuilderNew protocol = KafkaDsl.kafka().requestReply()
+            .producerSettings(
+                    Map.of(
+                            ProducerConfig.ACKS_CONFIG, "1",
+                            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"
+                    )
+            )
+            .consumeSettings(Map.of("bootstrap.servers", "localhost:9092"))
+            .timeout(Duration.ofSeconds(5));
+
+    private final ScenarioBuilder scn = scenario("ConsumeOnly")
+            .exec(session -> session.set("matchId", "corr-42".getBytes()))
+            .exec(
+                    KafkaDsl.kafka("Consume only")
+                            .receiveFrom("events")
+                            .matchIdForTracking(byteArrayExp(session -> (byte[]) session.get("matchId")))
+                            .replyMatchBy(message -> message.value())
+                            .saveAs("replyValue", message -> new String(message.value()))
+            );
+
+    {
+        setUp(scn.injectOpen(atOnceUsers(1))).protocols(protocol);
+    }
+}

--- a/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
+++ b/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/MatchSimulation.kt
@@ -93,7 +93,7 @@ class MatchSimulation : Simulation() {
                 .consumeSettings(mapOf("bootstrap.servers" to "localhost:9092"))
                 .requestMatchBy { message: KafkaProtocolMessage -> message.key }
                 .replyMatchBy { message: KafkaProtocolMessage -> message.value }
-                .saveReplyAs("replyValue") { message: KafkaProtocolMessage -> String(message.value) }
+                .saveAs("replyValue") { message: KafkaProtocolMessage -> String(message.value) }
         )
 
         init

--- a/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/OnlyConsumeSimulation.kt
+++ b/src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/OnlyConsumeSimulation.kt
@@ -1,0 +1,35 @@
+package org.galaxio.gatling.kafka.javaapi.examples
+
+import io.gatling.javaapi.core.CoreDsl.*
+import io.gatling.javaapi.core.Simulation
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.galaxio.gatling.kafka.javaapi.KafkaDsl
+import org.galaxio.gatling.kafka.javaapi.KafkaDsl.byteArrayExp
+import java.time.Duration
+
+class OnlyConsumeSimulation : Simulation() {
+
+    private val protocol = KafkaDsl.kafka().requestReply()
+        .producerSettings(
+            mapOf<String, Any>(
+                ProducerConfig.ACKS_CONFIG to "1",
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:9092"
+            )
+        )
+        .consumeSettings(mapOf("bootstrap.servers" to "localhost:9092"))
+        .timeout(Duration.ofSeconds(5))
+
+    private val scn = scenario("ConsumeOnly")
+        .exec { session -> session.set("matchId", "corr-42".toByteArray()) }
+        .exec(
+            KafkaDsl.kafka("Consume only")
+                .receiveFrom("events")
+                .matchIdForTracking(byteArrayExp { session -> session.get("matchId") as ByteArray })
+                .replyMatchBy { message -> message.value }
+                .saveAs("replyValue") { message -> String(message.value) }
+        )
+
+    init {
+        setUp(scn.injectOpen(atOnceUsers(1))).protocols(protocol)
+    }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionIntegrationSpec.scala
@@ -124,7 +124,17 @@ class KafkaConsumeActionIntegrationSpec extends AnyFunSuite with BeforeAndAfterA
           .map(_.value())
           .orNull
       },
-      replyExtractions = List(KafkaReplyExtraction("headerPayload", msg => new String(msg.value))),
+      replyExtractions = List(
+        KafkaReplyExtraction("headerPayload", msg => new String(msg.value)),
+        KafkaReplyExtraction(
+          "headerCorrelationId",
+          msg =>
+            msg.headers
+              .flatMap(headers => Option(headers.lastHeader("correlation-id")))
+              .map(header => new String(header.value()))
+              .orNull,
+        ),
+      ),
     )
 
     val resultSession = awaitConsumeResult(invalidBaseProtocol, attributes) {
@@ -138,6 +148,40 @@ class KafkaConsumeActionIntegrationSpec extends AnyFunSuite with BeforeAndAfterA
 
     assert(!resultSession.isFailed)
     assert(resultSession("headerPayload").as[String] == "header-payload")
+    assert(resultSession("headerCorrelationId").as[String] == "corr-123")
+  }
+
+  test("consume-only action can correlate by key and preserve message payload") {
+    assume(
+      canRunIntegration,
+      "Integration tests require either GATLING_KAFKA_TEST_BOOTSTRAP or a Docker environment for Testcontainers",
+    )
+
+    val topic = s"consume-keys-${UUID.randomUUID()}"
+    createTopics(topic)
+
+    val attributes = KafkaConsumeAttributes(
+      requestName = _ => Success("consume-key-integration"),
+      topic = _ => Success(topic),
+      expectedMatchId = _ => Success("order-42".getBytes()),
+      checks = List(bodyBytes.is("event-body".getBytes())),
+      silent = Some(false),
+      consumeSettingsOverride = Some(
+        Map(
+          "bootstrap.servers" -> bootstrapServers,
+          "auto.offset.reset" -> "earliest",
+        ),
+      ),
+      responseMatchExtractor = Some(_.key),
+      replyExtractions = List(KafkaReplyExtraction("eventBody", msg => new String(msg.value))),
+    )
+
+    val resultSession = awaitConsumeResult(invalidBaseProtocol, attributes) {
+      publish(topic, key = "order-42".getBytes(), value = "event-body".getBytes())
+    }
+
+    assert(!resultSession.isFailed)
+    assert(resultSession("eventBody").as[String] == "event-body")
   }
 
   private def invalidBaseProtocol: KafkaProtocol =

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionIntegrationSpec.scala
@@ -1,0 +1,271 @@
+package org.galaxio.gatling.kafka.actions
+
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import io.gatling.commons.stats.{OK, Status}
+import io.gatling.commons.util.DefaultClock
+import io.gatling.commons.validation.{Failure, Success}
+import io.gatling.core.Predef._
+import io.gatling.core.action.Action
+import io.gatling.core.session.Session
+import io.gatling.core.stats.StatsEngine
+import org.galaxio.gatling.kafka.Predef._
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.galaxio.gatling.kafka.client.KafkaTrackersPoolFactory
+import org.galaxio.gatling.kafka.protocol.{KafkaComponents, KafkaProtocol, KafkaProtocolBuilderNew}
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.{KafkaConsumeAttributes, KafkaReplyExtraction}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+import java.nio.file.{Files, Paths}
+import java.time.Duration
+import java.util.Properties
+import java.util.UUID
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+class KafkaConsumeActionIntegrationSpec extends AnyFunSuite with BeforeAndAfterAll {
+
+  private val externalBootstrap      = sys.env
+    .get("GATLING_KAFKA_TEST_BOOTSTRAP")
+    .orElse(sys.props.get("gatling.kafka.test.bootstrap"))
+  private val kafkaContainer         = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3"))
+  private val actorSystem            = ActorSystem("kafka-consume-integration")
+  private val clock                  = new DefaultClock
+  private lazy val dockerAvailable   = dockerSocketLikelyPresent && Try(DockerClientFactory.instance().client()).isSuccess
+  private lazy val bootstrapServers  = externalBootstrap.getOrElse(kafkaContainer.getBootstrapServers)
+  private lazy val canRunIntegration =
+    externalBootstrap.isDefined || dockerAvailable
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    if (externalBootstrap.isEmpty && dockerAvailable) {
+      kafkaContainer.start()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    actorSystem.terminate()
+    if (externalBootstrap.isEmpty && dockerAvailable) {
+      kafkaContainer.stop()
+    }
+    super.afterAll()
+  }
+
+  test("consume-only action tracks payload and stores consumed reply into session") {
+    assume(
+      canRunIntegration,
+      "Integration tests require either GATLING_KAFKA_TEST_BOOTSTRAP or a Docker environment for Testcontainers",
+    )
+
+    val topic = s"consume-topic-${UUID.randomUUID()}"
+    createTopics(topic)
+
+    val attributes = KafkaConsumeAttributes(
+      requestName = _ => Success("consume-integration"),
+      topic = _ => Success(topic),
+      expectedMatchId = _ => Success("tracked-payload".getBytes()),
+      checks = List(bodyBytes.is("tracked-payload".getBytes())),
+      silent = Some(false),
+      consumeSettingsOverride = Some(
+        Map(
+          "bootstrap.servers" -> bootstrapServers,
+          "auto.offset.reset" -> "earliest",
+        ),
+      ),
+      responseMatchExtractor = Some(_.value),
+      replyExtractions = List(
+        KafkaReplyExtraction("consumedPayload", message => new String(message.value)),
+        KafkaReplyExtraction("consumedKey", message => Option(message.key).map(new String(_)).orNull),
+      ),
+    )
+
+    val resultSession = awaitConsumeResult(invalidBaseProtocol, attributes) {
+      publish(topic, key = "event-key".getBytes(), value = "tracked-payload".getBytes())
+    }
+
+    assert(!resultSession.isFailed)
+    assert(resultSession("consumedPayload").as[String] == "tracked-payload")
+    assert(resultSession("consumedKey").as[String] == "event-key")
+  }
+
+  test("consume-only action can correlate by header without sending a Kafka request first") {
+    assume(
+      canRunIntegration,
+      "Integration tests require either GATLING_KAFKA_TEST_BOOTSTRAP or a Docker environment for Testcontainers",
+    )
+
+    val topic = s"consume-headers-${UUID.randomUUID()}"
+    createTopics(topic)
+
+    val attributes = KafkaConsumeAttributes(
+      requestName = _ => Success("consume-header-integration"),
+      topic = _ => Success(topic),
+      expectedMatchId = _ => Success("corr-123".getBytes()),
+      checks = Nil,
+      silent = Some(false),
+      consumeSettingsOverride = Some(
+        Map(
+          "bootstrap.servers" -> bootstrapServers,
+          "auto.offset.reset" -> "earliest",
+        ),
+      ),
+      responseMatchExtractor = Some { message =>
+        message.headers
+          .flatMap(headers => Option(headers.lastHeader("correlation-id")))
+          .map(_.value())
+          .orNull
+      },
+      replyExtractions = List(KafkaReplyExtraction("headerPayload", msg => new String(msg.value))),
+    )
+
+    val resultSession = awaitConsumeResult(invalidBaseProtocol, attributes) {
+      publish(
+        topic,
+        key = "event-key".getBytes(),
+        value = "header-payload".getBytes(),
+        headers = Map("correlation-id" -> "corr-123".getBytes()),
+      )
+    }
+
+    assert(!resultSession.isFailed)
+    assert(resultSession("headerPayload").as[String] == "header-payload")
+  }
+
+  private def invalidBaseProtocol: KafkaProtocol =
+    KafkaProtocolBuilderNew
+      .producerSettings(
+        Map(
+          ProducerConfig.ACKS_CONFIG              -> "1",
+          ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> "invalid-host:9099",
+        ),
+      )
+      .consumeSettings(
+        Map(
+          "bootstrap.servers" -> "invalid-host:9099",
+        ),
+      )
+      .timeout(5.seconds)
+      .build
+
+  private def awaitConsumeResult(
+      protocol: KafkaProtocol,
+      attributes: KafkaConsumeAttributes,
+  )(
+      publishCode: => Unit,
+  ): Session = {
+    val latch         = new CountDownLatch(1)
+    @volatile var out = Option.empty[Session]
+
+    val nextAction = new Action {
+      override def name: String = "capture-next"
+
+      override def !(session: Session): Unit =
+        execute(session)
+
+      override def execute(session: Session): Unit = {
+        out = Some(session)
+        latch.countDown()
+      }
+    }
+
+    val action = new KafkaConsumeAction(
+      components = KafkaComponents(
+        coreComponents = null,
+        kafkaProtocol = protocol,
+        trackersPoolFactory = new KafkaTrackersPoolFactory(actorSystem, NoOpStatsEngine, clock),
+        senderProvider = null,
+      ),
+      attributes = attributes,
+      statsEngine = NoOpStatsEngine,
+      clock = clock,
+      next = nextAction,
+      throttler = None,
+    )
+
+    val session =
+      Session("consume-integration", 1L, scala.collection.immutable.Map.empty, OK, Nil, Session.NothingOnExit, null)
+
+    action.sendRequest(session) match {
+      case Success(_)       =>
+        publishCode
+      case Failure(message) => fail(s"consume action failed before tracking: $message")
+    }
+
+    assert(latch.await(20, TimeUnit.SECONDS), "timed out waiting for consume action result")
+    out.get
+  }
+
+  private def createTopics(topics: String*): Unit = {
+    val admin = AdminClient.create(
+      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers).asJava,
+    )
+    try {
+      admin.createTopics(topics.map(topic => new NewTopic(topic, 1, 1.toShort)).asJava).all().get(20, TimeUnit.SECONDS)
+    } finally {
+      admin.close(Duration.ofSeconds(5))
+    }
+  }
+
+  private def publish(
+      topic: String,
+      key: Array[Byte],
+      value: Array[Byte],
+      headers: Map[String, Array[Byte]] = Map.empty,
+  ): Unit = {
+    val producer = new KafkaProducer[Array[Byte], Array[Byte]](producerProps, new ByteArraySerializer, new ByteArraySerializer)
+    try {
+      val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, key, value)
+      headers.foreach { case (headerKey, headerValue) =>
+        record.headers().add(headerKey, headerValue)
+      }
+      producer.send(record).get(10, TimeUnit.SECONDS)
+    } finally {
+      producer.close(Duration.ofSeconds(5))
+    }
+  }
+
+  private def producerProps: Properties = {
+    val props = new Properties()
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    props.put(ProducerConfig.ACKS_CONFIG, "1")
+    props
+  }
+
+  private def dockerSocketLikelyPresent: Boolean = {
+    val homeSocket = Paths.get(sys.props("user.home"), ".docker", "run", "docker.sock")
+    sys.env.contains("DOCKER_HOST") || Files.exists(Paths.get("/var/run/docker.sock")) || Files.exists(homeSocket)
+  }
+
+  private object NoOpStatsEngine extends StatsEngine {
+    override def start(): Unit                                                                                            = ()
+    override def stop(controller: ActorRef, exception: Option[Exception]): Unit                                           = ()
+    override def logUserStart(scenario: String): Unit                                                                     = ()
+    override def logUserEnd(scenario: String): Unit                                                                       = ()
+    override def logResponse(
+        scenario: String,
+        groups: List[String],
+        requestName: String,
+        startTimestamp: Long,
+        endTimestamp: Long,
+        status: Status,
+        responseCode: Option[String],
+        message: Option[String],
+    ): Unit                                                                                                               = ()
+    override def logGroupEnd(scenario: String, groupBlock: io.gatling.core.session.GroupBlock, exitTimestamp: Long): Unit = ()
+    override def logRequestCrash(
+        scenario: String,
+        groups: List[String],
+        requestName: String,
+        error: String,
+    ): Unit                                                                                                               = ()
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionSpec.scala
@@ -1,0 +1,86 @@
+package org.galaxio.gatling.kafka.actions
+
+import io.gatling.commons.validation.Success
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.KafkaConsumeAttributes
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.concurrent.duration.DurationInt
+
+class KafkaConsumeActionSpec extends AnyFunSuite {
+
+  private def attributes(
+      consumeSettingsOverride: Option[Map[String, AnyRef]] = None,
+      responseMatchExtractor: Option[KafkaProtocolMessage => Array[Byte]] = None,
+  ): KafkaConsumeAttributes =
+    KafkaConsumeAttributes(
+      requestName = _ => Success("consume"),
+      topic = _ => Success("events"),
+      expectedMatchId = _ => Success("match-id".getBytes()),
+      checks = Nil,
+      silent = None,
+      consumeSettingsOverride = consumeSettingsOverride,
+      responseMatchExtractor = responseMatchExtractor,
+      replyExtractions = Nil,
+    )
+
+  private val protocolMessage = KafkaProtocolMessage(
+    key = "message-key".getBytes(),
+    value = "message-value".getBytes(),
+    inputTopic = "events",
+    outputTopic = "events",
+  )
+
+  test("effectiveMessageMatcher keeps protocol matcher when no consume override is configured") {
+    val protocolMatcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = "protocol-request".getBytes()
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = "protocol-response".getBytes()
+    }
+
+    val effective = KafkaConsumeAction.effectiveMessageMatcher(protocolMatcher, attributes())
+
+    assert(effective eq protocolMatcher)
+  }
+
+  test("effectiveMessageMatcher uses action-level response extractor when configured") {
+    val protocolMatcher = new KafkaProtocol.KafkaMatcher {
+      override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = "protocol-request".getBytes()
+      override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = "protocol-response".getBytes()
+    }
+
+    val effective = KafkaConsumeAction.effectiveMessageMatcher(
+      protocolMatcher,
+      attributes(responseMatchExtractor = Some(_.key)),
+    )
+
+    assert(effective.requestMatch(protocolMessage).sameElements("protocol-request".getBytes()))
+    assert(effective.responseMatch(protocolMessage).sameElements("message-key".getBytes()))
+  }
+
+  test("effectiveConsumeSettings merges action override over protocol settings") {
+    val effective = KafkaConsumeAction.effectiveConsumeSettings(
+      org.galaxio.gatling.kafka.protocol.KafkaComponents(
+        coreComponents = null,
+        kafkaProtocol = KafkaProtocol(
+          "topic",
+          Map("bootstrap.servers" -> "protocol:9092"),
+          Map("bootstrap.servers" -> "protocol:9092", "application.id" -> "base-app"),
+          1.second,
+          KafkaProtocol.KafkaKeyMatcher,
+        ),
+        trackersPoolFactory = null,
+        senderProvider = null,
+      ),
+      attributes(consumeSettingsOverride = Some(Map("bootstrap.servers" -> "action:9092"))),
+    )
+
+    assert(effective == Map("bootstrap.servers" -> "action:9092", "application.id" -> "base-app"))
+  }
+
+  test("expectedMatchIdOrError rejects null tracking ids") {
+    val result = KafkaConsumeAction.expectedMatchIdOrError(null)
+
+    assert(result == Left("consume-only matcher returned null expected match id"))
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActorSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerActorSpec.scala
@@ -99,6 +99,39 @@ class KafkaMessageTrackerActorSpec extends AnyFunSuite {
     assert(late.isEmpty)
   }
 
+  test("buffered reply can be consumed when tracking is registered after message arrival") {
+    val bufferedReplies = mutable.HashMap.empty[String, KafkaMessageTrackerActor.BufferedReply]
+    val message         = KafkaProtocolMessage("reply".getBytes(), "value".getBytes(), "requests", "replies")
+
+    KafkaMessageTrackerActor.bufferReply("reply".getBytes(), received = 5_000L, message, bufferedReplies)
+
+    val buffered = KafkaMessageTrackerActor.removeBufferedReply("reply".getBytes(), bufferedReplies)
+
+    assert(buffered.exists(_.message == message))
+    assert(bufferedReplies.isEmpty)
+  }
+
+  test("removeExpiredBufferedReplies evicts stale unmatched replies") {
+    val bufferedReplies = mutable.HashMap(
+      KafkaMessageTrackerActor.makeTrackingKey("stale".getBytes()) ->
+        KafkaMessageTrackerActor.BufferedReply(
+          "stale".getBytes(),
+          received = 1_000L,
+          KafkaProtocolMessage("stale".getBytes(), "value".getBytes(), "requests", "replies"),
+        ),
+      KafkaMessageTrackerActor.makeTrackingKey("fresh".getBytes()) ->
+        KafkaMessageTrackerActor.BufferedReply(
+          "fresh".getBytes(),
+          received = 59_500L,
+          KafkaProtocolMessage("fresh".getBytes(), "value".getBytes(), "requests", "replies"),
+        ),
+    )
+
+    KafkaMessageTrackerActor.removeExpiredBufferedReplies(now = 61_500L, bufferedReplies)
+
+    assert(bufferedReplies.keySet == Set(KafkaMessageTrackerActor.makeTrackingKey("fresh".getBytes())))
+  }
+
   test("applyReplyExtractions stores extracted values into Gatling session") {
     val session = Session("scenario", 1L, null)
     val message = KafkaProtocolMessage(

--- a/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
@@ -2,6 +2,7 @@ package org.galaxio.gatling.kafka.client
 
 import org.apache.kafka.streams.KafkaStreams
 import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.common.header.internals.RecordHeaders
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.scalatest.funsuite.AnyFunSuite
@@ -116,6 +117,26 @@ class TrackersPoolSpec extends AnyFunSuite {
       firstProps.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) != secondProps.getProperty(
         StreamsConfig.APPLICATION_ID_CONFIG,
       ),
+    )
+  }
+
+  test("consumedMessage keeps Kafka headers for header-based matching") {
+    val headers = new RecordHeaders()
+    headers.add("correlation-id", "corr-123".getBytes())
+
+    val message = TrackersPool.consumedMessage(
+      key = "key".getBytes(),
+      value = "value".getBytes(),
+      inputTopic = "requests",
+      outputTopic = "replies",
+      headers = headers,
+    )
+
+    assert(
+      message.headers
+        .flatMap(h => Option(h.lastHeader("correlation-id")))
+        .map(_.value())
+        .exists(_.sameElements("corr-123".getBytes())),
     )
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/MatchSimulation.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/MatchSimulation.scala
@@ -66,7 +66,7 @@ class MatchSimulation extends Simulation {
         .consumeSettings(Map("bootstrap.servers" -> "localhost:9092"))
         .requestMatchBy(_.key)
         .replyMatchBy(_.value)
-        .saveReplyAs("replyValue")(msg => new String(msg.value)),
+        .saveAs("replyValue")(msg => new String(msg.value)),
     )
 
   setUp(scn.inject(atOnceUsers(1))).protocols(kafkaProtocolMatchByMessage).maxDuration(120.seconds)

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/OnlyConsumeSimulation.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/OnlyConsumeSimulation.scala
@@ -1,0 +1,35 @@
+package org.galaxio.gatling.kafka.examples
+
+import io.gatling.core.Predef._
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.galaxio.gatling.kafka.Predef._
+
+import scala.concurrent.duration.DurationInt
+
+class OnlyConsumeSimulation extends Simulation {
+
+  private val protocol = kafka.requestReply
+    .producerSettings(
+      Map(
+        ProducerConfig.ACKS_CONFIG              -> "1",
+        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> "localhost:9092",
+      ),
+    )
+    .consumeSettings(
+      Map(
+        "bootstrap.servers" -> "localhost:9092",
+      ),
+    )
+    .timeout(5.seconds)
+
+  private val scn = scenario("ConsumeOnly")
+    .exec(session => session.set("correlationId", "corr-42"))
+    .exec(
+      kafka("Consume only")
+        .receiveFrom("events")
+        .headerForTracking("correlation-id", "#{correlationId}")
+        .saveAs("replyValue")(message => new String(message.value)),
+    )
+
+  setUp(scn.inject(atOnceUsers(1))).protocols(protocol)
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/request/builder/KafkaSerializedExpressionSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/request/builder/KafkaSerializedExpressionSpec.scala
@@ -1,0 +1,30 @@
+package org.galaxio.gatling.kafka.request.builder
+
+import io.gatling.commons.validation.Success
+import io.gatling.core.session.Session
+import org.galaxio.gatling.kafka.Predef._
+import org.scalatest.funsuite.AnyFunSuite
+
+class KafkaSerializedExpressionSpec extends AnyFunSuite {
+
+  test("serializes string expressions after resolving Gatling EL") {
+    val topicExpression = (_: Session) => Success("events")
+    val valueExpression = (_: Session) => Success("#{correlationId}")
+    val session         = Session("scenario", 1L, null).set("correlationId", "corr-42")
+
+    val expression = KafkaSerializedExpression[String](topicExpression, valueExpression)
+    val result     = expression(session)
+
+    assert(result.map(_.sameElements("corr-42".getBytes())) == Success(true))
+  }
+
+  test("serializes non-string values via configured serde") {
+    val topicExpression = (_: Session) => Success("events")
+    val valueExpression = (_: Session) => Success(42L)
+
+    val expression = KafkaSerializedExpression[Long](topicExpression, valueExpression)
+    val result     = expression(Session("scenario", 1L, null))
+
+    assert(result.map(bytes => java.nio.ByteBuffer.wrap(bytes).getLong) == Success(42L))
+  }
+}


### PR DESCRIPTION
## Summary
- add a first-class `receiveFrom(...)` consume-only DSL for correlated Kafka reads without sending a Kafka request first
- support tracking by payload, key, header, or explicit match id plus `check(...)`, `saveAs(...)`, and consume-side settings overrides
- harden the tracker actor to buffer early consumed messages until tracking registration and document the new flow with Scala/Java/Kotlin examples

## Issues
- Closes #37
- Closes #56
- Addresses #30

## Validation
- `sbt --batch 'testOnly org.galaxio.gatling.kafka.request.builder.KafkaSerializedExpressionSpec org.galaxio.gatling.kafka.actions.KafkaConsumeActionSpec org.galaxio.gatling.kafka.client.KafkaMessageTrackerActorSpec org.galaxio.gatling.kafka.actions.KafkaConsumeActionIntegrationSpec org.galaxio.gatling.kafka.actions.KafkaRequestReplyActionSpec org.galaxio.gatling.kafka.client.TrackersPoolSpec'`
- `sbt --batch 'Test / compile' scalafmtAll scalafmtCheckAll`

## Notes
- Testcontainers integration tests are included and skip cleanly when Docker is unavailable.
- `saveAs(...)` is now the only extraction name; `saveReplyAs(...)` was removed from the API to keep the DSL consistent.
