### PR TITLE
build: set explicit Java 17 release target

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,9 @@ lazy val root = (project in file("."))
     Gatling / publishArtifact   := false,
     GatlingIt / publishArtifact := false,
     Test / testFrameworks += new TestFramework("org.scalatest.tools.Framework"),
+    javacOptions ++= Seq("--release", "11"),
     scalacOptions ++= Seq(
+      "-release", "11",
       "-encoding",
       "UTF-8",            // Option and arguments on same line
       "-Xfatal-warnings", // New lines for each options

--- a/build.sbt
+++ b/build.sbt
@@ -23,10 +23,10 @@ lazy val root = (project in file("."))
     Gatling / publishArtifact   := false,
     GatlingIt / publishArtifact := false,
     Test / testFrameworks += new TestFramework("org.scalatest.tools.Framework"),
-    javacOptions ++= Seq("--release", "11"),
+    javacOptions ++= Seq("--release", "17"),
     scalacOptions ++= Seq(
       "-release",
-      "11",
+      "17",
       "-encoding",
       "UTF-8",            // Option and arguments on same line
       "-Xfatal-warnings", // New lines for each options

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ lazy val root = (project in file("."))
     Test / testFrameworks += new TestFramework("org.scalatest.tools.Framework"),
     javacOptions ++= Seq("--release", "11"),
     scalacOptions ++= Seq(
-      "-release", "11",
+      "-release",
+      "11",
       "-encoding",
       "UTF-8",            // Option and arguments on same line
       "-Xfatal-warnings", // New lines for each options


### PR DESCRIPTION
## Summary
- Adds `--release 17` to `javacOptions` and `scalacOptions` in build.sbt
- Guarantees Java 17 as the minimum supported runtime (required by Gatling 3.11)

Closes #42

## Test plan
- [x] `sbt compile` passes
- [x] `sbt Test/compile` passes (text blocks in Java test sources require Java 17+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)