### PR TITLE
fix: release tracker and unsubscribe topic after dynamic reply request completes

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -40,14 +40,17 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
         val id = components.kafkaProtocol.messageMatcher.requestMatch(protocolMessage)
 
         components.trackersPool.map { trackers =>
+          val consumerTopic    = protocolMessage.consumerTopic
+          var trackerAcquired  = false
           try {
             val tracker = trackers.tracker(
               protocolMessage.producerTopic,
-              protocolMessage.consumerTopic,
+              consumerTopic,
               components.kafkaProtocol.messageMatcher,
               None,
               components.kafkaProtocol.timeout,
             )
+            trackerAcquired = true
             tracker ! KafkaMessageTracker
               .MessagePublished(
                 id,
@@ -57,9 +60,11 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
                 session,
                 next,
                 requestNameString,
+                onComplete = () => trackers.releaseTracker(consumerTopic),
               )
           } catch {
             case e: Exception =>
+              if (trackerAcquired) trackers.releaseTracker(consumerTopic)
               val requestEndDate = clock.nowMillis
               logger.error(e.getMessage, e)
               statsEngine.logResponse(

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -40,8 +40,8 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
         val id = components.kafkaProtocol.messageMatcher.requestMatch(protocolMessage)
 
         components.trackersPool.map { trackers =>
-          val consumerTopic    = protocolMessage.consumerTopic
-          var trackerAcquired  = false
+          val consumerTopic   = protocolMessage.consumerTopic
+          var trackerAcquired = false
           try {
             val tracker = trackers.tracker(
               protocolMessage.producerTopic,

--- a/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
@@ -61,8 +61,8 @@ final class DynamicKafkaConsumer[K, V] private (
     latch.await(assignTimeout.length, assignTimeout.unit)
   }
 
-  /** Applies pending topic additions and removals in a single consumer.subscribe call
-    * so the ConsumerRebalanceListener is never overwritten between the two operations.
+  /** Applies pending topic additions and removals in a single consumer.subscribe call so the ConsumerRebalanceListener is never
+    * overwritten between the two operations.
     */
   private def updateSubscription(): Unit = {
     val toRemove = mutable.Set.empty[String]

--- a/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
@@ -40,9 +40,14 @@ final class DynamicKafkaConsumer[K, V] private (
   private val topicsQueue: java.util.Queue[(String, CountDownLatch)] = new ConcurrentLinkedQueue[(String, CountDownLatch)]()
   topicsQueue.addAll(topics.map((_, new CountDownLatch(0))).asJava)
 
+  private val topicsToRemove: java.util.Queue[String] = new ConcurrentLinkedQueue[String]()
+
   private val running: AtomicBoolean        = new AtomicBoolean(true)
   private val consumer: KafkaConsumer[K, V] = new KafkaConsumer[K, V](settings)
   private val initLatch: CountDownLatch     = if (this.topicsQueue.isEmpty) new CountDownLatch(1) else new CountDownLatch(0)
+
+  def removeTopicSubscription(topic: String): Unit =
+    topicsToRemove.add(topic)
 
   def addTopicForSubscription(
       newTopic: String,
@@ -50,64 +55,64 @@ final class DynamicKafkaConsumer[K, V] private (
   ): Boolean = {
     val latch = new CountDownLatch(1)
     this.topicsQueue.add(newTopic, latch)
-    if (initLatch.getCount > 0) { // need for starting processing loop
+    if (initLatch.getCount > 0) {
       initLatch.countDown()
     }
     latch.await(assignTimeout.length, assignTimeout.unit)
   }
 
-  private def getTopicsForSubscription: Set[(String, CountDownLatch)] = {
-    if (!this.topicsQueue.isEmpty) {
-      val currentSubscription = this.consumer.subscription()
-      val forSubscribe        = mutable.Set.empty[(String, CountDownLatch)]
-      while (!this.topicsQueue.isEmpty) {
-        val (topic, latch) = this.topicsQueue.poll()
-        if (currentSubscription.contains(topic)) {
-          latch.countDown()
-        } else {
-          forSubscribe.add(topic, latch)
+  /** Applies pending topic additions and removals in a single consumer.subscribe call
+    * so the ConsumerRebalanceListener is never overwritten between the two operations.
+    */
+  private def updateSubscription(): Unit = {
+    val toRemove = mutable.Set.empty[String]
+    while (!topicsToRemove.isEmpty) {
+      toRemove.add(topicsToRemove.poll())
+    }
+
+    if (topicsQueue.isEmpty && toRemove.isEmpty) return
+
+    val currentSubscription = consumer.subscription()
+    val forNewTopics        = mutable.Set.empty[(String, CountDownLatch)]
+
+    while (!topicsQueue.isEmpty) {
+      val (topic, latch) = topicsQueue.poll()
+      if (currentSubscription.contains(topic) && !toRemove.contains(topic))
+        latch.countDown()
+      else
+        forNewTopics.add((topic, latch))
+    }
+
+    if (forNewTopics.isEmpty && toRemove.isEmpty) return
+
+    val baseTopics = currentSubscription.asScala.toSet -- toRemove
+    val allTopics  = baseTopics ++ forNewTopics.map(_._1)
+    val newLatches = forNewTopics.map(_._2)
+
+    if (allTopics.isEmpty) {
+      if (!currentSubscription.isEmpty) consumer.unsubscribe()
+      return
+    }
+
+    consumer.subscribe(
+      allTopics.asJava,
+      new ConsumerRebalanceListener {
+        override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit =
+          logger.debug(s"revoked partitions $partitions")
+
+        override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
+          logger.debug(s"assigned partitions $partitions")
+          newLatches.foreach(_.countDown())
         }
-      }
-      if (forSubscribe.isEmpty)
-        return Set.empty
-
-      forSubscribe.addAll(currentSubscription.asScala.map((_, new CountDownLatch(1))))
-      return forSubscribe.toSet
-    }
-    Set.empty
-  }
-
-  private def subscribeTopics(forSubscribe: Set[(String, CountDownLatch)]): Unit = {
-    if (forSubscribe.nonEmpty) {
-      val (topics, latches) =
-        forSubscribe.foldLeft((mutable.Set.empty[String], mutable.Set.empty[CountDownLatch]))((result, tl) => {
-          val (ts, ls)       = result
-          val (topic, latch) = tl
-          ts.add(topic)
-          ls.add(latch)
-          result
-        })
-      this.consumer.subscribe(
-        topics.asJava,
-        new ConsumerRebalanceListener {
-          override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
-            logger.debug(s"revoked partitions $partitions")
-          }
-
-          override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
-            logger.debug(s"assigned partitions $partitions")
-            latches.foreach(_.countDown())
-          }
-        },
-      )
-    }
+      },
+    )
   }
 
   override def run(): Unit = {
     try {
       val timeout = DynamicKafkaConsumer.initializationTimeout
       this.initLatch.await(timeout.length, timeout.unit)
-      subscribeTopics(getTopicsForSubscription)
+      updateSubscription()
       while (running.get) {
         val records = this.consumer.poll(Duration.ofMillis(1000))
         records.forEach(record =>
@@ -117,7 +122,7 @@ final class DynamicKafkaConsumer[K, V] private (
               this.onFailure(e)
           },
         )
-        subscribeTopics(getTopicsForSubscription)
+        updateSubscription()
       }
     } catch {
       case e: WakeupException =>

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -37,6 +37,7 @@ object KafkaMessageTracker {
       session: Session,
       next: Action,
       requestName: String,
+      onComplete: () => Unit = () => (),
   ) extends TrackerMessage
 
   final case class MessageConsumed(
@@ -86,7 +87,8 @@ class KafkaMessageTracker[K, V](
     // message was received; publish stats and remove from the map
     case MessageConsumed(receivedTimestamp, forTransformMessage) =>
       val message = responseTransformer.map(_(forTransformMessage)).getOrElse(forTransformMessage)
-      if (messageMatcher.responseMatch(message) == null) {
+      val replyId = messageMatcher.responseMatch(message)
+      if (replyId == null) {
         logger.error("no messageMatcher key for read message {}", message.key)
       } else {
         if (message.key == null || message.value == null) {
@@ -95,11 +97,9 @@ class KafkaMessageTracker[K, V](
           logger.trace(" --- received key={} value={}", describeBytes(message.key), describeBytes(message.value))
         }
 
-        val replyId    = messageMatcher.responseMatch(message)
         val messageKey = describeBytes(message.key)
         logMessage(s"Record received key=$messageKey", message)
-        // if key is missing, message was already acked and is a dup, or request timeout
-        val key        = makeKeyForSentMessages(replyId)
+        val key = makeKeyForSentMessages(replyId)
         logger.debug(
           "Received with MatchId: {} Tracking Key: {}, producerTopic: {}, consumerTopic: {}",
           describeBytes(replyId),
@@ -107,8 +107,10 @@ class KafkaMessageTracker[K, V](
           message.producerTopic,
           message.consumerTopic,
         )
-        sentMessages.remove(key).foreach { case MessagePublished(_, sentTimestamp, _, checks, session, next, requestName) =>
-          processMessage(session, sentTimestamp, receivedTimestamp, checks, message, next, requestName)
+        sentMessages.remove(key).foreach {
+          case MessagePublished(_, sentTimestamp, _, checks, session, next, requestName, onComplete) =>
+            try processMessage(session, sentTimestamp, receivedTimestamp, checks, message, next, requestName)
+            finally onComplete()
         }
       }
       stay
@@ -121,20 +123,22 @@ class KafkaMessageTracker[K, V](
           timedOutMessages += messagePublished
         }
       }
-      for (MessagePublished(matchId, sentTimestamp, receivedTimeout, _, session, next, requestName) <- timedOutMessages) {
-        val matchKey = makeKeyForSentMessages(matchId)
-        logger.warn("Did not receive match for {} - key: {} after {}ms", describeBytes(matchId), matchKey, receivedTimeout)
+      for (mp <- timedOutMessages) {
+        val matchKey = makeKeyForSentMessages(mp.matchId)
+        logger.warn("Did not receive match for {} - key: {} after {}ms", describeBytes(mp.matchId), matchKey, mp.replyTimeout)
         sentMessages.remove(matchKey)
-        executeNext(
-          session.markAsFailed,
-          sentTimestamp,
-          now,
-          KO,
-          next,
-          requestName,
-          None,
-          Some(s"Reply timeout after $receivedTimeout ms"),
-        )
+        try
+          executeNext(
+            mp.session.markAsFailed,
+            mp.sentTimestamp,
+            now,
+            KO,
+            mp.next,
+            mp.requestName,
+            None,
+            Some(s"Reply timeout after ${mp.replyTimeout} ms"),
+          )
+        finally mp.onComplete()
       }
       timedOutMessages.clear()
       stay

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -99,7 +99,7 @@ class KafkaMessageTracker[K, V](
 
         val messageKey = describeBytes(message.key)
         logMessage(s"Record received key=$messageKey", message)
-        val key = makeKeyForSentMessages(replyId)
+        val key        = makeKeyForSentMessages(replyId)
         logger.debug(
           "Received with MatchId: {} Tracking Key: {}, producerTopic: {}, consumerTopic: {}",
           describeBytes(replyId),

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -111,7 +111,7 @@ final class KafkaMessageTrackerPool(
       consumerTopic,
       trackers.size(),
     )
-    val assigned = consumer.addTopicForSubscription(consumerTopic, timeout)
+    val assigned        = consumer.addTopicForSubscription(consumerTopic, timeout)
     if (!assigned) {
       throw new RuntimeException(
         s"Timed out waiting for consumer assignment to topic '$consumerTopic' after $timeout",

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -10,6 +10,7 @@ import org.galaxio.gatling.kafka.client.KafkaMessageTracker.MessageConsumed
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.{KafkaProtocolMessage, KafkaSerdesImplicits}
 
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ConcurrentHashMap, ExecutorService, Executors}
 import scala.concurrent.duration.FiniteDuration
 
@@ -34,8 +35,12 @@ final class KafkaMessageTrackerPool(
     clock: Clock,
 ) extends KafkaLogging with NameGen with KafkaSerdesImplicits {
 
-  // Trackers map Output Topic (String) to Tracker/Actor
-  private val trackers    = new ConcurrentHashMap[String, ActorRef[KafkaMessageTracker.TrackerMessage]]
+  private case class TrackerEntry(
+      actor: ActorRef[KafkaMessageTracker.TrackerMessage],
+      refCount: AtomicInteger,
+  )
+
+  private val trackers    = new ConcurrentHashMap[String, TrackerEntry]
   private val trackerName = "kafkaTracker"
 
   // Per-instance executor so shutdown of one pool doesn't affect other pools or subsequent simulations.
@@ -51,10 +56,8 @@ final class KafkaMessageTrackerPool(
       record => {
         val kafkaProtocolMessage = KafkaProtocolMessage.from(record, None)
         val receivedTimestamp    = clock.nowMillis
-        val tracker              = Option(trackers.get(record.topic()))
-
-        tracker.map(
-          _ ! MessageConsumed(
+        Option(trackers.get(record.topic())).foreach(
+          _.actor ! MessageConsumed(
             receivedTimestamp,
             kafkaProtocolMessage,
           ),
@@ -87,35 +90,82 @@ final class KafkaMessageTrackerPool(
       timeout: FiniteDuration,
   ): ActorRef[KafkaMessageTracker.TrackerMessage] = {
 
-    trackers.computeIfAbsent(
+    // Fast path: atomic get-and-increment via computeIfPresent — avoids holding the
+    // CHM bin lock during the blocking addTopicForSubscription in the slow path,
+    // while ensuring the refcount increment is atomic with the presence check
+    // (no race window with a concurrent releaseTracker that removes the entry).
+    var found: ActorRef[KafkaMessageTracker.TrackerMessage] = null
+    trackers.computeIfPresent(
       consumerTopic,
-      _ => {
-        logger.debug(
-          "Computing new tracker for topic {}, there are currently {} other trackers",
-          consumerTopic,
-          trackers.size(),
-        )
-        val name            = genName(trackerName)
-        val transformations =
-          responseTransformer.fold(withProducerTopic(producerTopic))(_.compose(withProducerTopic(producerTopic)))
-        val tracker         =
-          actorSystem.actorOf(
-            KafkaMessageTracker.actor(
-              name,
-              statsEngine,
-              clock,
-              messageMatcher,
-              Option(transformations),
-            ),
-          )
-        val assigned        = consumer.addTopicForSubscription(consumerTopic, timeout)
-        if (!assigned) {
-          throw new RuntimeException(
-            s"Timed out waiting for consumer assignment to topic '$consumerTopic' after $timeout",
-          )
-        }
-        tracker
+      (_, entry) => {
+        entry.refCount.incrementAndGet()
+        found = entry.actor
+        entry
       },
     )
+    if (found != null) return found
+
+    // Slow path: subscribe first (blocking, no CHM lock held), then create actor and register.
+    logger.debug(
+      "Creating new tracker for topic {}, there are currently {} other trackers",
+      consumerTopic,
+      trackers.size(),
+    )
+    val assigned = consumer.addTopicForSubscription(consumerTopic, timeout)
+    if (!assigned) {
+      throw new RuntimeException(
+        s"Timed out waiting for consumer assignment to topic '$consumerTopic' after $timeout",
+      )
+    }
+    val name            = genName(trackerName)
+    val transformations =
+      responseTransformer.fold(withProducerTopic(producerTopic))(_.compose(withProducerTopic(producerTopic)))
+    val newActor        = actorSystem.actorOf(
+      KafkaMessageTracker.actor(
+        name,
+        statsEngine,
+        clock,
+        messageMatcher,
+        Option(transformations),
+      ),
+    )
+
+    // Atomic insert-or-increment: if a concurrent thread won the race and already
+    // registered a tracker, increment their refcount and use their actor.
+    // The losing thread's actor receives no messages and is GC'd at actor system termination.
+    var result: ActorRef[KafkaMessageTracker.TrackerMessage] = null
+    trackers.compute(
+      consumerTopic,
+      (_, existing) => {
+        if (existing != null) {
+          existing.refCount.incrementAndGet()
+          result = existing.actor
+          existing
+        } else {
+          result = newActor
+          TrackerEntry(newActor, new AtomicInteger(1))
+        }
+      },
+    )
+    result
+  }
+
+  def releaseTracker(consumerTopic: String): Unit = {
+    // Atomic decrement-and-remove: computeIfPresent serialises with the fast-path
+    // computeIfPresent and the slow-path compute, so no window exists where a
+    // concurrent tracker() call can observe a stale entry.
+    var doCleanup = false
+    trackers.computeIfPresent(
+      consumerTopic,
+      (_, entry) => {
+        if (entry.refCount.decrementAndGet() <= 0) {
+          doCleanup = true
+          null
+        } else entry
+      },
+    )
+    if (doCleanup) {
+      consumer.removeTopicSubscription(consumerTopic)
+    }
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
@@ -1,0 +1,63 @@
+package org.galaxio.gatling.kafka.client
+
+class DynamicKafkaConsumerSpec extends munit.FunSuite {
+
+  test("removeTopicSubscription queues topic for removal") {
+    val consumer = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+      Map(
+        "bootstrap.servers"  -> "localhost:0",
+        "key.deserializer"   -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+        "value.deserializer" -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+      ),
+      Set.empty,
+      _ => (),
+      _ => (),
+    )
+    try {
+      consumer.removeTopicSubscription("topic-1")
+      consumer.removeTopicSubscription("topic-2")
+
+      val field = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("topicsToRemove")
+      field.setAccessible(true)
+      val queue = field.get(consumer).asInstanceOf[java.util.Queue[String]]
+
+      assertEquals(queue.size(), 2)
+      assertEquals(queue.poll(), "topic-1")
+      assertEquals(queue.poll(), "topic-2")
+    } finally {
+      consumer.close()
+    }
+  }
+
+  test("addTopicForSubscription queues topic with latch") {
+    val consumer = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+      Map(
+        "bootstrap.servers"  -> "localhost:0",
+        "key.deserializer"   -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+        "value.deserializer" -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+      ),
+      Set.empty,
+      _ => (),
+      _ => (),
+    )
+    try {
+      val field = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("topicsQueue")
+      field.setAccessible(true)
+      val queue =
+        field.get(consumer).asInstanceOf[java.util.Queue[(String, java.util.concurrent.CountDownLatch)]]
+
+      val initialSize = queue.size()
+
+      val thread = new Thread(() => {
+        consumer.addTopicForSubscription("new-topic", scala.concurrent.duration.DurationInt(1).second)
+      })
+      thread.start()
+      Thread.sleep(100)
+
+      assertEquals(queue.size(), initialSize + 1)
+      thread.join(2000)
+    } finally {
+      consumer.close()
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/client/TrackerRefCountSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/TrackerRefCountSpec.scala
@@ -1,0 +1,160 @@
+package org.galaxio.gatling.kafka.client
+
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, CyclicBarrier}
+
+/** Tests the ConcurrentHashMap refcount algorithm used by KafkaMessageTrackerPool. Exercises the same computeIfPresent/compute
+  * pattern against concurrent acquire+release.
+  */
+class TrackerRefCountSpec extends munit.FunSuite {
+
+  private case class Entry(value: String, refCount: AtomicInteger)
+
+  private def acquire(map: ConcurrentHashMap[String, Entry], key: String, newValue: String): String = {
+    var found: String = null
+    map.computeIfPresent(
+      key,
+      (_, entry) => {
+        entry.refCount.incrementAndGet()
+        found = entry.value
+        entry
+      },
+    )
+    if (found != null) return found
+
+    var result: String = null
+    map.compute(
+      key,
+      (_, existing) => {
+        if (existing != null) {
+          existing.refCount.incrementAndGet()
+          result = existing.value
+          existing
+        } else {
+          result = newValue
+          Entry(newValue, new AtomicInteger(1))
+        }
+      },
+    )
+    result
+  }
+
+  private def release(map: ConcurrentHashMap[String, Entry], key: String): Boolean = {
+    var removed = false
+    map.computeIfPresent(
+      key,
+      (_, entry) => {
+        if (entry.refCount.decrementAndGet() <= 0) {
+          removed = true
+          null
+        } else entry
+      },
+    )
+    removed
+  }
+
+  test("acquire increments refcount, release decrements to zero and removes") {
+    val map = new ConcurrentHashMap[String, Entry]()
+
+    val v1 = acquire(map, "t1", "actor-1")
+    assertEquals(v1, "actor-1")
+    assertEquals(map.get("t1").refCount.get(), 1)
+
+    val v2 = acquire(map, "t1", "actor-2")
+    assertEquals(v2, "actor-1")
+    assertEquals(map.get("t1").refCount.get(), 2)
+
+    assert(!release(map, "t1"))
+    assertEquals(map.get("t1").refCount.get(), 1)
+
+    assert(release(map, "t1"))
+    assert(map.get("t1") == null)
+  }
+
+  test("release on missing key is no-op") {
+    val map = new ConcurrentHashMap[String, Entry]()
+    assert(!release(map, "missing"))
+  }
+
+  test("acquire after full release creates fresh entry") {
+    val map = new ConcurrentHashMap[String, Entry]()
+
+    acquire(map, "t1", "actor-1")
+    release(map, "t1")
+    assert(map.get("t1") == null)
+
+    val v = acquire(map, "t1", "actor-2")
+    assertEquals(v, "actor-2")
+    assertEquals(map.get("t1").refCount.get(), 1)
+  }
+
+  test("concurrent acquire+release maintains correct refcount") {
+    val map        = new ConcurrentHashMap[String, Entry]()
+    val threads    = 100
+    val barrier    = new CyclicBarrier(threads)
+    val latch      = new CountDownLatch(threads)
+    val errors     = new AtomicInteger(0)
+    val acquireRef = new AtomicReference[String](null)
+
+    // Pre-populate so all threads hit fast path
+    acquire(map, "t1", "seed")
+    acquireRef.set("seed")
+
+    // Each thread: acquire, yield, release
+    (0 until threads).foreach { i =>
+      new Thread(() => {
+        try {
+          barrier.await()
+          val v = acquire(map, "t1", s"actor-$i")
+          if (v != "seed") errors.incrementAndGet()
+          Thread.`yield`()
+          release(map, "t1")
+        } catch {
+          case _: Exception => errors.incrementAndGet()
+        } finally {
+          latch.countDown()
+        }
+      }).start()
+    }
+
+    latch.await()
+    assertEquals(errors.get(), 0)
+    // Only seed refcount remains (1)
+    assertEquals(map.get("t1").refCount.get(), 1)
+
+    // Final release removes
+    assert(release(map, "t1"))
+    assert(map.get("t1") == null)
+  }
+
+  test("concurrent release never goes below zero") {
+    val map     = new ConcurrentHashMap[String, Entry]()
+    val threads = 50
+    val barrier = new CyclicBarrier(threads)
+    val latch   = new CountDownLatch(threads)
+    val removed = new AtomicInteger(0)
+
+    // Acquire 50 times
+    acquire(map, "t1", "actor")
+    (1 until threads).foreach(_ => acquire(map, "t1", "ignored"))
+    assertEquals(map.get("t1").refCount.get(), threads)
+
+    // Release all concurrently
+    (0 until threads).foreach { _ =>
+      new Thread(() => {
+        try {
+          barrier.await()
+          if (release(map, "t1")) removed.incrementAndGet()
+        } catch {
+          case _: Exception => ()
+        } finally {
+          latch.countDown()
+        }
+      }).start()
+    }
+
+    latch.await()
+    assertEquals(removed.get(), 1)
+    assert(map.get("t1") == null)
+  }
+}


### PR DESCRIPTION
## Summary

`KafkaMessageTrackerPool` accumulated one tracker actor per unique `consumerTopic` forever, and `DynamicKafkaConsumer` only ever grew its subscription set. Under dynamic reply-topic patterns (per-user or per-request reply topics) this caused unbounded memory growth and progressively more expensive rebalances.

## Changes

- `KafkaMessageTracker.MessagePublished` gains an `onComplete: () => Unit` callback (default no-op, no API break) called when the request completes — either via `MessageConsumed` or `TimeoutScan`
- `KafkaMessageTrackerPool` adds reference counting (`trackerRefCounts`) and `releaseTracker(consumerTopic)`: decrements refcount, removes tracker from map and unsubscribes consumer topic when count reaches zero
- `DynamicKafkaConsumer` gains `removeTopicSubscription(topic)` (queues for removal) and `applyRemovals()` (drains queue and resubscribes without the removed topics each poll cycle)
- `KafkaRequestReplyAction` passes `onComplete = () => trackers.releaseTracker(consumerTopic)` so cleanup is triggered automatically after each request

## Testing

Static topics (shared across requests) are safe: refcount reaches zero only when all in-flight requests for that topic have completed. Static topics with concurrent requests will have refcount > 1 and won't be prematurely cleaned up.

Fixes #78