### PR TITLE
fix: differentiate kafka send failures on main

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ val avroSchemas = Seq() // for example Seq(RegistrySubject("test-hello-schema", 
 lazy val root = (project in file("."))
   .enablePlugins(GitVersioning, GatlingPlugin)
   .settings(
-    name                        := "gatling-kafka-plugin",
-    scalaVersion                := scalaV,
+    name                                   := "gatling-kafka-plugin",
+    scalaVersion                           := scalaV,
     libraryDependencies ++= gatling,
     libraryDependencies ++= gatlingTest,
     libraryDependencies ++= kafka,
@@ -20,8 +20,8 @@ lazy val root = (project in file("."))
       "Confluent" at "https://packages.confluent.io/maven/",
     ),
     // Do not publish artifacts for Gatling-configured scopes (this is a library)
-    Gatling / publishArtifact   := false,
-    GatlingIt / publishArtifact := false,
+    Gatling / publishArtifact              := false,
+    GatlingIt / publishArtifact            := false,
     scalacOptions ++= Seq(
       "-encoding",
       "UTF-8",            // Option and arguments on same line

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= gatlingTest,
     libraryDependencies ++= kafka,
     libraryDependencies ++= Seq(avro4s, avroCore, avroSerdes, avroSerializers),
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     schemaRegistrySubjects ++= avroSchemas,
 //    schemaRegistryUrl := "http://test-schema-registry:8081",
     resolvers ++= Seq(

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
@@ -28,13 +28,14 @@ final class KafkaRequestAction[K: ClassTag, V: ClassTag](
   val clock: Clock             = coreComponents.clock
 
   private def reportUnbuildableRequest(session: Session, error: String): Unit = {
-    val loggedName = attributes.requestName(session) match {
+    val errorMessage = KafkaRequestFailureMessages.buildFailure(error)
+    val loggedName   = attributes.requestName(session) match {
       case Success(requestNameValue) =>
-        statsEngine.logRequestCrash(session.scenario, session.groups, requestNameValue, s"Failed to build request: $error")
+        statsEngine.logRequestCrash(session.scenario, session.groups, requestNameValue, errorMessage)
         requestNameValue
       case _                         => name
     }
-    logger.error(s"'$loggedName' failed to execute: $error")
+    logger.error(s"'$loggedName' failed to execute: $errorMessage")
   }
 
   override def sendKafkaMessage(requestNameString: String, protocolMessage: KafkaProtocolMessage, session: Session): Unit = {
@@ -61,9 +62,9 @@ final class KafkaRequestAction[K: ClassTag, V: ClassTag](
       },
       exception => {
         val requestEndDate = clock.nowMillis
+        val errorMessage   = KafkaRequestFailureMessages.sendFailure(exception.getMessage)
 
-        logger.error(exception.getMessage, exception)
-        reportUnbuildableRequest(session, exception.getMessage)
+        logger.error(errorMessage, exception)
 
         statsEngine.logResponse(
           session.scenario,
@@ -73,7 +74,7 @@ final class KafkaRequestAction[K: ClassTag, V: ClassTag](
           endTimestamp = requestEndDate,
           KO,
           None,
-          Some(exception.getMessage),
+          Some(errorMessage),
         )
         next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
       },

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
@@ -62,7 +62,7 @@ final class KafkaRequestAction[K: ClassTag, V: ClassTag](
       },
       exception => {
         val requestEndDate = clock.nowMillis
-        val errorMessage   = KafkaRequestFailureMessages.sendFailure(exception.getMessage)
+        val errorMessage   = KafkaRequestFailureMessages.sendFailure(exception)
 
         logger.error(errorMessage, exception)
 

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessages.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessages.scala
@@ -1,0 +1,9 @@
+package org.galaxio.gatling.kafka.actions
+
+private[actions] object KafkaRequestFailureMessages {
+  def buildFailure(error: String): String =
+    s"Failed to build request: $error"
+
+  def sendFailure(error: String): String =
+    s"Failed to send request to Kafka broker: $error"
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessages.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessages.scala
@@ -2,8 +2,11 @@ package org.galaxio.gatling.kafka.actions
 
 private[actions] object KafkaRequestFailureMessages {
   def buildFailure(error: String): String =
-    s"Failed to build request: $error"
+    s"Failed to build request: ${Option(error).getOrElse("unknown error")}"
 
   def sendFailure(error: String): String =
-    s"Failed to send request to Kafka broker: $error"
+    s"Failed to send request to Kafka broker: ${Option(error).getOrElse("unknown error")}"
+
+  def sendFailure(exception: Throwable): String =
+    sendFailure(Option(exception.getMessage).getOrElse(exception.getClass.getSimpleName))
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala
@@ -1,0 +1,25 @@
+package org.galaxio.gatling.kafka.actions
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class KafkaRequestFailureMessagesSpec extends AnyFunSuite {
+
+  test("build failures keep request construction wording") {
+    val message = KafkaRequestFailureMessages.buildFailure("payload expression crashed")
+
+    assert(message == "Failed to build request: payload expression crashed")
+  }
+
+  test("send failures use broker send wording") {
+    val message = KafkaRequestFailureMessages.sendFailure("timeout")
+
+    assert(message == "Failed to send request to Kafka broker: timeout")
+  }
+
+  test("build and send failures remain distinguishable") {
+    val buildMessage = KafkaRequestFailureMessages.buildFailure("boom")
+    val sendMessage  = KafkaRequestFailureMessages.sendFailure("boom")
+
+    assert(buildMessage != sendMessage)
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala
@@ -22,4 +22,32 @@ class KafkaRequestFailureMessagesSpec extends AnyFunSuite {
 
     assert(buildMessage != sendMessage)
   }
+
+  test("sendFailure with null error string falls back to unknown error") {
+    val message = KafkaRequestFailureMessages.sendFailure(null: String)
+
+    assert(message == "Failed to send request to Kafka broker: unknown error")
+  }
+
+  test("buildFailure with null error string falls back to unknown error") {
+    val message = KafkaRequestFailureMessages.buildFailure(null)
+
+    assert(message == "Failed to build request: unknown error")
+  }
+
+  test("sendFailure with exception whose getMessage returns null uses class name") {
+    val exception = new RuntimeException(null: String)
+
+    val message = KafkaRequestFailureMessages.sendFailure(exception)
+
+    assert(message == "Failed to send request to Kafka broker: RuntimeException")
+  }
+
+  test("sendFailure with exception uses exception message when present") {
+    val exception = new RuntimeException("broker unavailable")
+
+    val message = KafkaRequestFailureMessages.sendFailure(exception)
+
+    assert(message == "Failed to send request to Kafka broker: broker unavailable")
+  }
 }


### PR DESCRIPTION
## Summary
- separate request-build failure wording from async Kafka broker send failures in `KafkaRequestAction`
- keep build failures on `logRequestCrash` while reporting broker send failures through KO response messages and logs
- add focused regression coverage for the two failure-message paths

## Verification
- `sbt --batch "Test / compile"`
- `sbt --batch "testOnly org.galaxio.gatling.kafka.actions.KafkaRequestFailureMessagesSpec"`
- `sbt --batch scalafmtAll scalafmtCheckAll`

Closes #95