### PR TITLE
fix: prevent duplicate publish and release in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
             git push origin "$NEXT_TAG"
           fi
       - name: Publish to Sonatype via sbt-ci-release
-        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
+        if: startsWith(github.ref, 'refs/tags/v')
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -209,14 +209,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            TAG="${GITHUB_REF##*/}"
-          else
-            TAG="${{ steps.bump.outputs.tag }}"
-            export GITHUB_REF="refs/tags/${TAG}"
-            export GITHUB_REF_NAME="${TAG}"
-          fi
-
+          TAG="${GITHUB_REF##*/}"
           VERSION="${TAG#v}"
           echo "Publishing version $VERSION (tag $TAG)"
 
@@ -232,11 +225,9 @@ jobs:
       - name: Generate Changelog
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v5
-        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           mode: "COMMIT"
-          fromTag: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.last_tag || '' }}
-          toTag:   ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || '' }}
           configurationJson: |
             {
               "template": "# Changelog\n\n#{{CHANGELOG}}",
@@ -263,10 +254,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || '' }}
           body: ${{ steps.changelog.outputs.changelog }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Prevents duplicate publish and release executions in the tag-driven CI workflow.

### Problem

The `release` job runs on both `push to main` and `push to v* tags`. When code merges to main, the workflow:
1. Runs on the main push, computes a version tag, creates and pushes the tag
2. The tag push triggers **another** workflow run
3. Both runs attempt to publish to Sonatype and create a GitHub release, causing duplicates

### Fix

Separate responsibilities between main pushes and tag pushes:
- **main push** → only computes and pushes the version tag (no publish, no release)
- **tag push** → publishes to Sonatype and creates the GitHub Release (no tag creation)

Specific changes:
- "Publish to Sonatype" step: condition changed to only run on tag pushes (`startsWith(github.ref, 'refs/tags/v')`), and removed the synthetic `GITHUB_REF` override that was needed for the main-push path
- "Generate Changelog" step: condition changed to only run on tag pushes
- "Create GitHub Release" step: condition changed to only run on tag pushes, removed the now-unnecessary `tag_name` override
- The release job's top-level `if` is unchanged — it still runs on both main and tags so the tag-creation step continues to work on main pushes

Fixes #87