### PR TITLE
fix: replace KafkaStreams with KafkaConsumer for reply tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,3 +426,40 @@ Example [scala](src/test/scala/org/galaxio/gatling/kafka/examples/AvroClassWithR
 Example [java](src/test/java/org/galaxio/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.java)
 
 Example [kotlin](src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.kt)
+
+## Migration Guide
+
+### Migrating to Consumer-based reply tracking (from KafkaStreams)
+
+Starting from this version, the plugin uses a plain `KafkaConsumer` instead of `KafkaStreams` for reply message consumption. This resolves compatibility issues with Confluent 7.9+ / Kafka 8.0 (`AbstractMethodError` in `SubscriptionInfoData`).
+
+#### Breaking changes
+
+1. **`consumeSettings` keys renamed**:
+
+| Before (Streams) | After (Consumer) |
+|---|---|
+| `application.id` | `group.id` |
+| `default.key.serde` | _(no longer needed, ignored)_ |
+| `default.value.serde` | _(no longer needed, ignored)_ |
+
+Example:
+```scala
+// Before
+.consumeSettings(Map(
+  "bootstrap.servers" -> "localhost:9092",
+  "application.id" -> "my-test-group",
+))
+
+// After
+.consumeSettings(Map(
+  "bootstrap.servers" -> "localhost:9092",
+  "group.id" -> "my-test-group",
+))
+```
+
+2. **`kafka-streams-scala` is now a `provided` dependency**. If your test code uses `WindowedSerdes.SessionWindowedSerde` from the plugin's implicits, add the dependency explicitly:
+
+```scala
+libraryDependencies += "org.apache.kafka" %% "kafka-streams-scala" % "7.9.5-ce" % Test
+```

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   lazy val kafka: Seq[ModuleID] = Seq(
     ("org.apache.kafka"  % "kafka-clients"       % Versions.kafka)
       .exclude("org.slf4j", "slf4j-api"),
-    ("org.apache.kafka" %% "kafka-streams-scala" % Versions.kafka)
+    ("org.apache.kafka" %% "kafka-streams-scala" % Versions.kafka % "provided")
       .exclude("org.slf4j", "slf4j-api"),
   )
 

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaChecks.scala
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaChecks.scala
@@ -13,9 +13,9 @@ import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.galaxio.gatling.kafka.{KafkaCheck, checks}
 import net.sf.saxon.s9api.XdmNode
 import com.fasterxml.jackson.databind.JsonNode
-import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde
+import io.confluent.kafka.serializers.{KafkaAvroDeserializer, KafkaAvroSerializer}
 import org.apache.avro.generic.GenericRecord
-import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer, Serdes => JSerdes}
 
 import java.{util => ju}
 import scala.jdk.CollectionConverters._
