### PR TITLE
fix: register trackerPools eviction hook before pool creation to respect LIFO order

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/protocol/KafkaProtocol.scala
@@ -70,19 +70,20 @@ object KafkaProtocol {
           trackerPools.computeIfAbsent(
             servers.toString,
             _ => {
-              val key  = servers.toString
-              val pool = KafkaMessageTrackerPool(
+              val key = servers.toString
+              // Register eviction BEFORE creating the pool. registerOnTermination is LIFO,
+              // so the pool's own consumer.close() hook (registered inside its constructor)
+              // will fire FIRST on shutdown, then this eviction hook fires — ensuring the
+              // consumer is fully closed before a new simulation can create a replacement pool.
+              coreComponents.actorSystem.registerOnTermination {
+                trackerPools.remove(key)
+              }
+              KafkaMessageTrackerPool(
                 protocol.consumerProperties,
                 coreComponents.actorSystem,
                 coreComponents.statsEngine,
                 coreComponents.clock,
               )
-              // Evict on termination so a subsequent simulation doesn't get a stale pool
-              // with a closed DynamicKafkaConsumer.
-              coreComponents.actorSystem.registerOnTermination {
-                trackerPools.remove(key)
-              }
-              pool
             },
           ),
         )


### PR DESCRIPTION
## Summary

`registerOnTermination` hooks fire in LIFO order. The previous fix registered the cache-eviction hook (`trackerPools.remove(key)`) AFTER creating the pool — meaning eviction fired FIRST on shutdown, opening a window where a new simulation could create a replacement pool while the old consumer was still running (same group-id, two consumers → rebalance storm).

## Changes

- Register `trackerPools.remove(key)` BEFORE calling `KafkaMessageTrackerPool(...)`. With LIFO order this ensures:
  1. `consumer.close()` fires first (registered last, inside pool constructor)
  2. `trackerPools.remove(key)` fires second (registered first, here)
- Consumer is fully closed before the cache entry is evicted and a new simulation can create a replacement pool.

## Testing

Compiles clean against full test suite.

Follows up on #80 / PR #118.