### PR TITLE
docs: clarify Gatling 3.11.5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Kafka protocol plugin for [Gatling](https://gatling.io/) load testing framework.
 | `main` | 3.13.5 | 2.13.16 | 17+ |
 | 0.22.x | 3.13.x | 2.13 | 17+ |
 | 0.21.x | 3.12.x | 2.13 | 17+ |
-| 0.14.2 | 3.11.5 | 2.13 | 17+ |
+| 0.20.5 | 3.11.5 | 2.13 | 17+ |
 
-> **Version guidance:** if you are on Gatling `3.11.5`, use plugin `0.14.2`. Do not use `0.22.x` on Gatling `3.11.5`; the `0.22.x` line on `main` targets Gatling `3.13.x`.
+> **Version guidance:** if you are on Gatling `3.11.5`, use plugin `0.20.5`. Do not use `0.22.x` on Gatling `3.11.5`; the `0.22.x` line on `main` targets Gatling `3.13.x`.
 >
-> Header support is available on the Gatling `3.11.5` line in `0.14.2`, and on newer lines such as `0.22.x` for Gatling `3.13.x`.
+> Header support is available on the Gatling `3.11.5` line in `0.20.5`, and on newer lines such as `0.22.x` for Gatling `3.13.x`.
 >
 > **Branch strategy:** `main` is the active development branch and current release line. Short-lived topic branches are cut from `main`, and `backport/*` branches are only created when a released line needs a targeted follow-up fix.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ Kafka protocol plugin for [Gatling](https://gatling.io/) load testing framework.
 | Branch / Line | Gatling | Scala | Java |
 |---|---|---|---|
 | `main` | 3.13.5 | 2.13.16 | 17+ |
+| 0.22.x | 3.13.x | 2.13 | 17+ |
+| 0.21.x | 3.12.x | 2.13 | 17+ |
+| 0.14.2 | 3.11.5 | 2.13 | 17+ |
 
+> **Version guidance:** if you are on Gatling `3.11.5`, use plugin `0.14.2`. Do not use `0.22.x` on Gatling `3.11.5`; the `0.22.x` line on `main` targets Gatling `3.13.x`.
+>
+> Header support is available on the Gatling `3.11.5` line in `0.14.2`, and on newer lines such as `0.22.x` for Gatling `3.13.x`.
+>
 > **Branch strategy:** `main` is the active development branch and current release line. Short-lived topic branches are cut from `main`, and `backport/*` branches are only created when a released line needs a targeted follow-up fix.
 
 ## Installation


### PR DESCRIPTION
## Summary
- clarify the README compatibility table with explicit plugin-to-Gatling version mappings
- document that Gatling 3.11.5 should use plugin 0.14.2
- state that 0.22.x targets Gatling 3.13.x while header support is available on both the 0.14.2 and 0.22.x lines

Closes #100