@@ -23,7 +23,10 @@ import scala.jdk.CollectionConverters._
 object KafkaChecks {
   class SimpleChecksScala extends KafkaCheckSupport {}
 
-  val avroSerde: Serde[GenericRecord] = new GenericAvroSerde()
+  val avroSerde: Serde[GenericRecord] = JSerdes.serdeFrom(
+    new KafkaAvroSerializer().asInstanceOf[Serializer[GenericRecord]],
+    new KafkaAvroDeserializer().asInstanceOf[Deserializer[GenericRecord]],
+  )
 
   private def toScalaCheck(javaCheckBuilder: io.gatling.javaapi.core.CheckBuilder): KafkaCheck = {
     val scalaCheck = javaCheckBuilder.asScala

--- a/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
@@ -57,7 +57,7 @@ object TrackersPool {
       consumerSettings: Map[String, AnyRef],
       trackerKey: TrackerCacheKey,
   ): Properties = {
-    val props             = new Properties()
+    val props       = new Properties()
     props.putAll(consumerSettings.asJava)
     val baseGroupId =
       consumerSettings.getOrElse(ConsumerConfig.GROUP_ID_CONFIG, "gatling-test").toString
@@ -93,11 +93,11 @@ class TrackersPool(
         val actor =
           system.actorOf(KafkaMessageTrackerActor.props(statsEngine, clock), genName("kafkaTrackerActor"))
 
-        val props = TrackersPool.consumerProperties(consumerSettings, trackerKey)
+        val props    = TrackersPool.consumerProperties(consumerSettings, trackerKey)
         val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](props)
         consumer.subscribe(Collections.singletonList(outputTopic))
 
-        val shutdown = new AtomicBoolean(false)
+        val shutdown   = new AtomicBoolean(false)
         val readyLatch = new CountDownLatch(1)
 
         val thread = new Thread(

--- a/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/TrackersPool.scala
@@ -4,20 +4,18 @@ import akka.actor.{ActorSystem, CoordinatedShutdown}
 import io.gatling.commons.util.Clock
 import io.gatling.core.stats.StatsEngine
 import io.gatling.core.util.NameGen
-import org.apache.kafka.streams.KafkaStreams
-import org.apache.kafka.streams.processor.api.{ContextualProcessor, Record}
-import org.apache.kafka.streams.StreamsConfig
-import org.apache.kafka.streams.scala.ImplicitConversions._
-import org.apache.kafka.streams.scala.StreamsBuilder
-import org.apache.kafka.streams.scala.serialization.Serdes._
+import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.galaxio.gatling.kafka.KafkaLogging
 import org.galaxio.gatling.kafka.client.KafkaMessageTrackerActor.MessageConsumed
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import java.nio.charset.StandardCharsets
-import java.util.{Properties, UUID}
+import java.time.Duration
+import java.util.{Collections, Properties, UUID}
 import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
 
@@ -30,29 +28,6 @@ object TrackersPool {
       messageMatcher: KafkaMatcher,
       responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
   )
-
-  private[client] def awaitRunning(
-      currentState: () => KafkaStreams.State,
-      registerListener: KafkaStreams.StateListener => Unit,
-      start: () => Unit,
-      timeoutMillis: Long,
-  ): Unit = {
-    if (currentState() == KafkaStreams.State.RUNNING) {
-      ()
-    } else {
-      val readyLatch = new CountDownLatch(1)
-      registerListener { (newState, _) =>
-        if (newState == KafkaStreams.State.RUNNING) {
-          readyLatch.countDown()
-        }
-      }
-      start()
-
-      if (currentState() != KafkaStreams.State.RUNNING && !readyLatch.await(timeoutMillis, TimeUnit.MILLISECONDS)) {
-        throw new IllegalStateException(s"Reply consumer did not reach RUNNING state within ${timeoutMillis} ms")
-      }
-    }
-  }
 
   private[client] def responseMatchIdOrError(
       message: KafkaProtocolMessage,
@@ -78,21 +53,27 @@ object TrackersPool {
     s"$baseApplicationId-$fingerprint"
   }
 
-  private[client] def trackerProperties(
-      streamsSettings: Map[String, AnyRef],
+  private[client] def consumerProperties(
+      consumerSettings: Map[String, AnyRef],
       trackerKey: TrackerCacheKey,
   ): Properties = {
     val props             = new Properties()
-    props.putAll(streamsSettings.asJava)
-    val baseApplicationId =
-      streamsSettings.getOrElse(StreamsConfig.APPLICATION_ID_CONFIG, "gatling-test").toString
-    props.put(StreamsConfig.APPLICATION_ID_CONFIG, trackerApplicationId(baseApplicationId, trackerKey))
+    props.putAll(consumerSettings.asJava)
+    val baseGroupId =
+      consumerSettings.getOrElse(ConsumerConfig.GROUP_ID_CONFIG, "gatling-test").toString
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, trackerApplicationId(baseGroupId, trackerKey))
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
+    if (!consumerSettings.contains(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)) {
+      props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")
+    }
     props
   }
 }
 
 class TrackersPool(
-    streamsSettings: Map[String, AnyRef],
+    consumerSettings: Map[String, AnyRef],
     system: ActorSystem,
     statsEngine: StatsEngine,
     clock: Clock,
@@ -112,61 +93,72 @@ class TrackersPool(
         val actor =
           system.actorOf(KafkaMessageTrackerActor.props(statsEngine, clock), genName("kafkaTrackerActor"))
 
-        val builder = new StreamsBuilder
+        val props = TrackersPool.consumerProperties(consumerSettings, trackerKey)
+        val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](props)
+        consumer.subscribe(Collections.singletonList(outputTopic))
 
-        builder
-          .stream[Array[Byte], Array[Byte]](outputTopic)
-          .process(() =>
-            new ContextualProcessor[Array[Byte], Array[Byte], Void, Void] {
-              override def process(record: Record[Array[Byte], Array[Byte]]): Unit = {
-                val message = TrackersPool.consumedMessage(
-                  record.key(),
-                  record.value(),
-                  inputTopic,
-                  outputTopic,
-                  record.headers(),
-                )
-                TrackersPool.responseMatchIdOrError(message, messageMatcher) match {
-                  case Left(_)        =>
-                    logger.error(s"no messageMatcher key for read message")
-                  case Right(replyId) =>
-                    val receivedTimestamp = clock.nowMillis
-                    if (logger.underlying.isDebugEnabled) {
-                      if (record.key() != null)
-                        logMessage(
-                          s"Record received key=${new String(record.key())}",
-                          message,
-                        )
-                      else
-                        logMessage(
-                          s"Record received key=null",
-                          message,
-                        )
-                    }
+        val shutdown = new AtomicBoolean(false)
+        val readyLatch = new CountDownLatch(1)
 
-                    actor ! MessageConsumed(
-                      replyId,
-                      receivedTimestamp,
-                      responseTransformer.map(_(message)).getOrElse(message),
-                    )
+        val thread = new Thread(
+          () => {
+            try {
+              while (!shutdown.get()) {
+                val records = consumer.poll(Duration.ofMillis(100))
+                readyLatch.countDown()
+                records.forEach { record =>
+                  val message = TrackersPool.consumedMessage(
+                    record.key(),
+                    record.value(),
+                    inputTopic,
+                    outputTopic,
+                    record.headers(),
+                  )
+                  TrackersPool.responseMatchIdOrError(message, messageMatcher) match {
+                    case Left(_)        =>
+                      logger.error(s"no messageMatcher key for read message")
+                    case Right(replyId) =>
+                      val receivedTimestamp = clock.nowMillis
+                      if (logger.underlying.isDebugEnabled) {
+                        if (record.key() != null)
+                          logMessage(
+                            s"Record received key=${new String(record.key())}",
+                            message,
+                          )
+                        else
+                          logMessage(
+                            s"Record received key=null",
+                            message,
+                          )
+                      }
+
+                      actor ! MessageConsumed(
+                        replyId,
+                        receivedTimestamp,
+                        responseTransformer.map(_(message)).getOrElse(message),
+                      )
+                  }
                 }
               }
-            },
-          )
-
-        val streams = new KafkaStreams(builder.build(), TrackersPool.trackerProperties(streamsSettings, trackerKey))
-
-        TrackersPool.awaitRunning(
-          () => streams.state(),
-          streams.setStateListener,
-          () => {
-            streams.cleanUp()
-            streams.start()
+            } finally {
+              consumer.close()
+            }
           },
-          TrackersPool.ConsumerStartupTimeout.toMillis,
+          s"kafka-tracker-${TrackersPool.trackerApplicationId("poll", trackerKey)}",
         )
+        thread.setDaemon(true)
+        thread.start()
 
-        CoordinatedShutdown(system).addJvmShutdownHook(streams.close())
+        if (!readyLatch.await(TrackersPool.ConsumerStartupTimeout.toMillis, TimeUnit.MILLISECONDS)) {
+          throw new IllegalStateException(
+            s"Reply consumer did not start within ${TrackersPool.ConsumerStartupTimeout.toMillis} ms",
+          )
+        }
+
+        CoordinatedShutdown(system).addJvmShutdownHook {
+          shutdown.set(true)
+          consumer.wakeup()
+        }
 
         new KafkaMessageTracker(actor)
       },

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNew.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNew.scala
@@ -49,7 +49,7 @@ case class KafkaProtocolBuilderNew(
     )
 
     val consumeDefaults = Map(
-      ConsumerConfig.GROUP_ID_CONFIG              -> s"gatling-test-${java.util.UUID.randomUUID()}",
+      ConsumerConfig.GROUP_ID_CONFIG                 -> s"gatling-test-${java.util.UUID.randomUUID()}",
       ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
       ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
     )

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNew.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderNew.scala
@@ -1,9 +1,9 @@
 package org.galaxio.gatling.kafka.protocol
 
 import io.gatling.core.session.Expression
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
-import org.apache.kafka.common.serialization.Serdes
-import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol._
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
@@ -49,9 +49,9 @@ case class KafkaProtocolBuilderNew(
     )
 
     val consumeDefaults = Map(
-      StreamsConfig.APPLICATION_ID_CONFIG            -> s"gatling-test-${java.util.UUID.randomUUID()}",
-      StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG   -> Serdes.ByteArray().getClass.getName,
-      StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG -> Serdes.ByteArray().getClass.getName,
+      ConsumerConfig.GROUP_ID_CONFIG              -> s"gatling-test-${java.util.UUID.randomUUID()}",
+      ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+      ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
     )
 
     KafkaProtocol("test", producerSettings ++ serializers, consumeDefaults ++ consumeSettings, timeout, messageMatcher)

--- a/src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala
@@ -2,7 +2,6 @@ package org.galaxio.gatling.kafka.request
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import io.confluent.kafka.serializers.{KafkaAvroDeserializer, KafkaAvroSerializer}
-import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer, Serdes => JSerdes}
 import org.apache.kafka.streams.kstream.WindowedSerdes
@@ -42,6 +41,9 @@ trait KafkaSerdesImplicits {
     ).asInstanceOf[Deserializer[T]]
   }
 
-  implicit val avroSerde: Serde[GenericRecord] = new GenericAvroSerde()
+  implicit val avroSerde: Serde[GenericRecord] = JSerdes.serdeFrom(
+    new KafkaAvroSerializer().asInstanceOf[Serializer[GenericRecord]],
+    new KafkaAvroDeserializer().asInstanceOf[Deserializer[GenericRecord]],
+  )
 
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/TrackersPoolSpec.scala
@@ -1,13 +1,10 @@
 package org.galaxio.gatling.kafka.client
 
-import org.apache.kafka.streams.KafkaStreams
-import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.scalatest.funsuite.AnyFunSuite
-
-import java.util.concurrent.atomic.AtomicReference
 
 class TrackersPoolSpec extends AnyFunSuite {
 
@@ -40,41 +37,6 @@ class TrackersPoolSpec extends AnyFunSuite {
     assert(result == Left("response matcher returned null match id"))
   }
 
-  test("awaitRunning starts the consumer and waits for RUNNING state") {
-    val currentState = new AtomicReference(KafkaStreams.State.CREATED)
-    val started      = new AtomicReference(false)
-    val listenerRef  = new AtomicReference[KafkaStreams.StateListener]()
-
-    TrackersPool.awaitRunning(
-      () => currentState.get(),
-      listener => listenerRef.set(listener),
-      () => {
-        started.set(true)
-        currentState.set(KafkaStreams.State.RUNNING)
-        Option(listenerRef.get()).foreach(_.onChange(KafkaStreams.State.RUNNING, KafkaStreams.State.REBALANCING))
-      },
-      timeoutMillis = 100,
-    )
-
-    assert(started.get())
-    assert(listenerRef.get() != null)
-  }
-
-  test("awaitRunning fails when the consumer never reaches RUNNING") {
-    val currentState = new AtomicReference(KafkaStreams.State.CREATED)
-
-    val error = intercept[IllegalStateException] {
-      TrackersPool.awaitRunning(
-        () => currentState.get(),
-        _ => (),
-        () => currentState.set(KafkaStreams.State.REBALANCING),
-        timeoutMillis = 10,
-      )
-    }
-
-    assert(error.getMessage.contains("did not reach RUNNING state"))
-  }
-
   test("tracker cache key isolates same topic across different matchers") {
     val requestMatcher  = new KafkaProtocol.KafkaMatcher {
       override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
@@ -91,7 +53,7 @@ class TrackersPoolSpec extends AnyFunSuite {
     assert(left != right)
   }
 
-  test("trackerProperties derives a unique application id per tracker key") {
+  test("consumerProperties derives a unique group id per tracker key") {
     val firstMatcher  = new KafkaProtocol.KafkaMatcher {
       override def requestMatch(msg: KafkaProtocolMessage): Array[Byte]  = msg.key
       override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.key
@@ -101,21 +63,21 @@ class TrackersPoolSpec extends AnyFunSuite {
       override def responseMatch(msg: KafkaProtocolMessage): Array[Byte] = msg.value
     }
 
-    val baseSettings = Map[String, AnyRef](StreamsConfig.APPLICATION_ID_CONFIG -> "gatling-test-base")
-    val firstProps   = TrackersPool.trackerProperties(
+    val baseSettings = Map[String, AnyRef](ConsumerConfig.GROUP_ID_CONFIG -> "gatling-test-base")
+    val firstProps   = TrackersPool.consumerProperties(
       baseSettings,
       TrackersPool.TrackerCacheKey("requests", "replies", firstMatcher, None),
     )
-    val secondProps  = TrackersPool.trackerProperties(
+    val secondProps  = TrackersPool.consumerProperties(
       baseSettings,
       TrackersPool.TrackerCacheKey("requests", "replies", secondMatcher, None),
     )
 
-    assert(firstProps.getProperty(StreamsConfig.APPLICATION_ID_CONFIG).startsWith("gatling-test-base-"))
-    assert(secondProps.getProperty(StreamsConfig.APPLICATION_ID_CONFIG).startsWith("gatling-test-base-"))
+    assert(firstProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG).startsWith("gatling-test-base-"))
+    assert(secondProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG).startsWith("gatling-test-base-"))
     assert(
-      firstProps.getProperty(StreamsConfig.APPLICATION_ID_CONFIG) != secondProps.getProperty(
-        StreamsConfig.APPLICATION_ID_CONFIG,
+      firstProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG) != secondProps.getProperty(
+        ConsumerConfig.GROUP_ID_CONFIG,
       ),
     )
   }


### PR DESCRIPTION
## Summary

- Replace `KafkaStreams` topology with plain `KafkaConsumer` polling thread in `TrackersPool`
- Resolves `AbstractMethodError` in `SubscriptionInfoData` with Confluent 7.9+ / Kafka 8.0
- Move `kafka-streams-scala` to `provided` scope (keeps `WindowedSerdes` available for users who add it explicitly)
- Replace `GenericAvroSerde` with direct `KafkaAvroSerializer`/`KafkaAvroDeserializer` usage

Closes #33

## Breaking changes

- `consumeSettings` key `application.id` → `group.id`
- `default.key.serde` / `default.value.serde` no longer needed
- Users of `WindowedSerdes.SessionWindowedSerde` must add `kafka-streams-scala` dependency explicitly

## Test plan

- [x] `sbt compile` — passes
- [x] `sbt test` — 35 tests pass
- [ ] Integration tests with Testcontainers (need Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)