### PR TITLE
ci: parallel jobs, auto release notes, deprecated/gatling-3-11 release

### DIFF
--- a/.github/changelog/release-changelog-builder.json
+++ b/.github/changelog/release-changelog-builder.json
@@ -1,0 +1,90 @@
+{
+  "template": "# 🚀 Release #{{TO_TAG}}\n\n#{{CHANGELOG}}\n\n<details>\n<summary>📦 Other changes</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+  "empty_template": "# 🚀 Release #{{TO_TAG}}\n\nNo user-facing changes were detected.",
+  "commit_template": "- #{{TITLE}} by @#{{AUTHOR}} (#{{MERGE_SHA}})",
+  "categories": [
+    {
+      "title": "## 💥 Breaking Changes",
+      "labels": ["breaking", "boom", "💥"]
+    },
+    {
+      "title": "## ✨ Features",
+      "labels": ["feat", "feature", "sparkles", "✨"]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": ["fix", "bug", "bugfix", "🐛"]
+    },
+    {
+      "title": "## ⏪️ Reverts",
+      "labels": ["revert", "rewind", "⏪️"]
+    },
+    {
+      "title": "## ⚡ Performance",
+      "labels": ["perf", "zap", "⚡"]
+    },
+    {
+      "title": "## ♻️ Refactoring",
+      "labels": ["refactor", "recycle", "♻️"]
+    },
+    {
+      "title": "## 📝 Documentation",
+      "labels": ["docs", "doc", "memo", "📝"]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": ["test", "tests", "white_check_mark", "test_tube", "🧪"]
+    },
+    {
+      "title": "## 🤖 CI / Build",
+      "labels": ["ci", "build", "construction_worker", "bricks", "🤖"]
+    },
+    {
+      "title": "## 📦 Dependencies",
+      "labels": ["deps", "dependency", "dependencies", "package", "📦"]
+    },
+    {
+      "title": "## 🧹 Chores",
+      "labels": ["chore", "style", "wrench", "broom", "🧹"]
+    },
+    {
+      "title": "## 🔒 Security",
+      "labels": ["security", "lock", "🔒"]
+    }
+  ],
+  "label_extractor": [
+    {
+      "pattern": "^(.+)!:",
+      "on_property": "title",
+      "target": "breaking"
+    },
+    {
+      "pattern": "BREAKING CHANGE",
+      "on_property": "body",
+      "method": "match",
+      "target": "breaking"
+    },
+    {
+      "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-.]+\\))?(!)?: .+",
+      "on_property": "title",
+      "target": "$1"
+    },
+    {
+      "pattern": "^:(boom|sparkles|bug|zap|recycle|memo|white_check_mark|test_tube|construction_worker|bricks|package|wrench|broom|lock|rewind): .+",
+      "on_property": "title",
+      "target": "$1"
+    },
+    {
+      "pattern": "^(💥|✨|🐛|⚡|♻️|📝|🧪|🤖|📦|🧹|🔒|⏪️) .+",
+      "on_property": "title",
+      "target": "$1"
+    }
+  ],
+  "sort": {
+    "order": "ASC",
+    "on_property": "mergedAt"
+  },
+  "trim_values": true,
+  "max_tags_to_fetch": 200,
+  "max_back_track_time_days": 365
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,10 @@ on:
   push:
     branches: ['**']
     tags: ['v*']
+  workflow_dispatch:
 
 permissions:
-  contents: write
-  actions: read
-  checks: write
-  pull-requests: write
-  packages: write
+  contents: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -26,9 +23,50 @@ env:
   TERM: xterm-256color
 
 jobs:
-  test:
-    name: Lint, Compile & Test
+  format:
+    name: Formatting
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (Temurin 17) with sbt cache
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache Coursier
+        uses: coursier/cache-action@v8
+
+      - name: Cache Ivy/SBT
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+          restore-keys: sbt-${{ runner.os }}-
+
+      - name: Check Formatting
+        run: sbt scalafmtCheckAll scalafmtSbtCheck
+
+  test:
+    name: Test (Java ${{ matrix.java }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['17', '21']
     services:
       zookeeper:
         image: wurstmeister/zookeeper
@@ -61,73 +99,103 @@ jobs:
           SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:9094
         ports:
           - '9094:9094'
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup Java (Temurin 17) with sbt cache
-        uses: actions/setup-java@v4
+      - name: Setup Java (Temurin ${{ matrix.java }}) with sbt cache
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: ${{ matrix.java }}
           cache: sbt
 
-      - uses: sbt/setup-sbt@v1
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Cache Coursier
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
 
       - name: Cache Ivy/SBT
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.ivy2/cache
             ~/.sbt
             ~/.cache/coursier
-          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
-          restore-keys: sbt-${{ runner.os }}-
-
-      - name: Check Formatting
-        run: sbt scalafmtCheckAll scalafmtSbtCheck
+          key: sbt-${{ runner.os }}-java${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+          restore-keys: sbt-${{ runner.os }}-java${{ matrix.java }}-
 
       - name: Compile
         run: sbt clean compile
 
-      - name: Test (Gatling targeted) 
+      - name: Test (Gatling targeted)
         env:
           GATLING_KAFKA_TEST_BOOTSTRAP: localhost:9093
-        run: sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport
+        run: |
+          sbt "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" \
+              "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" \
+              test
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-
-  release:
-    name: Release (tag-driven)
-    needs: [test]
+  coverage:
+    name: Coverage
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-    permissions:
-      contents: write
+    timeout-minutes: 30
+    services:
+      zookeeper:
+        image: wurstmeister/zookeeper
+        env:
+          ZOO_MY_ID: "1"
+          ZOO_PORT: "2181"
+          ZOO_SERVERS: server.1=zoo1:2888:3888
+        ports:
+          - '2181:2181'
+      kafka:
+        image: wurstmeister/kafka:2.13-2.8.1
+        env:
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+          KAFKA_ADVERTISED_HOST_NAME: kafka
+          KAFKA_LISTENERS: BROKER://:9092,EXTERNAL://:9093
+          KAFKA_ADVERTISED_LISTENERS: BROKER://kafka:9092,EXTERNAL://localhost:9093
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: BROKER:PLAINTEXT,EXTERNAL:PLAINTEXT
+          KAFKA_INTER_BROKER_LISTENER_NAME: BROKER
+          KAFKA_BROKER_ID: "1"
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+          KAFKA_CREATE_TOPICS: "myTopic1:1:1, test.t1:1:1, myTopic2:1:1, test.t2:1:1, myTopic3:1:1, test.t3:1:1"
+        ports:
+          - '9092:9092'
+          - '9093:9093'
+      schema-registry:
+        image: confluentinc/cp-schema-registry:7.2.1
+        env:
+          SCHEMA_REGISTRY_HOST_NAME: schema-registry
+          SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'kafka:9092,localhost:9093'
+          SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:9094
+        ports:
+          - '9094:9094'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Setup Java (Temurin 17) with sbt cache
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
           cache: sbt
+
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
+
       - name: Cache Coursier
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
+
       - name: Cache Ivy/SBT
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.ivy2/cache
@@ -135,9 +203,62 @@ jobs:
             ~/.cache/coursier
           key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
           restore-keys: sbt-${{ runner.os }}-
-      - name: Compute next version & create tag on main
+
+      - name: Test with Coverage
+        env:
+          GATLING_KAFKA_TEST_BOOTSTRAP: localhost:9093
+        run: |
+          sbt coverage \
+              "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" \
+              "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" \
+              test coverageOff coverageReport
+
+      - name: Upload coverage reports to Codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+
+  release:
+    name: Release
+    needs: [format, test, coverage]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deprecated/gatling-3-11' || startsWith(github.ref, 'refs/tags/v'))
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (Temurin 17) with sbt cache
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache Coursier
+        uses: coursier/cache-action@v8
+
+      - name: Cache Ivy/SBT
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+          restore-keys: sbt-${{ runner.os }}-
+
+      - name: Compute next version & create tag
         id: bump
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deprecated/gatling-3-11'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -197,8 +318,11 @@ jobs:
             git tag -a "$NEXT_TAG" -m "Release $NEXT_TAG"
             git push origin "$NEXT_TAG"
           fi
+
       - name: Publish to Sonatype via sbt-ci-release
-        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
+        if: >-
+          startsWith(github.ref, 'refs/tags/v') ||
+          ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deprecated/gatling-3-11') && steps.bump.outputs.tag)
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -228,44 +352,28 @@ jobs:
           else
             sbt "set ThisBuild/version := \"${VERSION}\"" ci-release
           fi
+
       - name: Generate Changelog
         id: changelog
-        uses: mikepenz/release-changelog-builder-action@v5
-        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
+        uses: mikepenz/release-changelog-builder-action@v6
+        if: >-
+          startsWith(github.ref, 'refs/tags/v') ||
+          ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deprecated/gatling-3-11') && steps.bump.outputs.tag)
         with:
           mode: "COMMIT"
-          fromTag: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.last_tag || '' }}
-          toTag:   ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || '' }}
-          configurationJson: |
-            {
-              "template": "# Changelog\n\n#{{CHANGELOG}}",
-              "categories": [
-                {"title": "✨ Features", "labels": ["feat", "feature"]},
-                {"title": "🐛 Bug Fixes", "labels": ["fix", "bug"]},
-                {"title": "📝 Documentation", "labels": ["docs"]},
-                {"title": "⚡ Performance Improvements", "labels": ["perf"]},
-                {"title": "♻️ Refactoring", "labels": ["refactor"]},
-                {"title": "🧪 Tests", "labels": ["test"]},
-                {"title": "🧹 Chores", "labels": ["chore"]},
-                {"title": "📦 Dependencies", "labels": ["dependency"]},
-                {"title": "🚨 Breaking Changes", "labels": ["breaking"]},
-                {"title": "🤖 CI / Build", "labels": ["ci"]}
-              ],
-              "label_extractor": [
-                {
-                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
-                  "on_property": "title",
-                  "target": "$1"
-                }
-              ]
-            }
+          fromTag: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deprecated/gatling-3-11') && steps.bump.outputs.last_tag || '' }}
+          toTag: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deprecated/gatling-3-11') && steps.bump.outputs.tag || '' }}
+          configuration: ".github/changelog/release-changelog-builder.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
-        uses: softprops/action-gh-release@v2
+        if: >-
+          startsWith(github.ref, 'refs/tags/v') ||
+          ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deprecated/gatling-3-11') && steps.bump.outputs.tag)
+        uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || '' }}
+          tag_name: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deprecated/gatling-3-11') && steps.bump.outputs.tag || '' }}
           body: ${{ steps.changelog.outputs.changelog }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Split monolithic `test` job into 4 parallel jobs: `format`, `test` (Java 17+21 matrix), `coverage`, `release`
- Extract changelog config to `.github/changelog/release-changelog-builder.json` matching org-wide pattern (gatling-picatinny)
- Add `deprecated/gatling-3-11` branch as release trigger alongside `main`
- Upgrade action versions: checkout v6, setup-java v5, coursier v8, cache v5, changelog-builder v6, gh-release v3
- Add `workflow_dispatch` trigger for manual runs
- Tighten permissions: `contents: read` default, `contents: write` only on release job
- Add `timeout-minutes` to all jobs

## Job dependency graph

```
format ──────────┐
test (Java 17) ──┤
test (Java 21) ──┼── release
coverage ────────┘
```

## Test plan

- [ ] Verify format, test (2 matrix jobs), coverage all start in parallel on PR
- [ ] Verify YAML and JSON syntax validity
- [ ] Merge to `main` → verify release job triggers, creates tag, publishes changelog
- [ ] Push to `deprecated/gatling-3-11` → verify release triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)