### PR TITLE
fix: complete the protocol topic deprecation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,13 @@ import org.galaxio.gatling.kafka.Predef._
 import io.gatling.core.Predef._
 
 class KafkaSimulation extends Simulation {
-  val kafkaConf = kafka.topic("test-topic")
+  val kafkaConf = kafka
     .properties(Map("bootstrap.servers" -> "localhost:9092"))
 
   val scn = scenario("Kafka Producer")
     .exec(
       kafka("send message")
+        .topic("test-topic")
         .send[String, String]("key", """{"msg": "hello"}""")
     )
 
@@ -99,12 +100,13 @@ import static org.galaxio.gatling.kafka.javaapi.KafkaDsl.*;
 import static io.gatling.javaapi.core.CoreDsl.*;
 
 public class KafkaSimulation extends Simulation {
-  var kafkaConf = kafka().topic("test-topic")
+  var kafkaConf = kafka()
     .properties(Map.of("bootstrap.servers", "localhost:9092"));
 
   var scn = scenario("Kafka Producer")
     .exec(
       kafka("send message")
+        .topic("test-topic")
         .send("key", "{\"msg\": \"hello\"}")
     );
 
@@ -119,12 +121,13 @@ import org.galaxio.gatling.kafka.javaapi.KafkaDsl.*
 import io.gatling.javaapi.core.CoreDsl.*
 
 class KafkaSimulation : Simulation() {
-  val kafkaConf = kafka().topic("test-topic")
+  val kafkaConf = kafka()
     .properties(mapOf("bootstrap.servers" to "localhost:9092"))
 
   val scn = scenario("Kafka Producer")
     .exec(
       kafka("send message")
+        .topic("test-topic")
         .send("key", """{"msg": "hello"}""")
     )
 
@@ -142,6 +145,7 @@ import org.galaxio.gatling.kafka.Predef._
 scenario("Producer")
   .exec(
     kafka("send string")
+      .topic("test-topic")
       .send[String, String]("key", "payload"),
   )
 ```
@@ -152,6 +156,7 @@ Target a specific partition or set an explicit timestamp on produced records:
 
 ```scala
 kafka("send to partition")
+  .topic("test-topic")
   .send[String, String]("key", "payload")
   .partition(3)
   .timestamp(System.currentTimeMillis())
@@ -163,9 +168,12 @@ Both `.partition()` and `.timestamp()` accept Gatling `Expression` values for dy
 
 ```scala
 kafka("silent request")
+  .topic("test-topic")
   .send[String]("foo")
   .silent
 ```
+
+Protocol-level `.topic(...)` is deprecated and only kept as a backward-compatible fallback. New producer scenarios should set the topic on each request builder with `kafka("name").topic("...")`.
 
 ---
 

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAction.scala
@@ -21,6 +21,9 @@ abstract class KafkaAction[K: ClassTag, V: ClassTag](
     throttler: Option[ActorRef[Throttler.Command]],
 ) extends RequestAction with KafkaLogging with NameGen {
 
+  private val missingProducerTopicError =
+    "Kafka producer topic is not defined. Set it with kafka(\"request\").topic(...) or use the deprecated protocol-level kafka.topic(...)."
+
   override def requestName: Expression[String] = attributes.requestName
 
   override def sendRequest(session: Session): Validation[Unit] = {
@@ -37,6 +40,12 @@ abstract class KafkaAction[K: ClassTag, V: ClassTag](
 
   private def traverse[T](ovt: Option[Validation[T]]): Validation[Option[T]] =
     ovt.fold(Option.empty[T].success)(_.map(Option[T]))
+
+  private def resolveProducerTopic(session: Session): Validation[String] =
+    attributes.producerTopic
+      .map(_(session))
+      .orElse(components.kafkaProtocol.producerTopic.map(_.success))
+      .getOrElse(missingProducerTopicError.failure)
 
   private def serializeKey(
       serde: Option[Serde[? <: K]],
@@ -66,12 +75,8 @@ abstract class KafkaAction[K: ClassTag, V: ClassTag](
     // need for work gatling Expression Language
     if (classTag[V].runtimeClass.getCanonicalName == "java.lang.String")
       for {
-        key           <- serializeKey(
-                           attributes.keySerde,
-                           attributes.key,
-                           attributes.producerTopic.getOrElse(components.kafkaProtocol.producerTopic.el),
-                         )(s)
-        producerTopic <- attributes.producerTopic.fold(components.kafkaProtocol.producerTopic.success)(_(s))
+        producerTopic <- resolveProducerTopic(s)
+        key           <- serializeKey(attributes.keySerde, attributes.key, _ => producerTopic.success)(s)
         consumerTopic <- traverse(attributes.consumerTopic.map(_(s)))
         value         <- attributes.value
                            .asInstanceOf[Expression[String]](s)
@@ -82,17 +87,13 @@ abstract class KafkaAction[K: ClassTag, V: ClassTag](
         key.getOrElse(Array.emptyByteArray),
         value,
         producerTopic,
-        consumerTopic.getOrElse("<unknown>"),
+        consumerTopic.getOrElse(producerTopic),
         headers,
       )
     else
       for {
-        key           <- serializeKey(
-                           attributes.keySerde,
-                           attributes.key,
-                           attributes.producerTopic.getOrElse(components.kafkaProtocol.producerTopic.el),
-                         )(s)
-        producerTopic <- attributes.producerTopic.fold(components.kafkaProtocol.producerTopic.success)(_(s))
+        producerTopic <- resolveProducerTopic(s)
+        key           <- serializeKey(attributes.keySerde, attributes.key, _ => producerTopic.success)(s)
         consumerTopic <- traverse(attributes.consumerTopic.map(_(s)))
         value         <- attributes
                            .value(s)
@@ -102,7 +103,7 @@ abstract class KafkaAction[K: ClassTag, V: ClassTag](
         key.getOrElse(Array.emptyByteArray),
         value,
         producerTopic,
-        consumerTopic.getOrElse("<unknown>"),
+        consumerTopic.getOrElse(producerTopic),
         headers,
       )
 

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocol.scala
@@ -85,14 +85,15 @@ object KafkaProtocol {
 }
 
 final case class KafkaProtocol(
-    producerTopic: String, // TODO: remove after 1.1.0 (when topic moved from protocol to request builders)
+    producerTopic: Option[String], // TODO: remove after 1.1.0 (when topic moved from protocol to request builders)
     producerProperties: Map[String, AnyRef],
     consumerProperties: Map[String, AnyRef],
     timeout: FiniteDuration,
     messageMatcher: KafkaMatcher,
 ) extends Protocol {
 
-  def topic(t: String): KafkaProtocol = copy(producerTopic = t)
+  @deprecated("use topic definition in kafka request builders", "1.0.0")
+  def topic(t: String): KafkaProtocol = copy(producerTopic = Some(t))
 
   def properties(properties: Map[String, AnyRef]): KafkaProtocol =
     copy(producerProperties = properties)

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilder.scala
@@ -94,6 +94,6 @@ final case class KafkaProtocolBuilder(
           ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> Serdes.ByteArray().deserializer().getClass.getName,
         )
 
-    KafkaProtocol("kafka-test", producerSettings ++ serializers, consumerSettingsWithDefaults, timeout, messageMatcher)
+    KafkaProtocol(None, producerSettings ++ serializers, consumerSettingsWithDefaults, timeout, messageMatcher)
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderBackwardCompatible.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocolBuilderBackwardCompatible.scala
@@ -12,7 +12,7 @@ final case class KafkaProtocolBuilderBackwardCompatible(topic: String, props: Ma
       ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> "org.apache.kafka.common.serialization.ByteArraySerializer",
       ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.ByteArraySerializer",
     )
-    KafkaProtocol(topic, props ++ serializers, Map.empty, timeout, KafkaKeyMatcher)
+    KafkaProtocol(Some(topic), props ++ serializers, Map.empty, timeout, KafkaKeyMatcher)
   }
 
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/request/KafkaProtocolMessage.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/KafkaProtocolMessage.scala
@@ -39,7 +39,7 @@ object KafkaProtocolMessage {
     KafkaProtocolMessage(
       consumerRecord.key(),
       consumerRecord.value(),
-      inputTopic.getOrElse("<unknown>"),
+      inputTopic.getOrElse(consumerRecord.topic()),
       consumerRecord.topic(),
       Option(consumerRecord.headers()),
     )

--- a/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestBuilderBase.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/builder/KafkaRequestBuilderBase.scala
@@ -59,7 +59,7 @@ case class KafkaRequestBuilderBase(requestName: Expression[String]) {
       KafkaRequestBuilder[Nothing, V](
         KafkaAttributes(
           requestName = requestName,
-          producerTopic = None, // TODO: it should be set after topic definition
+          producerTopic = None, // falls back to the deprecated protocol-level topic if one is configured
           consumerTopic = None,
           key = None,
           value = payload,
@@ -73,7 +73,7 @@ case class KafkaRequestBuilderBase(requestName: Expression[String]) {
       KafkaRequestBuilder(
         KafkaAttributes(
           requestName = requestName,
-          producerTopic = None, // TODO: it should be set after topic definition
+          producerTopic = None, // falls back to the deprecated protocol-level topic if one is configured
           consumerTopic = None,
           key = Option(key),
           value = payload,
@@ -89,7 +89,7 @@ case class KafkaRequestBuilderBase(requestName: Expression[String]) {
     KafkaRequestBuilder[Nothing, V](
       KafkaAttributes(
         requestName = requestName,
-        producerTopic = None, // TODO: it should be set after topic definition
+        producerTopic = None, // falls back to the deprecated protocol-level topic if one is configured
         consumerTopic = None,
         key = None,
         value = payload,


### PR DESCRIPTION
## Summary
- stop defaulting producer protocols to the `kafka-test` sentinel topic and require an explicit producer topic
- preserve backward compatibility by keeping the deprecated protocol-level topic as an optional fallback
- replace `<unknown>` topic placeholders in runtime messages and update the README migration path

Fixes #93

## Validation
- sbt --batch "Test / compile" scalafmtAll scalafmtCheckAll