### PR TITLE
Improve logging for binary Kafka payloads and explicit charset handling

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -11,7 +11,7 @@ import io.gatling.core.session.{Expression, Session}
 import io.gatling.core.stats.StatsEngine
 import io.gatling.core.util.NameGen
 import org.apache.kafka.common.serialization.Serializer
-import org.galaxio.gatling.kafka.KafkaLogging
+import org.galaxio.gatling.kafka.{KafkaLogFormatter, KafkaLogging}
 import org.galaxio.gatling.kafka.client.KafkaMessageTracker
 import org.galaxio.gatling.kafka.protocol.KafkaComponents
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
@@ -87,7 +87,10 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
     components.sender.send(msg)(
       rm => {
         if (logger.underlying.isDebugEnabled) {
-          logMessage(s"Record sent user=${session.userId} key=${new String(msg.key)} topic=${rm.topic()}", msg)
+          logMessage(
+            s"Record sent user=${session.userId} key=${KafkaLogFormatter.summarizeIdentifier(msg.key)} topic=${rm.topic()}",
+            msg,
+          )
         }
         val id      = components.kafkaProtocol.messageMatcher.requestMatch(msg)
         val tracker =

--- a/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala
@@ -8,21 +8,25 @@ import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.json.JsonParsers
 import net.sf.saxon.s9api.XdmNode
 import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.serialization.Serde
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import java.io.ByteArrayInputStream
-import java.nio.charset.Charset
+import java.nio.charset.{Charset, StandardCharsets}
 import scala.util.Try
 
 trait KafkaMessagePreparer[P] extends Preparer[KafkaProtocolMessage, P]
 
 object KafkaMessagePreparer {
 
+  private[kafka] def contentEncodingCharset(headers: Headers): Option[Validation[Charset]] =
+    Option(headers.lastHeader("content_encoding"))
+      .map(header => Try(Charset.forName(new String(header.value(), StandardCharsets.UTF_8))).toValidation)
+
   private def messageCharset(cfg: GatlingConfiguration, msg: KafkaProtocolMessage): Validation[Charset] =
     msg.headers
-      .flatMap(h => Option(h.lastHeader("content_encoding")))
-      .map(header => Try(Charset.forName(new String(header.value()))).toValidation)
+      .flatMap(contentEncodingCharset)
       .getOrElse(cfg.core.charset.success)
 
   def stringBodyPreparer(configuration: GatlingConfiguration): KafkaMessagePreparer[String] =

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -8,7 +8,7 @@ import io.gatling.core.actor.{Actor, Behavior}
 import io.gatling.core.check.Check
 import io.gatling.core.session.Session
 import io.gatling.core.stats.StatsEngine
-import org.galaxio.gatling.kafka.KafkaCheck
+import org.galaxio.gatling.kafka.{KafkaCheck, KafkaLogFormatter}
 import org.galaxio.gatling.kafka.client.KafkaMessageTracker._
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
@@ -62,9 +62,13 @@ class KafkaMessageTracker[K, V](name: String, statsEngine: StatsEngine, clock: C
 
   override def init(): Behavior[TrackerMessage] = {
     // message was sent; add the timestamps to the map
-    case messageSent: MessagePublished    =>
+    case messageSent: MessagePublished =>
       val key = makeKeyForSentMessages(messageSent.matchId)
-      logger.debug("Published with MatchId: {} Tracking Key: {}", new String(messageSent.matchId), key)
+      logger.debug(
+        "Published with MatchId: {} Tracking Key: {}",
+        KafkaLogFormatter.summarizeIdentifier(messageSent.matchId),
+        key,
+      )
       sentMessages += key -> messageSent
       if (messageSent.replyTimeout > 0) {
         triggerPeriodicTimeoutScan()
@@ -78,7 +82,7 @@ class KafkaMessageTracker[K, V](name: String, statsEngine: StatsEngine, clock: C
       val message           = messageConsumed.message
       // if key is missing, message was already acked and is a dup, or request timeout
       val key               = makeKeyForSentMessages(replyId)
-      logger.debug("Received with MatchId: {} Tracking Key: {}", new String(replyId), key)
+      logger.debug("Received with MatchId: {} Tracking Key: {}", KafkaLogFormatter.summarizeIdentifier(replyId), key)
       sentMessages.remove(key).foreach { case MessagePublished(_, sentTimestamp, _, checks, session, next, requestName) =>
         processMessage(session, sentTimestamp, receivedTimestamp, checks, message, next, requestName)
       }
@@ -94,7 +98,12 @@ class KafkaMessageTracker[K, V](name: String, statsEngine: StatsEngine, clock: C
       }
       for (MessagePublished(matchId, sentTimestamp, receivedTimeout, _, session, next, requestName) <- timedOutMessages) {
         val matchKey = makeKeyForSentMessages(matchId)
-        logger.warn("Did not receive match for {} - key: {} after {}ms", new String(matchId), matchKey, receivedTimeout)
+        logger.warn(
+          "Did not receive match for {} - key: {} after {}ms",
+          KafkaLogFormatter.summarizeIdentifier(matchId),
+          matchKey,
+          receivedTimeout,
+        )
         sentMessages.remove(matchKey)
         executeNext(
           session.markAsFailed,

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -9,7 +9,7 @@ import org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG
 import org.apache.kafka.streams.processor.api
 import org.apache.kafka.streams.processor.api.{Processor, ProcessorSupplier}
 import org.apache.kafka.streams.scala.StreamsBuilder
-import org.galaxio.gatling.kafka.KafkaLogging
+import org.galaxio.gatling.kafka.{KafkaLogFormatter, KafkaLogging}
 import org.galaxio.gatling.kafka.client.KafkaMessageTracker.{TrackerMessage, MessageConsumed}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.{KafkaProtocolMessage, KafkaSerdesImplicits}
@@ -49,7 +49,7 @@ object KafkaMessageTrackerPool {
           }
           val receivedTimestamp = clock.nowMillis
           val replyId           = messageMatcher.responseMatch(message)
-          val messageKey        = if (key == null) "null" else new String(key)
+          val messageKey        = KafkaLogFormatter.summarizeIdentifier(key)
           logMessage(s"Record received key=$messageKey", message)
 
           tracker ! MessageConsumed(

--- a/src/main/scala/org/galaxio/gatling/kafka/package.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/package.scala
@@ -4,13 +4,36 @@ import com.typesafe.scalalogging.StrictLogging
 import io.gatling.core.check.Check
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
+import java.util.Base64
+
 package object kafka {
   type KafkaCheck = Check[KafkaProtocolMessage]
+
+  object KafkaLogFormatter {
+    private val PreviewBytes = 16
+
+    def summarizeIdentifier(bytes: Array[Byte]): String =
+      Option(bytes).map { value =>
+        s"base64=${Base64.getEncoder.encodeToString(value)} bytes=${value.length}"
+      }
+        .getOrElse("null")
+
+    def summarizePayload(bytes: Array[Byte]): String =
+      Option(bytes).map { value =>
+        val preview = Base64.getEncoder.encodeToString(value.take(PreviewBytes))
+        val suffix  = if (value.length > PreviewBytes) "..." else ""
+        s"bytes=${value.length} previewBase64=${preview}${suffix}"
+      }
+        .getOrElse("null")
+
+    def summarizeMessage(msg: KafkaProtocolMessage): String =
+      s"KafkaProtocolMessage(inputTopic=${msg.inputTopic}, outputTopic=${msg.outputTopic}, key=${summarizeIdentifier(msg.key)}, value=${summarizePayload(msg.value)}, headers=${msg.headers.fold(0)(_.toArray.length)}, responseCode=${msg.responseCode.getOrElse("none")})"
+  }
 
   trait KafkaLogging extends StrictLogging {
     def logMessage(text: => String, msg: KafkaProtocolMessage): Unit = {
       logger.debug(text)
-      logger.trace(msg.toString)
+      logger.trace(KafkaLogFormatter.summarizeMessage(msg))
     }
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/KafkaLogFormatterSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/KafkaLogFormatterSpec.scala
@@ -1,0 +1,56 @@
+package org.galaxio.gatling.kafka
+
+import io.gatling.commons.validation.Success
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.galaxio.gatling.kafka.checks.KafkaMessagePreparer
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.charset.StandardCharsets
+
+class KafkaLogFormatterSpec extends AnyFunSuite {
+
+  test("summarizeIdentifier renders deterministic base64 metadata") {
+    val bytes = "key".getBytes(StandardCharsets.UTF_8)
+
+    val summary = KafkaLogFormatter.summarizeIdentifier(bytes)
+
+    assert(summary == "base64=a2V5 bytes=3")
+  }
+
+  test("summarizePayload avoids raw binary strings and truncates preview") {
+    val bytes = Array.tabulate[Byte](32)(_.toByte)
+
+    val summary = KafkaLogFormatter.summarizePayload(bytes)
+
+    assert(summary.startsWith("bytes=32 previewBase64="))
+    assert(summary.endsWith("..."))
+  }
+
+  test("summarizeMessage reports metadata instead of full raw payloads") {
+    val headers = new RecordHeaders().add("trace-id", "123".getBytes(StandardCharsets.UTF_8))
+    val message = KafkaProtocolMessage(
+      key = "request-key".getBytes(StandardCharsets.UTF_8),
+      value = Array[Byte](1, 2, 3, 4),
+      inputTopic = "requests",
+      outputTopic = "replies",
+      headers = Some(headers),
+    )
+
+    val summary = KafkaLogFormatter.summarizeMessage(message)
+
+    assert(summary.contains("inputTopic=requests"))
+    assert(summary.contains("outputTopic=replies"))
+    assert(summary.contains("key=base64=cmVxdWVzdC1rZXk= bytes=11"))
+    assert(summary.contains("value=bytes=4 previewBase64=AQIDBA=="))
+    assert(summary.contains("headers=1"))
+  }
+
+  test("contentEncodingCharset decodes charset names with utf-8") {
+    val headers = new RecordHeaders().add("content_encoding", "UTF-16LE".getBytes(StandardCharsets.UTF_8))
+
+    val charset = KafkaMessagePreparer.contentEncodingCharset(headers)
+
+    assert(charset.contains(Success(StandardCharsets.UTF_16LE)))
+  }
+}


### PR DESCRIPTION
## Summary
- replace implicit byte-to-string logging with deterministic base64 summaries for keys and match ids
- trace Kafka protocol messages with metadata and truncated payload previews instead of raw byte arrays
- decode `content_encoding` header values with explicit UTF-8 and cover the new helpers with focused tests

## Verification
- `sbt --batch scalafmtAll scalafmtCheckAll`
- `sbt --batch "Test / compile"` *(fails on the base branch before and after this change due to pre-existing compile errors in untouched files such as `KafkaAvro4sRequestAction`, `KafkaRequestAction`, and `KafkaMessageTrackerPool`)*

Closes #94