### PR TITLE
fix: fail fast when request-reply configured without consumer settings

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -39,46 +39,63 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
         }
         val id = components.kafkaProtocol.messageMatcher.requestMatch(protocolMessage)
 
-        components.trackersPool.map { trackers =>
-          val consumerTopic   = protocolMessage.consumerTopic
-          var trackerAcquired = false
-          try {
-            val tracker = trackers.tracker(
-              protocolMessage.producerTopic,
-              consumerTopic,
-              components.kafkaProtocol.messageMatcher,
-              None,
-              components.kafkaProtocol.timeout,
-            )
-            trackerAcquired = true
-            tracker ! KafkaMessageTracker
-              .MessagePublished(
-                id,
-                clock.nowMillis,
-                components.kafkaProtocol.timeout.toMillis,
-                attributes.checks,
-                session,
-                next,
-                requestNameString,
-                onComplete = () => trackers.releaseTracker(consumerTopic),
-              )
-          } catch {
-            case e: Exception =>
-              if (trackerAcquired) trackers.releaseTracker(consumerTopic)
-              val requestEndDate = clock.nowMillis
-              logger.error(e.getMessage, e)
-              statsEngine.logResponse(
-                session.scenario,
-                session.groups,
-                requestNameString,
-                requestStartDate,
-                requestEndDate,
-                KO,
+        components.trackersPool match {
+          case Some(trackers) =>
+            val consumerTopic   = protocolMessage.consumerTopic
+            var trackerAcquired = false
+            try {
+              val tracker = trackers.tracker(
+                protocolMessage.producerTopic,
+                consumerTopic,
+                components.kafkaProtocol.messageMatcher,
                 None,
-                Some(e.getMessage),
+                components.kafkaProtocol.timeout,
               )
-              next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
-          }
+              trackerAcquired = true
+              tracker ! KafkaMessageTracker
+                .MessagePublished(
+                  id,
+                  clock.nowMillis,
+                  components.kafkaProtocol.timeout.toMillis,
+                  attributes.checks,
+                  session,
+                  next,
+                  requestNameString,
+                  onComplete = () => trackers.releaseTracker(consumerTopic),
+                )
+            } catch {
+              case e: Exception =>
+                if (trackerAcquired) trackers.releaseTracker(consumerTopic)
+                val requestEndDate = clock.nowMillis
+                logger.error(e.getMessage, e)
+                statsEngine.logResponse(
+                  session.scenario,
+                  session.groups,
+                  requestNameString,
+                  requestStartDate,
+                  requestEndDate,
+                  KO,
+                  None,
+                  Some(e.getMessage),
+                )
+                next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
+            }
+          case None           =>
+            val requestEndDate = clock.nowMillis
+            val msg            =
+              "Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration"
+            logger.error(msg)
+            statsEngine.logResponse(
+              session.scenario,
+              session.groups,
+              requestNameString,
+              requestStartDate,
+              requestEndDate,
+              KO,
+              None,
+              Some(msg),
+            )
+            next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
         }
       },
       e => {

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -83,7 +83,8 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
           case None           =>
             val requestEndDate = clock.nowMillis
             val msg            =
-              "Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration"
+              s"Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration, " +
+                s"otherwise the virtual user will hang for ${components.kafkaProtocol.timeout} with no reply"
             logger.error(msg)
             statsEngine.logResponse(
               session.scenario,


### PR DESCRIPTION
## Summary

- When `trackersPool` is `None` (no `consumeSettings` configured), `KafkaRequestReplyAction` now immediately fails the request with a clear error message instead of silently hanging the virtual user indefinitely.
- Changed `components.trackersPool.map { ... }` to a pattern match that handles the `None` case by logging an error, reporting KO to the stats engine, and advancing the session as failed.

Fixes #86

## Test plan

- [ ] Verify compilation passes
- [ ] Confirm that a request-reply scenario without `consumeSettings` now fails fast with a descriptive error instead of hanging
- [ ] Confirm that existing request-reply scenarios with proper consumer settings continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)