### PR TITLE
fix: clarify kafka send failure reporting on backport/v0.20.4-headers

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAvro4sRequestAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAvro4sRequestAction.scala
@@ -55,12 +55,17 @@ class KafkaAvro4sRequestAction[K, V](
   private def reportUnbuildableRequest(session: Session, error: String): Unit = {
     val loggedName = attr.requestName(session) match {
       case Success(requestNameValue) =>
-        statsEngine.logRequestCrash(session.scenario, session.groups, requestNameValue, s"Failed to build request: $error")
+        statsEngine.logRequestCrash(
+          session.scenario,
+          session.groups,
+          requestNameValue,
+          KafkaRequestFailureMessages.buildFailure(error),
+        )
         requestNameValue
       case _                         =>
         name
     }
-    logger.error(s"'$loggedName' failed to execute: $error")
+    logger.error(s"'$loggedName' failed to execute: ${KafkaRequestFailureMessages.buildFailure(error)}")
   }
 
   private def resolveProducerRecord: Expression[ProducerRecord[K, GenericRecord]] = s =>
@@ -106,8 +111,9 @@ class KafkaAvro4sRequestAction[K, V](
 
         case util.Failure(exception) =>
           val requestEndDate = clock.nowMillis
+          val errorMessage   = KafkaRequestFailureMessages.sendFailure(exception.getMessage)
 
-          logger.error(exception.getMessage, exception)
+          logger.error(errorMessage, exception)
 
           statsEngine.logResponse(
             session.scenario,
@@ -117,7 +123,7 @@ class KafkaAvro4sRequestAction[K, V](
             endTimestamp = requestEndDate,
             KO,
             None,
-            Some(exception.getMessage),
+            Some(errorMessage),
           )
           next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
       }(components.sender.executionContext)

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
@@ -54,11 +54,16 @@ class KafkaRequestAction[K, V](
   private def reportUnbuildableRequest(session: Session, error: String): Unit = {
     val loggedName = attr.requestName(session) match {
       case Success(requestNameValue) =>
-        statsEngine.logRequestCrash(session.scenario, session.groups, requestNameValue, s"Failed to build request: $error")
+        statsEngine.logRequestCrash(
+          session.scenario,
+          session.groups,
+          requestNameValue,
+          KafkaRequestFailureMessages.buildFailure(error),
+        )
         requestNameValue
       case _                         => name
     }
-    logger.error(s"'$loggedName' failed to execute: $error")
+    logger.error(s"'$loggedName' failed to execute: ${KafkaRequestFailureMessages.buildFailure(error)}")
   }
 
   private def stringExpressionResolve[T](ek: Expression[T]): Expression[T] = s =>
@@ -111,8 +116,9 @@ class KafkaRequestAction[K, V](
 
         case util.Failure(exception) =>
           val requestEndDate = clock.nowMillis
+          val errorMessage   = KafkaRequestFailureMessages.sendFailure(exception.getMessage)
 
-          logger.error(exception.getMessage, exception)
+          logger.error(errorMessage, exception)
 
           statsEngine.logResponse(
             session.scenario,
@@ -122,7 +128,7 @@ class KafkaRequestAction[K, V](
             endTimestamp = requestEndDate,
             KO,
             None,
-            Some(exception.getMessage),
+            Some(errorMessage),
           )
           next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
       }(components.sender.executionContext)

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessages.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessages.scala
@@ -1,0 +1,9 @@
+package org.galaxio.gatling.kafka.actions
+
+private[actions] object KafkaRequestFailureMessages {
+  def buildFailure(error: String): String =
+    s"Failed to build request: $error"
+
+  def sendFailure(error: String): String =
+    s"Failed to send request to Kafka broker: $error"
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -62,7 +62,7 @@ class KafkaMessageTracker[K, V](name: String, statsEngine: StatsEngine, clock: C
 
   override def init(): Behavior[TrackerMessage] = {
     // message was sent; add the timestamps to the map
-    case messageSent: MessagePublished    =>
+    case messageSent: MessagePublished =>
       val key = makeKeyForSentMessages(messageSent.matchId)
       logger.debug("Published with MatchId: {} Tracking Key: {}", new String(messageSent.matchId), key)
       sentMessages += key -> messageSent

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala
@@ -1,0 +1,25 @@
+package org.galaxio.gatling.kafka.actions
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class KafkaRequestFailureMessagesSpec extends AnyFunSuite {
+
+  test("build failures keep request construction wording") {
+    val message = KafkaRequestFailureMessages.buildFailure("payload expression crashed")
+
+    assert(message == "Failed to build request: payload expression crashed")
+  }
+
+  test("send failures use broker send wording") {
+    val message = KafkaRequestFailureMessages.sendFailure("timeout")
+
+    assert(message == "Failed to send request to Kafka broker: timeout")
+  }
+
+  test("build and send failures remain distinguishable") {
+    val buildMessage = KafkaRequestFailureMessages.buildFailure("boom")
+    val sendMessage  = KafkaRequestFailureMessages.sendFailure("boom")
+
+    assert(buildMessage != sendMessage)
+  }
+}


### PR DESCRIPTION
## Summary
- distinguish request-build failures from broker send failures with explicit messages shared by both request actions
- keep build failures on `logRequestCrash` while prefixing async send failures in `logResponse(KO)` and error logs
- add regression coverage for the message split and include the branch-required scalafmt fix in `KafkaMessageTracker.scala`

## Testing
- `sbt --batch scalafmtAll scalafmtCheckAll`
- `sbt --batch "Test / compile"` *(fails on pre-existing branch compile errors unrelated to this patch, including missing `io.gatling.core.actor` APIs and `consumeProperties`/`trackersPoolFactory` mismatches on `backport/v0.20.4-headers`)*

Closes #95