### PR TITLE
build: add binary compatibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Compile
         run: sbt clean compile
 
+      - name: Check Binary Compatibility
+        run: sbt mimaReportBinaryIssues
+
       - name: Smoke test examples
         run: sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"
 

--- a/README.md
+++ b/README.md
@@ -463,6 +463,9 @@ sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"
 # Compile the library
 sbt compile
 
+# Check binary compatibility against the latest mainline release
+sbt checkBinaryCompatibility
+
 # Run the full Scala test suite in the Test scope
 sbt test
 
@@ -478,6 +481,12 @@ sbt scalafmtAll scalafmtSbt
 # Recommended local check before pushing (matches the main CI flow)
 sbt clean compile "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test
 ```
+
+Binary compatibility for the published Scala and Java APIs is enforced with MiMa against the current `main` baseline declared in [`build.sbt`](build.sbt).
+
+When `main` releases a new compatible version, update `binaryCompatibilityBaselineVersion` to that published artifact so future PRs compare against the latest shipped API.
+
+If you intentionally break binary compatibility, keep the change explicit: document the break in the PR, add the narrowest possible `binaryCompatibilityExceptions` filter in [`build.sbt`](build.sbt), and remove it again once the new baseline is released.
 
 ## License
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,41 @@
 import Dependencies.*
+import com.typesafe.tools.mima.core._
 //import org.galaxio.performance.avro.RegistrySubject
 
-val scalaV      = "2.13.16"
-val avroSchemas = Seq() // for example Seq(RegistrySubject("test-hello-schema", 1))
+val scalaV                             = "2.13.16"
+val avroSchemas                        = Seq() // for example Seq(RegistrySubject("test-hello-schema", 1))
+val binaryCompatibilityBaselineVersion =
+  settingKey[Option[String]]("Released artifact used as the MiMa compatibility baseline.")
+val binaryCompatibilityExceptions      =
+  settingKey[Seq[ProblemFilter]]("Approved MiMa problem filters for intentional binary breaks.")
+
+ThisBuild / binaryCompatibilityBaselineVersion := Some("0.22.2")
+ThisBuild / binaryCompatibilityExceptions      := Seq(
+  // KafkaProtocol.producerTopic: String -> Option[String] (intentional: topic deprecation, PR #93)
+  ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.galaxio.gatling.kafka.protocol.KafkaProtocol.producerTopic"),
+  ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.galaxio.gatling.kafka.protocol.KafkaProtocol.copy$default$1"),
+  ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.galaxio.gatling.kafka.protocol.KafkaProtocol.apply"),
+  ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.galaxio.gatling.kafka.protocol.KafkaProtocol.copy"),
+  ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.galaxio.gatling.kafka.protocol.KafkaProtocol.this"),
+  // KafkaLogging trait: new internal fields Utf8/BinaryPreviewLength (intentional: binary logging, PR #94)
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "org.galaxio.gatling.kafka.package#KafkaLogging.org$galaxio$gatling$kafka$KafkaLogging$$Utf8",
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "org.galaxio.gatling.kafka.package#KafkaLogging.org$galaxio$gatling$kafka$KafkaLogging$$BinaryPreviewLength",
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "org.galaxio.gatling.kafka.package#KafkaLogging.org$galaxio$gatling$kafka$KafkaLogging$_setter_$org$galaxio$gatling$kafka$KafkaLogging$$Utf8_=",
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "org.galaxio.gatling.kafka.package#KafkaLogging.org$galaxio$gatling$kafka$KafkaLogging$_setter_$org$galaxio$gatling$kafka$KafkaLogging$$BinaryPreviewLength_=",
+  ),
+)
+ThisBuild / mimaFailOnNoPrevious               := false
+ThisBuild / mimaPreviousArtifacts              := (ThisBuild / binaryCompatibilityBaselineVersion).value
+  .map(version => organization.value %% moduleName.value % version)
+  .toSet
+ThisBuild / mimaBinaryIssueFilters ++= (ThisBuild / binaryCompatibilityExceptions).value
 
 lazy val root = (project in file("."))
   .enablePlugins(GitVersioning, GatlingPlugin)
@@ -39,3 +72,5 @@ Gatling / javaOptions := overrideDefaultJavaOptions(
   "--add-opens=java.base/java.util=ALL-UNNAMED",
   "--add-opens=java.base/java.lang=ALL-UNNAMED",
 )
+
+addCommandAlias("checkBinaryCompatibility", "mimaReportBinaryIssues")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,7 @@ libraryDependencies += "org.apache.avro" % "avro-compiler" % "1.11.4"
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release"             % "1.11.1")
 addSbtPlugin("io.gatling"     % "gatling-sbt"                % "4.13.3")
+addSbtPlugin("com.typesafe"   % "sbt-mima-plugin"            % "1.1.5")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"               % "2.5.5")
 addSbtPlugin("com.github.sbt" % "sbt-avro"                   % "4.0.1")
 addSbtPlugin("org.galaxio"    % "sbt-schema-registry-plugin" % "0.5.6")


### PR DESCRIPTION
## Summary
- add an sbt MiMa gate against the latest `main` release baseline (`0.22.2`)
- run binary compatibility checks in CI so API regressions fail before merge
- document how to advance the baseline and how to handle intentional binary breaks

Closes #91