### PR TITLE
fix: isolate reply-topic trackers by matcher identity

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -42,12 +42,13 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
         components.trackersPool match {
           case Some(trackers) =>
             val consumerTopic   = protocolMessage.consumerTopic
+            val matcher         = components.kafkaProtocol.messageMatcher
             var trackerAcquired = false
             try {
               val tracker = trackers.tracker(
                 protocolMessage.producerTopic,
                 consumerTopic,
-                components.kafkaProtocol.messageMatcher,
+                matcher,
                 None,
                 components.kafkaProtocol.timeout,
               )
@@ -61,11 +62,11 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
                   session,
                   next,
                   requestNameString,
-                  onComplete = () => trackers.releaseTracker(consumerTopic),
+                  onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
                 )
             } catch {
               case e: Exception =>
-                if (trackerAcquired) trackers.releaseTracker(consumerTopic)
+                if (trackerAcquired) trackers.releaseTracker(consumerTopic, matcher)
                 val requestEndDate = clock.nowMillis
                 logger.error(e.getMessage, e)
                 statsEngine.logResponse(

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -40,12 +40,7 @@ final class KafkaMessageTrackerPool(
       refCount: AtomicInteger,
   )
 
-  /** Two-level map: consumerTopic -> (matcherKey -> TrackerEntry).
-    *
-    * The outer key is the Kafka topic so that the consumer callback can fan-out a received record to every tracker listening on
-    * that topic. The inner key incorporates the matcher's identity so that two request-reply flows sharing the same reply topic
-    * but using different [[KafkaMatcher]] instances get independent trackers.
-    */
+  // consumerTopic -> (matcherKey -> TrackerEntry)
   private val trackers    = new ConcurrentHashMap[String, ConcurrentHashMap[String, TrackerEntry]]
   private val trackerName = "kafkaTracker"
 
@@ -103,23 +98,23 @@ final class KafkaMessageTrackerPool(
 
     val mKey = matcherKey(messageMatcher)
 
-    // Fast path: atomic get-and-increment via computeIfPresent on the inner map —
-    // avoids holding the CHM bin lock during the blocking addTopicForSubscription
-    // in the slow path, while ensuring the refcount increment is atomic with the
-    // presence check (no race window with a concurrent releaseTracker that removes
-    // the entry).
+    // Fast path: outer computeIfPresent holds the bin lock while we touch the inner
+    // map, so a concurrent releaseTracker cannot remove the outer entry in between.
     var found: ActorRef[KafkaMessageTracker.TrackerMessage] = null
-    val innerMap                                            = trackers.get(consumerTopic)
-    if (innerMap != null) {
-      innerMap.computeIfPresent(
-        mKey,
-        (_, entry) => {
-          entry.refCount.incrementAndGet()
-          found = entry.actor
-          entry
-        },
-      )
-    }
+    trackers.computeIfPresent(
+      consumerTopic,
+      (_, innerMap) => {
+        innerMap.computeIfPresent(
+          mKey,
+          (_, entry) => {
+            entry.refCount.incrementAndGet()
+            found = entry.actor
+            entry
+          },
+        )
+        innerMap
+      },
+    )
     if (found != null) return found
 
     // Slow path: subscribe first (blocking, no CHM lock held), then create actor and register.
@@ -148,52 +143,53 @@ final class KafkaMessageTrackerPool(
       ),
     )
 
-    // Atomic insert-or-increment: if a concurrent thread won the race and already
-    // registered a tracker for this (topic, matcher), increment their refcount and
-    // use their actor. The losing thread's actor receives no messages and is GC'd
-    // at actor system termination.
+    // Atomic insert-or-increment under the outer bin lock so a concurrent
+    // releaseTracker cannot remove the outer entry between get-or-create and insert.
     var result: ActorRef[KafkaMessageTracker.TrackerMessage] = null
-    val topicMap                                             =
-      trackers.computeIfAbsent(consumerTopic, _ => new ConcurrentHashMap[String, TrackerEntry]())
-    topicMap.compute(
-      mKey,
+    trackers.compute(
+      consumerTopic,
       (_, existing) => {
-        if (existing != null) {
-          existing.refCount.incrementAndGet()
-          result = existing.actor
-          existing
-        } else {
-          result = newActor
-          TrackerEntry(newActor, new AtomicInteger(1))
-        }
+        val innerMap = if (existing != null) existing else new ConcurrentHashMap[String, TrackerEntry]()
+        innerMap.compute(
+          mKey,
+          (_, entry) => {
+            if (entry != null) {
+              entry.refCount.incrementAndGet()
+              result = entry.actor
+              entry
+            } else {
+              result = newActor
+              TrackerEntry(newActor, new AtomicInteger(1))
+            }
+          },
+        )
+        innerMap
       },
     )
     result
   }
 
   def releaseTracker(consumerTopic: String, messageMatcher: KafkaMatcher): Unit = {
-    val mKey      = matcherKey(messageMatcher)
-    // Atomic decrement-and-remove: computeIfPresent serialises with the fast-path
-    // computeIfPresent and the slow-path compute, so no window exists where a
-    // concurrent tracker() call can observe a stale entry.
-    var doCleanup = false
-    val innerMap  = trackers.get(consumerTopic)
-    if (innerMap != null) {
-      innerMap.computeIfPresent(
-        mKey,
-        (_, entry) => {
-          if (entry.refCount.decrementAndGet() <= 0) {
-            doCleanup = true
-            null
-          } else entry
-        },
-      )
-      // If the inner map is now empty, remove the topic entry and unsubscribe.
-      if (doCleanup && innerMap.isEmpty) {
-        // Remove the outer entry only if it's still the same (empty) inner map.
-        trackers.remove(consumerTopic, innerMap)
-        consumer.removeTopicSubscription(consumerTopic)
-      }
+    val mKey          = matcherKey(messageMatcher)
+    var doUnsubscribe = false
+    trackers.computeIfPresent(
+      consumerTopic,
+      (_, innerMap) => {
+        innerMap.computeIfPresent(
+          mKey,
+          (_, entry) => {
+            if (entry.refCount.decrementAndGet() <= 0) null
+            else entry
+          },
+        )
+        if (innerMap.isEmpty) {
+          doUnsubscribe = true
+          null
+        } else innerMap
+      },
+    )
+    if (doUnsubscribe) {
+      consumer.removeTopicSubscription(consumerTopic)
     }
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -40,12 +40,17 @@ final class KafkaMessageTrackerPool(
       refCount: AtomicInteger,
   )
 
-  // consumerTopic -> (matcherKey -> TrackerEntry)
-  private val trackers    = new ConcurrentHashMap[String, ConcurrentHashMap[String, TrackerEntry]]
-  private val trackerName = "kafkaTracker"
+  // Uses reference equality so distinct matcher instances with the same identityHashCode
+  // are never conflated (identityHashCode collisions only affect bucket distribution).
+  private class MatcherRef(val matcher: KafkaMatcher) {
+    override def hashCode(): Int           = System.identityHashCode(matcher)
+    override def equals(obj: Any): Boolean = obj.isInstanceOf[MatcherRef] && (matcher eq obj.asInstanceOf[MatcherRef].matcher)
+    override def toString: String          = s"${matcher.getClass.getSimpleName}@${System.identityHashCode(matcher)}"
+  }
 
-  private def matcherKey(messageMatcher: KafkaMatcher): String =
-    s"${messageMatcher.getClass.getName}@${System.identityHashCode(messageMatcher)}"
+  // consumerTopic -> (MatcherRef -> TrackerEntry)
+  private val trackers    = new ConcurrentHashMap[String, ConcurrentHashMap[MatcherRef, TrackerEntry]]
+  private val trackerName = "kafkaTracker"
 
   // Per-instance executor so shutdown of one pool doesn't affect other pools or subsequent simulations.
   private val consumerExecutor: ExecutorService = Executors.newSingleThreadExecutor()
@@ -60,6 +65,8 @@ final class KafkaMessageTrackerPool(
       record => {
         val kafkaProtocolMessage = KafkaProtocolMessage.from(record, None)
         val receivedTimestamp    = clock.nowMillis
+        // Lock-free read: a stale snapshot after concurrent removal is benign —
+        // the tracker actor simply won't match any pending request.
         Option(trackers.get(record.topic())).foreach { innerMap =>
           innerMap.values().forEach { entry =>
             entry.actor ! MessageConsumed(
@@ -96,7 +103,7 @@ final class KafkaMessageTrackerPool(
       timeout: FiniteDuration,
   ): ActorRef[KafkaMessageTracker.TrackerMessage] = {
 
-    val mKey = matcherKey(messageMatcher)
+    val mRef = new MatcherRef(messageMatcher)
 
     // Fast path: outer computeIfPresent holds the bin lock while we touch the inner
     // map, so a concurrent releaseTracker cannot remove the outer entry in between.
@@ -105,7 +112,7 @@ final class KafkaMessageTrackerPool(
       consumerTopic,
       (_, innerMap) => {
         innerMap.computeIfPresent(
-          mKey,
+          mRef,
           (_, entry) => {
             entry.refCount.incrementAndGet()
             found = entry.actor
@@ -121,7 +128,7 @@ final class KafkaMessageTrackerPool(
     logger.debug(
       "Creating new tracker for topic {} matcher {}, there are currently {} other topic entries",
       consumerTopic,
-      mKey,
+      mRef,
       trackers.size(),
     )
     val assigned        = consumer.addTopicForSubscription(consumerTopic, timeout)
@@ -149,9 +156,9 @@ final class KafkaMessageTrackerPool(
     trackers.compute(
       consumerTopic,
       (_, existing) => {
-        val innerMap = if (existing != null) existing else new ConcurrentHashMap[String, TrackerEntry]()
+        val innerMap = if (existing != null) existing else new ConcurrentHashMap[MatcherRef, TrackerEntry]()
         innerMap.compute(
-          mKey,
+          mRef,
           (_, entry) => {
             if (entry != null) {
               entry.refCount.incrementAndGet()
@@ -170,13 +177,13 @@ final class KafkaMessageTrackerPool(
   }
 
   def releaseTracker(consumerTopic: String, messageMatcher: KafkaMatcher): Unit = {
-    val mKey          = matcherKey(messageMatcher)
+    val mRef          = new MatcherRef(messageMatcher)
     var doUnsubscribe = false
     trackers.computeIfPresent(
       consumerTopic,
       (_, innerMap) => {
         innerMap.computeIfPresent(
-          mKey,
+          mRef,
           (_, entry) => {
             if (entry.refCount.decrementAndGet() <= 0) null
             else entry

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -40,8 +40,17 @@ final class KafkaMessageTrackerPool(
       refCount: AtomicInteger,
   )
 
-  private val trackers    = new ConcurrentHashMap[String, TrackerEntry]
+  /** Two-level map: consumerTopic -> (matcherKey -> TrackerEntry).
+    *
+    * The outer key is the Kafka topic so that the consumer callback can fan-out a received record to every tracker listening on
+    * that topic. The inner key incorporates the matcher's identity so that two request-reply flows sharing the same reply topic
+    * but using different [[KafkaMatcher]] instances get independent trackers.
+    */
+  private val trackers    = new ConcurrentHashMap[String, ConcurrentHashMap[String, TrackerEntry]]
   private val trackerName = "kafkaTracker"
+
+  private def matcherKey(messageMatcher: KafkaMatcher): String =
+    s"${messageMatcher.getClass.getName}@${System.identityHashCode(messageMatcher)}"
 
   // Per-instance executor so shutdown of one pool doesn't affect other pools or subsequent simulations.
   private val consumerExecutor: ExecutorService = Executors.newSingleThreadExecutor()
@@ -56,12 +65,14 @@ final class KafkaMessageTrackerPool(
       record => {
         val kafkaProtocolMessage = KafkaProtocolMessage.from(record, None)
         val receivedTimestamp    = clock.nowMillis
-        Option(trackers.get(record.topic())).foreach(
-          _.actor ! MessageConsumed(
-            receivedTimestamp,
-            kafkaProtocolMessage,
-          ),
-        )
+        Option(trackers.get(record.topic())).foreach { innerMap =>
+          innerMap.values().forEach { entry =>
+            entry.actor ! MessageConsumed(
+              receivedTimestamp,
+              kafkaProtocolMessage,
+            )
+          }
+        }
       },
       exception => logger.error(exception.getMessage, exception),
     )
@@ -90,25 +101,32 @@ final class KafkaMessageTrackerPool(
       timeout: FiniteDuration,
   ): ActorRef[KafkaMessageTracker.TrackerMessage] = {
 
-    // Fast path: atomic get-and-increment via computeIfPresent — avoids holding the
-    // CHM bin lock during the blocking addTopicForSubscription in the slow path,
-    // while ensuring the refcount increment is atomic with the presence check
-    // (no race window with a concurrent releaseTracker that removes the entry).
+    val mKey = matcherKey(messageMatcher)
+
+    // Fast path: atomic get-and-increment via computeIfPresent on the inner map —
+    // avoids holding the CHM bin lock during the blocking addTopicForSubscription
+    // in the slow path, while ensuring the refcount increment is atomic with the
+    // presence check (no race window with a concurrent releaseTracker that removes
+    // the entry).
     var found: ActorRef[KafkaMessageTracker.TrackerMessage] = null
-    trackers.computeIfPresent(
-      consumerTopic,
-      (_, entry) => {
-        entry.refCount.incrementAndGet()
-        found = entry.actor
-        entry
-      },
-    )
+    val innerMap                                            = trackers.get(consumerTopic)
+    if (innerMap != null) {
+      innerMap.computeIfPresent(
+        mKey,
+        (_, entry) => {
+          entry.refCount.incrementAndGet()
+          found = entry.actor
+          entry
+        },
+      )
+    }
     if (found != null) return found
 
     // Slow path: subscribe first (blocking, no CHM lock held), then create actor and register.
     logger.debug(
-      "Creating new tracker for topic {}, there are currently {} other trackers",
+      "Creating new tracker for topic {} matcher {}, there are currently {} other topic entries",
       consumerTopic,
+      mKey,
       trackers.size(),
     )
     val assigned        = consumer.addTopicForSubscription(consumerTopic, timeout)
@@ -131,11 +149,14 @@ final class KafkaMessageTrackerPool(
     )
 
     // Atomic insert-or-increment: if a concurrent thread won the race and already
-    // registered a tracker, increment their refcount and use their actor.
-    // The losing thread's actor receives no messages and is GC'd at actor system termination.
+    // registered a tracker for this (topic, matcher), increment their refcount and
+    // use their actor. The losing thread's actor receives no messages and is GC'd
+    // at actor system termination.
     var result: ActorRef[KafkaMessageTracker.TrackerMessage] = null
-    trackers.compute(
-      consumerTopic,
+    val topicMap                                             =
+      trackers.computeIfAbsent(consumerTopic, _ => new ConcurrentHashMap[String, TrackerEntry]())
+    topicMap.compute(
+      mKey,
       (_, existing) => {
         if (existing != null) {
           existing.refCount.incrementAndGet()
@@ -150,22 +171,29 @@ final class KafkaMessageTrackerPool(
     result
   }
 
-  def releaseTracker(consumerTopic: String): Unit = {
+  def releaseTracker(consumerTopic: String, messageMatcher: KafkaMatcher): Unit = {
+    val mKey      = matcherKey(messageMatcher)
     // Atomic decrement-and-remove: computeIfPresent serialises with the fast-path
     // computeIfPresent and the slow-path compute, so no window exists where a
     // concurrent tracker() call can observe a stale entry.
     var doCleanup = false
-    trackers.computeIfPresent(
-      consumerTopic,
-      (_, entry) => {
-        if (entry.refCount.decrementAndGet() <= 0) {
-          doCleanup = true
-          null
-        } else entry
-      },
-    )
-    if (doCleanup) {
-      consumer.removeTopicSubscription(consumerTopic)
+    val innerMap  = trackers.get(consumerTopic)
+    if (innerMap != null) {
+      innerMap.computeIfPresent(
+        mKey,
+        (_, entry) => {
+          if (entry.refCount.decrementAndGet() <= 0) {
+            doCleanup = true
+            null
+          } else entry
+        },
+      )
+      // If the inner map is now empty, remove the topic entry and unsubscribe.
+      if (doCleanup && innerMap.isEmpty) {
+        // Remove the outer entry only if it's still the same (empty) inner map.
+        trackers.remove(consumerTopic, innerMap)
+        consumer.removeTopicSubscription(consumerTopic)
+      }
     }
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/TrackerRefCountSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/TrackerRefCountSpec.scala
@@ -4,11 +4,19 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, CyclicBarrier}
 
 /** Tests the ConcurrentHashMap refcount algorithm used by KafkaMessageTrackerPool. Exercises the same computeIfPresent/compute
-  * pattern against concurrent acquire+release.
+  * pattern against concurrent acquire+release, including the two-level map used for matcher isolation.
   */
 class TrackerRefCountSpec extends munit.FunSuite {
 
   private case class Entry(value: String, refCount: AtomicInteger)
+
+  // Identity-based key mirroring KafkaMessageTrackerPool.MatcherRef
+  private class IdentityKey(val id: AnyRef) {
+    override def hashCode(): Int           = System.identityHashCode(id)
+    override def equals(obj: Any): Boolean = obj.isInstanceOf[IdentityKey] && (id eq obj.asInstanceOf[IdentityKey].id)
+  }
+
+  // --- Single-level helpers (original algorithm) ---
 
   private def acquire(map: ConcurrentHashMap[String, Entry], key: String, newValue: String): String = {
     var found: String = null
@@ -52,6 +60,74 @@ class TrackerRefCountSpec extends munit.FunSuite {
     )
     removed
   }
+
+  // --- Two-level helpers (mirrors KafkaMessageTrackerPool with MatcherRef) ---
+
+  private type InnerMap = ConcurrentHashMap[IdentityKey, Entry]
+  private type OuterMap = ConcurrentHashMap[String, InnerMap]
+
+  private def acquire2(map: OuterMap, topic: String, matcherRef: IdentityKey, newValue: String): String = {
+    var found: String = null
+    map.computeIfPresent(
+      topic,
+      (_, innerMap) => {
+        innerMap.computeIfPresent(
+          matcherRef,
+          (_, entry) => {
+            entry.refCount.incrementAndGet()
+            found = entry.value
+            entry
+          },
+        )
+        innerMap
+      },
+    )
+    if (found != null) return found
+
+    var result: String = null
+    map.compute(
+      topic,
+      (_, existing) => {
+        val innerMap = if (existing != null) existing else new ConcurrentHashMap[IdentityKey, Entry]()
+        innerMap.compute(
+          matcherRef,
+          (_, entry) => {
+            if (entry != null) {
+              entry.refCount.incrementAndGet()
+              result = entry.value
+              entry
+            } else {
+              result = newValue
+              Entry(newValue, new AtomicInteger(1))
+            }
+          },
+        )
+        innerMap
+      },
+    )
+    result
+  }
+
+  private def release2(map: OuterMap, topic: String, matcherRef: IdentityKey): Boolean = {
+    var topicRemoved = false
+    map.computeIfPresent(
+      topic,
+      (_, innerMap) => {
+        innerMap.computeIfPresent(
+          matcherRef,
+          (_, entry) => {
+            if (entry.refCount.decrementAndGet() <= 0) null
+            else entry
+          },
+        )
+        if (innerMap.isEmpty) { topicRemoved = true; null }
+        else innerMap
+      },
+    )
+    topicRemoved
+  }
+
+  // ==================== Single-level tests ====================
 
   test("acquire increments refcount, release decrements to zero and removes") {
     val map = new ConcurrentHashMap[String, Entry]()
@@ -156,5 +232,139 @@ class TrackerRefCountSpec extends munit.FunSuite {
     latch.await()
     assertEquals(removed.get(), 1)
     assert(map.get("t1") == null)
+  }
+
+  // ==================== Two-level tests (matcher isolation) ====================
+
+  test("two-level: different matchers on same topic get independent trackers") {
+    val map      = new OuterMap()
+    val matcher1 = new Object
+    val matcher2 = new Object
+    val ref1     = new IdentityKey(matcher1)
+    val ref2     = new IdentityKey(matcher2)
+
+    val v1 = acquire2(map, "reply-topic", ref1, "tracker-key")
+    val v2 = acquire2(map, "reply-topic", ref2, "tracker-value")
+
+    assertEquals(v1, "tracker-key")
+    assertEquals(v2, "tracker-value")
+    assertEquals(map.get("reply-topic").size(), 2)
+
+    // Release one matcher — topic stays (other matcher still active)
+    assert(!release2(map, "reply-topic", ref1))
+    assert(map.get("reply-topic") != null)
+    assertEquals(map.get("reply-topic").size(), 1)
+
+    // Release the other — topic removed
+    assert(release2(map, "reply-topic", ref2))
+    assert(map.get("reply-topic") == null)
+  }
+
+  test("two-level: same matcher instance reuses tracker via refcount") {
+    val map     = new OuterMap()
+    val matcher = new Object
+    val ref     = new IdentityKey(matcher)
+
+    val v1 = acquire2(map, "topic", ref, "actor-1")
+    val v2 = acquire2(map, "topic", ref, "actor-2")
+    assertEquals(v1, "actor-1")
+    assertEquals(v2, "actor-1")
+    assertEquals(map.get("topic").get(ref).refCount.get(), 2)
+
+    assert(!release2(map, "topic", ref))
+    assertEquals(map.get("topic").get(ref).refCount.get(), 1)
+
+    assert(release2(map, "topic", ref))
+    assert(map.get("topic") == null)
+  }
+
+  test("two-level: IdentityKey distinguishes objects with same identityHashCode") {
+    // Force collision by wrapping different objects with overridden hashCode
+    class CollidingKey(val id: AnyRef) {
+      override def hashCode(): Int           = 42
+      override def equals(obj: Any): Boolean = obj.isInstanceOf[CollidingKey] && (id eq obj.asInstanceOf[CollidingKey].id)
+    }
+
+    val innerMap = new ConcurrentHashMap[CollidingKey, Entry]()
+    val obj1     = new Object
+    val obj2     = new Object
+    val k1       = new CollidingKey(obj1)
+    val k2       = new CollidingKey(obj2)
+
+    innerMap.put(k1, Entry("a", new AtomicInteger(1)))
+    innerMap.put(k2, Entry("b", new AtomicInteger(1)))
+
+    assertEquals(innerMap.size(), 2)
+    assertEquals(innerMap.get(k1).value, "a")
+    assertEquals(innerMap.get(k2).value, "b")
+
+    // Lookup with fresh wrapper for same ref works
+    assertEquals(innerMap.get(new CollidingKey(obj1)).value, "a")
+
+    // Lookup with wrapper for different ref does not cross-match
+    assert(innerMap.get(new CollidingKey(new Object)) == null)
+  }
+
+  test("two-level: concurrent acquire+release across multiple matchers") {
+    val map      = new OuterMap()
+    val matchers = (0 until 4).map(_ => new Object)
+    val refs     = matchers.map(new IdentityKey(_))
+    val threads  = 100
+    val barrier  = new CyclicBarrier(threads)
+    val latch    = new CountDownLatch(threads)
+    val errors   = new AtomicInteger(0)
+    val topic    = "shared-reply"
+
+    // Seed each matcher
+    refs.zipWithIndex.foreach { case (ref, i) =>
+      acquire2(map, topic, ref, s"seed-$i")
+    }
+
+    // Each thread picks a random matcher, acquires, yields, releases
+    (0 until threads).foreach { i =>
+      new Thread(() => {
+        try {
+          barrier.await()
+          val ref  = refs(i % refs.length)
+          val seed = s"seed-${i % refs.length}"
+          val v    = acquire2(map, topic, ref, s"actor-$i")
+          if (v != seed) errors.incrementAndGet()
+          Thread.`yield`()
+          release2(map, topic, ref)
+        } catch {
+          case _: Exception => errors.incrementAndGet()
+        } finally {
+          latch.countDown()
+        }
+      }).start()
+    }
+
+    latch.await()
+    assertEquals(errors.get(), 0)
+
+    // Each seed refcount remains at 1
+    refs.foreach { ref =>
+      assertEquals(map.get(topic).get(ref).refCount.get(), 1)
+    }
+
+    // Release all seeds — topic removed after last
+    refs.init.foreach { ref =>
+      assert(!release2(map, topic, ref))
+    }
+    assert(release2(map, topic, refs.last))
+    assert(map.get(topic) == null)
+  }
+
+  test("two-level: release on wrong matcher is no-op") {
+    val map      = new OuterMap()
+    val matcher  = new Object
+    val other    = new Object
+    val ref      = new IdentityKey(matcher)
+    val wrongRef = new IdentityKey(other)
+
+    acquire2(map, "topic", ref, "actor")
+    assert(!release2(map, "topic", wrongRef))
+    // Original still present
+    assertEquals(map.get("topic").get(ref).refCount.get(), 1)
   }
 }


### PR DESCRIPTION
## Summary

- Fix tracker pool to use a two-level cache key (`consumerTopic` + matcher identity) instead of `consumerTopic` alone, so two request-reply flows sharing the same reply topic but using different `KafkaMatcher` implementations get independent trackers.
- Fan out consumed records to all trackers registered for a topic, letting each matcher decide independently whether a message matches a pending request.
- Update `releaseTracker` to accept the matcher parameter and only unsubscribe from the topic when no trackers remain for it.

Fixes #85

## Test plan

- [ ] Verify compilation passes (`sbt compile`)
- [ ] Existing request-reply tests continue to pass
- [ ] Two flows with different matchers on the same reply topic each correlate correctly
- [ ] Releasing one flow's tracker does not unsubscribe the topic while the other flow still uses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)