### PR TITLE
feat(metrics): support external start time for end-to-end latency

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeAction.scala
@@ -64,9 +64,10 @@ class KafkaConsumeAction(
       rn         <- requestName(session)
       topic      <- attributes.topic(session)
       expectedId <- attributes.expectedMatchId.map(_(session)).getOrElse(Success(KafkaConsumeAttributes.ConsumeAnyMatchId))
+      startTime  <- attributes.startTimestamp.map(_(session)).getOrElse(Success(clock.nowMillis))
     } yield throttler
-      .fold(trackAndAwait(rn, topic, expectedId, session))(
-        _.throttle(session.scenario, () => trackAndAwait(rn, topic, expectedId, session)),
+      .fold(trackAndAwait(rn, topic, expectedId, session, startTime))(
+        _.throttle(session.scenario, () => trackAndAwait(rn, topic, expectedId, session, startTime)),
       )
 
   private def trackAndAwait(
@@ -74,14 +75,14 @@ class KafkaConsumeAction(
       topic: String,
       expectedId: Array[Byte],
       session: Session,
+      startTime: Long,
   ): Unit = {
-    val now = clock.nowMillis
     KafkaConsumeAction.expectedMatchIdOrError(expectedId) match {
       case Right(matchId)     =>
         val tracker: KafkaMessageTracker = trackersPool.tracker(topic, topic, messageMatcher, None)
         tracker.track(
           matchId,
-          now,
+          startTime,
           components.kafkaProtocol.timeout.toMillis,
           attributes.checks,
           attributes.replyExtractions,
@@ -91,6 +92,7 @@ class KafkaConsumeAction(
           attributes.silent.getOrElse(false),
         )
       case Left(errorMessage) =>
+        val now = clock.nowMillis
         logger.error(errorMessage)
         if (!attributes.silent.getOrElse(false)) {
           statsEngine.logResponse(

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaConsumeActionBuilder.scala
@@ -85,6 +85,12 @@ case class KafkaConsumeActionBuilder(attributes: KafkaConsumeAttributes) extends
   def matchByKafkaMatcher(matcher: KafkaMatcher): KafkaConsumeActionBuilder =
     replyMatchBy(matcher.responseMatch)
 
+  def startTimeForTracking(startTime: Expression[Long]): KafkaConsumeActionBuilder =
+    this.modify(_.attributes.startTimestamp).setTo(Some(startTime))
+
+  def startTimeForTracking(sessionKey: String): KafkaConsumeActionBuilder =
+    startTimeForTracking(session => session(sessionKey).validate[Long])
+
   def saveAs(sessionKey: String)(extractor: KafkaProtocolMessage => Any): KafkaConsumeActionBuilder =
     this.modify(_.attributes.replyExtractions).using(_ :+ KafkaReplyExtraction(sessionKey, extractor))
 

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -86,11 +86,12 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
 
   override def sendRequest(session: Session): Validation[Unit] = {
     for {
-      rn  <- requestName(session)
-      msg <- resolveToProtocolMessage(session)
+      rn        <- requestName(session)
+      msg       <- resolveToProtocolMessage(session)
+      startTime <- attributes.startTimestamp.map(_(session)).getOrElse(Success(clock.nowMillis))
     } yield throttler
-      .fold(publishAndLogMessage(rn, msg, session))(
-        _.throttle(session.scenario, () => publishAndLogMessage(rn, msg, session)),
+      .fold(publishAndLogMessage(rn, msg, session, startTime))(
+        _.throttle(session.scenario, () => publishAndLogMessage(rn, msg, session, startTime)),
       )
 
   }
@@ -137,7 +138,12 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
         headers     <- optToVal(attributes.headers.map(_(s)))
       } yield KafkaProtocolMessage(key, value, inputTopic, outputTopic, headers)
 
-  private def publishAndLogMessage(requestNameString: String, msg: KafkaProtocolMessage, session: Session): Unit = {
+  private def publishAndLogMessage(
+      requestNameString: String,
+      msg: KafkaProtocolMessage,
+      session: Session,
+      startTime: Long,
+  ): Unit = {
     val now = clock.nowMillis
     KafkaRequestReplyAction.prepareTrackerOrError(msg, trackersPool, messageMatcher) match {
       case Right(preparedTracker) =>
@@ -149,7 +155,7 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
             preparedTracker.tracker
               .track(
                 preparedTracker.matchId,
-                clock.nowMillis,
+                startTime,
                 components.kafkaProtocol.timeout.toMillis,
                 attributes.checks,
                 attributes.replyExtractions,

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionBuilder.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.kafka.actions
 import com.softwaremill.quicklens.ModifyPimp
 import io.gatling.core.action.Action
 import io.gatling.core.action.builder.ActionBuilder
+import io.gatling.core.session.Expression
 import io.gatling.core.structure.ScenarioContext
 import org.galaxio.gatling.kafka.KafkaCheck
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.{KafkaMatcher, KafkaMessageMatcher}
@@ -40,6 +41,12 @@ case class KafkaRequestReplyActionBuilder[K: ClassTag, V: ClassTag](attributes: 
 
   def matchByKafkaMatcher(matcher: KafkaMatcher): KafkaRequestReplyActionBuilder[K, V] =
     requestMatchBy(matcher.requestMatch).replyMatchBy(matcher.responseMatch)
+
+  def startTimeForTracking(startTime: Expression[Long]): KafkaRequestReplyActionBuilder[K, V] =
+    this.modify(_.attributes.startTimestamp).setTo(Some(startTime))
+
+  def startTimeForTracking(sessionKey: String): KafkaRequestReplyActionBuilder[K, V] =
+    startTimeForTracking(session => session(sessionKey).validate[Long])
 
   def saveAs(sessionKey: String)(extractor: KafkaProtocolMessage => Any): KafkaRequestReplyActionBuilder[K, V] =
     this.modify(_.attributes.replyExtractions).using(_ :+ KafkaReplyExtraction(sessionKey, extractor))

--- a/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaConsumeAttributes.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaConsumeAttributes.scala
@@ -17,4 +17,5 @@ case class KafkaConsumeAttributes(
     consumeSettingsOverride: Option[Map[String, AnyRef]],
     responseMatchExtractor: Option[KafkaProtocolMessage => Array[Byte]],
     replyExtractions: List[KafkaReplyExtraction],
+    startTimestamp: Option[Expression[Long]] = None,
 )

--- a/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestReplyAttributes.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestReplyAttributes.scala
@@ -22,4 +22,5 @@ case class KafkaRequestReplyAttributes[K, V](
     requestMatchExtractor: Option[org.galaxio.gatling.kafka.request.KafkaProtocolMessage => Array[Byte]],
     responseMatchExtractor: Option[org.galaxio.gatling.kafka.request.KafkaProtocolMessage => Array[Byte]],
     replyExtractions: List[KafkaReplyExtraction],
+    startTimestamp: Option[Expression[Long]] = None,
 )


### PR DESCRIPTION
## Summary
- Add `startTimeForTracking` DSL method to `KafkaConsumeActionBuilder` and `KafkaRequestReplyActionBuilder`
- Accepts `Expression[Long]` or a session key string for ergonomic access
- When not set, behavior is unchanged (uses `clock.nowMillis`)

Closes #57

## Usage
```scala
.exec(session => session.set("e2eStart", System.currentTimeMillis()))
.exec(httpAction(...))
.exec(
  kafka("wait for result")
    .consumeFrom("output-topic")
    .headerForTracking("correlation-id", "#{correlationId}")
    .startTimeForTracking("e2eStart")
)
```

## Test plan
- [x] `sbt compile` passes
- [x] `sbt test` — all 37 tests pass, backward compatible (field defaults to `None`)
- [ ] Integration test with Docker Kafka verifying custom start time appears in stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)