### PR TITLE
fix(examples): clean up warning and smoke-check examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Compile
         run: sbt clean compile
 
+      - name: Smoke test examples
+        run: sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"
+
       - name: Test (Gatling targeted)
         run: sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,12 @@ The plugin uses `KafkaConsumer` instead of `KafkaStreams` for reply tracking.
 - [Java examples](src/test/java/org/galaxio/gatling/kafka/javaapi/examples)
 - [Kotlin examples](src/test/kotlin/org/galaxio/gatling/kafka/javaapi/examples)
 
+Validate that all example simulations still construct against the current API:
+
+```bash
+sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"
+```
+
 ## Contributing
 
 ```bash

--- a/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.java
+++ b/src/test/java/org/galaxio/gatling/kafka/javaapi/examples/AvroClassWithRequestReplySimulation.java
@@ -23,10 +23,8 @@ public class AvroClassWithRequestReplySimulation extends Simulation {
     private static final SchemaRegistryClient client = new CachedSchemaRegistryClient(Arrays.asList("schRegUrl".split(",")), 16);
 
     // example of using custom serde
-    public static Serializer<MyAvroClass> ser =
-            (Serializer) new KafkaAvroSerializer(client);
-    public static Deserializer<MyAvroClass> de =
-            (Deserializer) new KafkaAvroDeserializer(client);
+    public static Serializer<MyAvroClass> ser = serializer(client);
+    public static Deserializer<MyAvroClass> de = deserializer(client);
 
     // protocol
     private final KafkaProtocolBuilder kafkaProtocolRRAvro = kafka()
@@ -54,6 +52,37 @@ public class AvroClassWithRequestReplySimulation extends Simulation {
     // simulation
     {
         setUp(scenario("Kafka RequestReply Avro").exec(kafkaMessage).injectOpen(atOnceUsers(1))).protocols(kafkaProtocolRRAvro);
+    }
+
+    private static Serializer<MyAvroClass> serializer(SchemaRegistryClient client) {
+        KafkaAvroSerializer delegate = new KafkaAvroSerializer(client);
+        return new Serializer<>() {
+            @Override
+            public byte[] serialize(String topic, MyAvroClass data) {
+                return delegate.serialize(topic, data);
+            }
+
+            @Override
+            public void close() {
+                delegate.close();
+            }
+        };
+    }
+
+    private static Deserializer<MyAvroClass> deserializer(SchemaRegistryClient client) {
+        KafkaAvroDeserializer delegate = new KafkaAvroDeserializer(client);
+        return new Deserializer<>() {
+            @Override
+            public MyAvroClass deserialize(String topic, byte[] data) {
+                Object value = delegate.deserialize(topic, data);
+                return value == null ? null : MyAvroClass.class.cast(value);
+            }
+
+            @Override
+            public void close() {
+                delegate.close();
+            }
+        };
     }
 
     private static class MyAvroClass {

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/ExampleSmokeValidation.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/ExampleSmokeValidation.scala
@@ -1,0 +1,33 @@
+package org.galaxio.gatling.kafka.examples
+
+import io.gatling.core.scenario.Simulation
+
+object ExampleSmokeValidation {
+
+  private val scalaSimulationClass = classOf[Simulation]
+  private val javaSimulationClass  = classOf[io.gatling.javaapi.core.Simulation]
+
+  private val exampleSimulationClasses = Seq(
+    "org.galaxio.gatling.kafka.examples.Avro4sSimulation",
+    "org.galaxio.gatling.kafka.examples.AvroClassWithRequestReplySimulation",
+    "org.galaxio.gatling.kafka.examples.BasicSimulation",
+    "org.galaxio.gatling.kafka.examples.MatchSimulation",
+    "org.galaxio.gatling.kafka.examples.ProducerSimulation",
+    "org.galaxio.gatling.kafka.javaapi.examples.AvroClassWithRequestReplySimulation",
+    "org.galaxio.gatling.kafka.javaapi.examples.BasicSimulation",
+    "org.galaxio.gatling.kafka.javaapi.examples.MatchSimulation",
+    "org.galaxio.gatling.kafka.javaapi.examples.ProducerSimulation",
+  )
+
+  def main(args: Array[String]): Unit = {
+    exampleSimulationClasses.foreach { className =>
+      val clazz = Class.forName(className)
+      require(
+        scalaSimulationClass.isAssignableFrom(clazz) || javaSimulationClass.isAssignableFrom(clazz),
+        s"$className does not extend ${scalaSimulationClass.getName} or ${javaSimulationClass.getName}",
+      )
+      clazz.getDeclaredConstructor()
+      println(s"Validated example simulation class: $className")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the raw Avro serializer/deserializer casts in the Java request-reply example with typed delegates
- add a lightweight example smoke runner that validates compiled Scala and Java example simulation classes
- run the smoke runner in CI and document the local command in the README

Fixes #99

## Validation
- sbt --batch scalafmtAll scalafmtCheckAll "Test / compile" "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"