### PR TITLE
fix(logging): improve binary payload diagnostics

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
   lazy val gatlingTest: Seq[ModuleID] = Seq(
     "io.gatling.highcharts" % "gatling-charts-highcharts" % Versions.gatling % "it,test",
     "io.gatling"            % "gatling-test-framework"    % Versions.gatling % "it,test",
+    "org.scalameta"        %% "munit"                     % "1.1.1"          % Test,
   )
 
   lazy val kafka: Seq[ModuleID] = Seq(

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala
@@ -43,8 +43,10 @@ final class KafkaRequestAction[K: ClassTag, V: ClassTag](
       metadata => {
         val requestEndDate = clock.nowMillis
         if (logger.underlying.isDebugEnabled) {
-          logger.debug(s"Record sent user=${session.userId} key=${new String(protocolMessage.key)} topic=${metadata.topic()}")
-          logger.trace(s"ProducerRecord=${protocolMessage.toProducerRecord}")
+          logger.debug(
+            s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${metadata.topic()}",
+          )
+          logger.trace(describeMessage(protocolMessage))
         }
 
         statsEngine.logResponse(

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -33,7 +33,7 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
       rm => {
         if (logger.underlying.isDebugEnabled) {
           logMessage(
-            s"Record sent user=${session.userId} key=${new String(protocolMessage.key)} topic=${rm.topic()}",
+            s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${rm.topic()}",
             protocolMessage,
           )
         }

--- a/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala
@@ -12,7 +12,7 @@ import org.apache.kafka.common.serialization.Serde
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import java.io.ByteArrayInputStream
-import java.nio.charset.Charset
+import java.nio.charset.{Charset, StandardCharsets}
 import scala.util.Try
 
 trait KafkaMessagePreparer[P] extends Preparer[KafkaProtocolMessage, P]
@@ -20,9 +20,10 @@ trait KafkaMessagePreparer[P] extends Preparer[KafkaProtocolMessage, P]
 object KafkaMessagePreparer {
 
   private def messageCharset(cfg: GatlingConfiguration, msg: KafkaProtocolMessage): Validation[Charset] =
-    Try(Charset.forName(msg.headers.map(_.lastHeader("content_encoding").value()).map(new String(_)).get))
-      .orElse(Try(cfg.core.charset))
-      .toValidation
+    msg.headers
+      .flatMap(headers => Option(headers.lastHeader("content_encoding")))
+      .map(header => Try(Charset.forName(new String(header.value(), StandardCharsets.UTF_8))).toValidation)
+      .getOrElse(cfg.core.charset.success)
 
   def stringBodyPreparer(configuration: GatlingConfiguration): KafkaMessagePreparer[String] =
     msg =>

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -76,7 +76,7 @@ class KafkaMessageTracker[K, V](
     // message was sent; add the timestamps to the map
     case messageSent: MessagePublished =>
       val key = makeKeyForSentMessages(messageSent.matchId)
-      logger.debug("Published with MatchId: {} Tracking Key: {}", new String(messageSent.matchId), key)
+      logger.debug("Published with MatchId: {} Tracking Key: {}", describeBytes(messageSent.matchId), key)
       sentMessages += key -> messageSent
       if (messageSent.replyTimeout > 0) {
         triggerPeriodicTimeoutScan()
@@ -92,17 +92,17 @@ class KafkaMessageTracker[K, V](
         if (message.key == null || message.value == null) {
           logger.warn(" --- received message with null key or value")
         } else {
-          logger.trace(" --- received {} {}", message.key, message.value)
+          logger.trace(" --- received key={} value={}", describeBytes(message.key), describeBytes(message.value))
         }
 
         val replyId    = messageMatcher.responseMatch(message)
-        val messageKey = if (message.key == null) "null" else new String(message.key)
+        val messageKey = describeBytes(message.key)
         logMessage(s"Record received key=$messageKey", message)
         // if key is missing, message was already acked and is a dup, or request timeout
         val key        = makeKeyForSentMessages(replyId)
         logger.debug(
           "Received with MatchId: {} Tracking Key: {}, producerTopic: {}, consumerTopic: {}",
-          new String(replyId),
+          describeBytes(replyId),
           key,
           message.producerTopic,
           message.consumerTopic,
@@ -123,7 +123,7 @@ class KafkaMessageTracker[K, V](
       }
       for (MessagePublished(matchId, sentTimestamp, receivedTimeout, _, session, next, requestName) <- timedOutMessages) {
         val matchKey = makeKeyForSentMessages(matchId)
-        logger.warn("Did not receive match for {} - key: {} after {}ms", new String(matchId), matchKey, receivedTimeout)
+        logger.warn("Did not receive match for {} - key: {} after {}ms", describeBytes(matchId), matchKey, receivedTimeout)
         sentMessages.remove(matchKey)
         executeNext(
           session.markAsFailed,

--- a/src/main/scala/org/galaxio/gatling/kafka/package.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/package.scala
@@ -4,13 +4,67 @@ import com.typesafe.scalalogging.StrictLogging
 import io.gatling.core.check.Check
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
+import java.nio.ByteBuffer
+import java.nio.charset.{CharacterCodingException, CodingErrorAction, StandardCharsets}
+
 package object kafka {
   type KafkaCheck = Check[KafkaProtocolMessage]
 
   trait KafkaLogging extends StrictLogging {
+    private val Utf8                = StandardCharsets.UTF_8
+    private val BinaryPreviewLength = 24
+
+    private def decodeUtf8(bytes: Array[Byte]): Option[String] = {
+      val decoder = Utf8.newDecoder()
+      decoder.onMalformedInput(CodingErrorAction.REPORT)
+      decoder.onUnmappableCharacter(CodingErrorAction.REPORT)
+      try Some(decoder.decode(ByteBuffer.wrap(bytes)).toString)
+      catch {
+        case _: CharacterCodingException => None
+      }
+    }
+
+    private def isPrintable(text: String): Boolean =
+      text.forall(ch => !Character.isISOControl(ch) || ch == '\n' || ch == '\r' || ch == '\t')
+
+    private def escape(text: String): String =
+      text.flatMap {
+        case '\\' => "\\\\"
+        case '"'  => "\\\""
+        case '\n' => "\\n"
+        case '\r' => "\\r"
+        case '\t' => "\\t"
+        case ch   => ch.toString
+      }
+
+    private def hexPreview(bytes: Array[Byte]): String =
+      bytes
+        .take(BinaryPreviewLength)
+        .map(b => f"${b & 0xff}%02x")
+        .mkString
+
+    protected def describeBytes(bytes: Array[Byte]): String =
+      Option(bytes) match {
+        case None                         => "null"
+        case Some(value) if value.isEmpty => "bytes(len=0)"
+        case Some(value)                  =>
+          decodeUtf8(value).filter(isPrintable) match {
+            case Some(text) =>
+              s"""text(utf-8,len=${value.length},"${escape(text)}")"""
+            case None       =>
+              val suffix = if (value.length > BinaryPreviewLength) "..." else ""
+              s"bytes(len=${value.length},hex=${hexPreview(value)}$suffix)"
+          }
+      }
+
+    protected def describeMessage(msg: KafkaProtocolMessage): String = {
+      val headerCount = msg.headers.fold(0)(_.toArray.length)
+      s"KafkaProtocolMessage(producerTopic=${msg.producerTopic}, consumerTopic=${msg.consumerTopic}, key=${describeBytes(msg.key)}, value=${describeBytes(msg.value)}, headers=$headerCount, responseCode=${msg.responseCode.getOrElse("none")})"
+    }
+
     def logMessage(text: => String, msg: KafkaProtocolMessage): Unit = {
       logger.debug(text)
-      logger.trace(msg.toString)
+      logger.trace(describeMessage(msg))
     }
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/KafkaLoggingSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/KafkaLoggingSpec.scala
@@ -1,0 +1,37 @@
+package org.galaxio.gatling.kafka
+
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+
+class KafkaLoggingSpec extends munit.FunSuite {
+
+  private object TestLogging extends KafkaLogging {
+    def bytes(bytes: Array[Byte]): String          = describeBytes(bytes)
+    def message(msg: KafkaProtocolMessage): String = describeMessage(msg)
+  }
+
+  test("describeBytes renders printable UTF-8 text deterministically") {
+    val value = "payload".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+
+    assertEquals(TestLogging.bytes(value), """text(utf-8,len=7,"payload")""")
+  }
+
+  test("describeBytes falls back to hex preview for binary payloads") {
+    val value = Array[Byte](0x00, 0x01, 0x7f, 0x0a, 0x2a)
+
+    assertEquals(TestLogging.bytes(value), "bytes(len=5,hex=00017f0a2a)")
+  }
+
+  test("describeMessage summarises payload metadata without raw arrays") {
+    val msg = KafkaProtocolMessage(
+      key = "key".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+      value = Array[Byte](0x00, 0x7f),
+      producerTopic = "producer-topic",
+      consumerTopic = "consumer-topic",
+    )
+
+    assertEquals(
+      TestLogging.message(msg),
+      """KafkaProtocolMessage(producerTopic=producer-topic, consumerTopic=consumer-topic, key=text(utf-8,len=3,"key"), value=bytes(len=2,hex=007f), headers=0, responseCode=none)""",
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- decode Kafka `content_encoding` headers with explicit UTF-8 handling
- replace platform-default/raw byte logging with deterministic text-or-hex summaries
- add focused regression tests for the logging formatter

## Testing
- sbt --batch scalafmtAll scalafmtCheckAll
- sbt --batch "Test / compile" test

Closes #94