### PR TITLE
fix: propagate background consumer failures instead of surfacing as reply timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,12 @@ jobs:
           restore-keys: sbt-${{ runner.os }}-
 
       - name: Check Formatting
-        run: sbt scalafmtCheckAll scalafmtSbtCheck
+        run: |
+          sbt scalafmtAll scalafmtSbt
+          if ! git diff --exit-code; then
+            echo "::error::Files were reformatted by scalafmt. See diff above."
+            exit 1
+          fi
 
       - name: Compile
         run: sbt clean compile

--- a/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
@@ -128,10 +128,12 @@ final class DynamicKafkaConsumer[K, V] private (
       case e: WakeupException =>
         // Ignore exception if closing
         // rethrow when someone call wakeup while it is working
-        if (running.get) throw e
+        if (running.get) {
+          this.onFailure(e)
+        }
       case e: Exception       =>
-        // unexpected exception
-        throw new RuntimeException(e)
+        // Propagate unexpected exception through the failure callback
+        this.onFailure(e)
     } finally {
       this.topicsQueue.clear()
       consumer.close()

--- a/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
@@ -8,7 +8,7 @@ import org.apache.kafka.common.errors.WakeupException
 import java.time.Duration
 import java.util
 import java.util.Properties
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
 import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -42,9 +42,10 @@ final class DynamicKafkaConsumer[K, V] private (
 
   private val topicsToRemove: java.util.Queue[String] = new ConcurrentLinkedQueue[String]()
 
-  private val running: AtomicBoolean        = new AtomicBoolean(true)
-  private val consumer: KafkaConsumer[K, V] = new KafkaConsumer[K, V](settings)
-  private val initLatch: CountDownLatch     = if (this.topicsQueue.isEmpty) new CountDownLatch(1) else new CountDownLatch(0)
+  private val running: AtomicBoolean                      = new AtomicBoolean(true)
+  private val consumer: KafkaConsumer[K, V]               = new KafkaConsumer[K, V](settings)
+  private val initLatch: CountDownLatch                   = if (this.topicsQueue.isEmpty) new CountDownLatch(1) else new CountDownLatch(0)
+  private val consumerFailure: AtomicReference[Exception] = new AtomicReference[Exception](null)
 
   def removeTopicSubscription(topic: String): Unit =
     topicsToRemove.add(topic)
@@ -53,12 +54,36 @@ final class DynamicKafkaConsumer[K, V] private (
       newTopic: String,
       assignTimeout: FiniteDuration = DynamicKafkaConsumer.defaultAssignTimeout,
   ): Boolean = {
-    val latch = new CountDownLatch(1)
+    failIfConsumerFailed()
+    val latch    = new CountDownLatch(1)
     this.topicsQueue.add(newTopic, latch)
     if (initLatch.getCount > 0) {
       initLatch.countDown()
     }
-    latch.await(assignTimeout.length, assignTimeout.unit)
+    val assigned = latch.await(assignTimeout.length, assignTimeout.unit)
+    failIfConsumerFailed()
+    assigned
+  }
+
+  private def failIfConsumerFailed(): Unit = {
+    val failure = consumerFailure.get()
+    if (failure != null) {
+      throw new IllegalStateException("Kafka consumer failed; dynamic consumer can no longer be used", failure)
+    }
+  }
+
+  private def markConsumerFailed(exception: Exception): Unit = {
+    if (consumerFailure.compareAndSet(null, exception)) {
+      while (!topicsQueue.isEmpty) {
+        val (_, latch) = topicsQueue.poll()
+        if (latch != null) {
+          latch.countDown()
+        }
+      }
+      if (initLatch.getCount > 0) {
+        initLatch.countDown()
+      }
+    }
   }
 
   /** Applies pending topic additions and removals in a single consumer.subscribe call so the ConsumerRebalanceListener is never
@@ -129,10 +154,12 @@ final class DynamicKafkaConsumer[K, V] private (
         // Ignore exception if closing
         // rethrow when someone call wakeup while it is working
         if (running.get) {
+          markConsumerFailed(e)
           this.onFailure(e)
         }
       case e: Exception       =>
         // Propagate unexpected exception through the failure callback
+        markConsumerFailed(e)
         this.onFailure(e)
     } finally {
       this.topicsQueue.clear()

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -45,6 +45,8 @@ object KafkaMessageTracker {
       message: KafkaProtocolMessage,
   ) extends TrackerMessage
 
+  final case class ConsumerFailure(errorMessage: String) extends TrackerMessage
+
   private final case object TimeoutScan extends TrackerMessage
 
   private def makeKeyForSentMessages(m: Array[Byte]): String =
@@ -112,6 +114,27 @@ class KafkaMessageTracker[K, V](
             try processMessage(session, sentTimestamp, receivedTimestamp, checks, message, next, requestName)
             finally onComplete()
         }
+      }
+      stay
+
+    case ConsumerFailure(errorMessage) =>
+      val now = clock.nowMillis
+      logger.error("Consumer failure propagated to tracker: {}", errorMessage)
+      val pending = sentMessages.values.toList
+      sentMessages.clear()
+      for (mp <- pending) {
+        try
+          executeNext(
+            mp.session.markAsFailed,
+            mp.sentTimestamp,
+            now,
+            KO,
+            mp.next,
+            mp.requestName,
+            None,
+            Some(s"Consumer failure: $errorMessage"),
+          )
+        finally mp.onComplete()
       }
       stay
 

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -118,7 +118,7 @@ class KafkaMessageTracker[K, V](
       stay
 
     case ConsumerFailure(errorMessage) =>
-      val now = clock.nowMillis
+      val now     = clock.nowMillis
       logger.error("Consumer failure propagated to tracker: {}", errorMessage)
       val pending = sentMessages.values.toList
       sentMessages.clear()

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -50,8 +50,8 @@ final class KafkaMessageTrackerPool(
   }
 
   // consumerTopic -> (MatcherRef -> TrackerEntry)
-  private val trackers    = new ConcurrentHashMap[String, ConcurrentHashMap[MatcherRef, TrackerEntry]]
-  private val trackerName = "kafkaTracker"
+  private val trackers        = new ConcurrentHashMap[String, ConcurrentHashMap[MatcherRef, TrackerEntry]]
+  private val trackerName     = "kafkaTracker"
   private val consumerFailure = new AtomicReference[Exception](null)
 
   // Per-instance executor so shutdown of one pool doesn't affect other pools or subsequent simulations.

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -77,10 +77,14 @@ final class KafkaMessageTrackerPool(
         }
       },
       exception => {
-        logger.error("Consumer failure detected, propagating to {} active tracker(s): {}", trackers.size(), exception.getMessage)
+        logger.error(
+          "Consumer failure detected, propagating to {} active tracker(s): {}",
+          trackers.size(),
+          exception.getMessage,
+        )
         logger.debug("Consumer failure stacktrace", exception)
         val failure = KafkaMessageTracker.ConsumerFailure(exception.getMessage)
-        trackers.values().forEach(entry => entry.actor ! failure)
+        trackers.values().forEach(_.values().forEach(entry => entry.actor ! failure))
       },
     )
 

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -11,6 +11,7 @@ import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.{KafkaProtocolMessage, KafkaSerdesImplicits}
 
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{ConcurrentHashMap, ExecutorService, Executors}
 import scala.concurrent.duration.FiniteDuration
 
@@ -51,6 +52,7 @@ final class KafkaMessageTrackerPool(
   // consumerTopic -> (MatcherRef -> TrackerEntry)
   private val trackers    = new ConcurrentHashMap[String, ConcurrentHashMap[MatcherRef, TrackerEntry]]
   private val trackerName = "kafkaTracker"
+  private val consumerFailure = new AtomicReference[Exception](null)
 
   // Per-instance executor so shutdown of one pool doesn't affect other pools or subsequent simulations.
   private val consumerExecutor: ExecutorService = Executors.newSingleThreadExecutor()
@@ -83,8 +85,11 @@ final class KafkaMessageTrackerPool(
           exception.getMessage,
         )
         logger.debug("Consumer failure stacktrace", exception)
-        val failure = KafkaMessageTracker.ConsumerFailure(exception.getMessage)
-        trackers.values().forEach(_.values().forEach(entry => entry.actor ! failure))
+        if (consumerFailure.compareAndSet(null, exception)) {
+          val failure = KafkaMessageTracker.ConsumerFailure(exception.getMessage)
+          trackers.values().forEach(_.values().forEach(entry => entry.actor ! failure))
+          trackers.clear()
+        }
       },
     )
 
@@ -104,6 +109,13 @@ final class KafkaMessageTrackerPool(
   private def withProducerTopic(producerTopic: String): KafkaProtocolMessage => KafkaProtocolMessage =
     _.copy(producerTopic = producerTopic)
 
+  private def failIfConsumerFailed(): Unit = {
+    val failure = consumerFailure.get()
+    if (failure != null) {
+      throw new IllegalStateException("Kafka consumer failed; tracker pool can no longer be used", failure)
+    }
+  }
+
   def tracker(
       producerTopic: String,
       consumerTopic: String,
@@ -111,6 +123,7 @@ final class KafkaMessageTrackerPool(
       responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
       timeout: FiniteDuration,
   ): ActorRef[KafkaMessageTracker.TrackerMessage] = {
+    failIfConsumerFailed()
 
     val mRef = new MatcherRef(messageMatcher)
 
@@ -134,6 +147,7 @@ final class KafkaMessageTrackerPool(
     if (found != null) return found
 
     // Slow path: subscribe first (blocking, no CHM lock held), then create actor and register.
+    failIfConsumerFailed()
     logger.debug(
       "Creating new tracker for topic {} matcher {}, there are currently {} other topic entries",
       consumerTopic,

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -76,7 +76,12 @@ final class KafkaMessageTrackerPool(
           }
         }
       },
-      exception => logger.error(exception.getMessage, exception),
+      exception => {
+        logger.error("Consumer failure detected, propagating to {} active tracker(s): {}", trackers.size(), exception.getMessage)
+        logger.debug("Consumer failure stacktrace", exception)
+        val failure = KafkaMessageTracker.ConsumerFailure(exception.getMessage)
+        trackers.values().forEach(entry => entry.actor ! failure)
+      },
     )
 
   private val consumerFuture = consumerExecutor.submit(consumer)

--- a/src/test/scala/io/gatling/core/stats/RecordingStatsEngine.scala
+++ b/src/test/scala/io/gatling/core/stats/RecordingStatsEngine.scala
@@ -1,0 +1,52 @@
+package io.gatling.core.stats
+
+import io.gatling.commons.stats.Status
+import io.gatling.core.actor.ActorRef
+import io.gatling.core.controller.Controller
+import io.gatling.core.session.GroupBlock
+
+import java.util.concurrent.atomic.AtomicReference
+
+final case class LoggedResponse(
+    requestName: String,
+    startTimestamp: Long,
+    endTimestamp: Long,
+    status: Status,
+    message: Option[String],
+)
+
+final class RecordingStatsEngine extends StatsEngine {
+  val responses: AtomicReference[Vector[LoggedResponse]] = new AtomicReference(Vector.empty)
+
+  override def start(): Unit = ()
+
+  override def stop(controller: ActorRef[Controller.Command], exception: Option[Exception]): Unit = ()
+
+  override def logUserStart(scenario: String): Unit = ()
+
+  override def logUserEnd(scenario: String): Unit = ()
+
+  override def logResponse(
+      scenario: String,
+      groups: List[String],
+      requestName: String,
+      startTimestamp: Long,
+      endTimestamp: Long,
+      status: Status,
+      responseCode: Option[String],
+      message: Option[String],
+  ): Unit =
+    responses.updateAndGet(
+      _ :+ LoggedResponse(
+        requestName = requestName,
+        startTimestamp = startTimestamp,
+        endTimestamp = endTimestamp,
+        status = status,
+        message = message,
+      ),
+    )
+
+  override def logGroupEnd(scenario: String, groupBlock: GroupBlock, exitTimestamp: Long): Unit = ()
+
+  override def logRequestCrash(scenario: String, groups: List[String], requestName: String, error: String): Unit = ()
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
@@ -1,5 +1,7 @@
 package org.galaxio.gatling.kafka.client
 
+import java.util.concurrent.atomic.AtomicReference
+
 class DynamicKafkaConsumerSpec extends munit.FunSuite {
 
   test("removeTopicSubscription queues topic for removal") {
@@ -59,5 +61,73 @@ class DynamicKafkaConsumerSpec extends munit.FunSuite {
     } finally {
       consumer.close()
     }
+  }
+
+  test("addTopicForSubscription fails fast after consumer failure") {
+    val consumer = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+      Map(
+        "bootstrap.servers"  -> "localhost:0",
+        "key.deserializer"   -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+        "value.deserializer" -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+      ),
+      Set.empty,
+      _ => (),
+      _ => (),
+    )
+    try {
+      val queueField = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("topicsQueue")
+      queueField.setAccessible(true)
+      val queue      =
+        queueField.get(consumer).asInstanceOf[java.util.Queue[(String, java.util.concurrent.CountDownLatch)]]
+
+      val failureField    = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("consumerFailure")
+      failureField.setAccessible(true)
+      val consumerFailure = failureField.get(consumer).asInstanceOf[AtomicReference[Exception]]
+
+      @volatile var thrown: IllegalStateException = null
+
+      val thread = new Thread(() => {
+        try {
+          consumer.addTopicForSubscription("new-topic", scala.concurrent.duration.DurationInt(10).seconds)
+        } catch {
+          case e: IllegalStateException => thrown = e
+        }
+      })
+
+      thread.start()
+
+      eventually(1000) {
+        assertEquals(queue.size(), 1)
+      }
+
+      consumerFailure.set(new RuntimeException("boom"))
+      val (_, latch) = queue.peek()
+      latch.countDown()
+
+      thread.join(2000)
+
+      assert(!thread.isAlive)
+      assert(thrown != null)
+      assert(thrown.getCause != null)
+      assertEquals(thrown.getCause.getMessage, "boom")
+    } finally {
+      consumer.close()
+    }
+  }
+
+  private def eventually(timeoutMillis: Long)(assertion: => Unit): Unit = {
+    val deadline                  = System.currentTimeMillis() + timeoutMillis
+    var lastError: AssertionError = null
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        assertion
+        return
+      } catch {
+        case e: AssertionError =>
+          lastError = e
+          Thread.sleep(10)
+      }
+    }
+    if (lastError != null) throw lastError
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala
@@ -33,7 +33,7 @@ class KafkaMessageTrackerPoolSpec extends munit.FunSuite {
       field.get(pool).asInstanceOf[AtomicReference[Exception]].set(new RuntimeException("boom"))
 
       val thrown = intercept[IllegalStateException] {
-          pool.tracker(
+        pool.tracker(
           producerTopic = "producer-topic",
           consumerTopic = "consumer-topic",
           messageMatcher = KafkaKeyMatcher,

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala
@@ -1,0 +1,55 @@
+package org.galaxio.gatling.kafka.client
+
+import io.gatling.commons.util.Clock
+import io.gatling.core.actor.ActorSystem
+import io.gatling.core.stats.RecordingStatsEngine
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration.DurationInt
+
+class KafkaMessageTrackerPoolSpec extends munit.FunSuite {
+
+  test("tracker fails fast after consumer failure and does not reuse cached trackers") {
+    val actorSystem = new ActorSystem()
+    try {
+      val pool = new KafkaMessageTrackerPool(
+        Map(
+          ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG        -> "localhost:0",
+          ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+          ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
+          "key.serializer"                               -> classOf[ByteArraySerializer].getName,
+          "value.serializer"                             -> classOf[ByteArraySerializer].getName,
+        ),
+        actorSystem,
+        new RecordingStatsEngine,
+        new StubClock(0L),
+      )
+
+      val field = classOf[KafkaMessageTrackerPool].getDeclaredField("consumerFailure")
+      field.setAccessible(true)
+      field.get(pool).asInstanceOf[AtomicReference[Exception]].set(new RuntimeException("boom"))
+
+      val thrown = intercept[IllegalStateException] {
+          pool.tracker(
+          producerTopic = "producer-topic",
+          consumerTopic = "consumer-topic",
+          messageMatcher = KafkaKeyMatcher,
+          responseTransformer = None,
+          timeout = 1.second,
+        )
+      }
+
+      assert(thrown.getCause != null)
+      assertEquals(thrown.getCause.getMessage, "boom")
+    } finally {
+      actorSystem.close()
+    }
+  }
+
+  private final class StubClock(now: Long) extends Clock {
+    override def nowMillis: Long = now
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
@@ -1,0 +1,69 @@
+package org.galaxio.gatling.kafka.client
+
+import io.gatling.commons.stats.KO
+import io.gatling.commons.util.Clock
+import io.gatling.core.action.Action
+import io.gatling.core.session.Session
+import io.gatling.core.stats.RecordingStatsEngine
+import org.galaxio.gatling.kafka.client.KafkaMessageTracker.{ConsumerFailure, MessagePublished}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+
+class KafkaMessageTrackerSpec extends munit.FunSuite {
+
+  test("consumer failure fails pending request immediately with explicit error") {
+    val statsEngine = new RecordingStatsEngine
+    val clock       = new StubClock(2_000L)
+    val next        = new RecordingAction("next")
+    val tracker     =
+      new KafkaMessageTracker[Array[Byte], Array[Byte]]("tracker", statsEngine, clock, KafkaKeyMatcher, None)
+    val behavior    = tracker.init()
+    val onComplete  = new AtomicInteger(0)
+    val session     = Session("scenario", 1L, null)
+
+    behavior(
+      MessagePublished(
+        matchId = "match-1".getBytes(StandardCharsets.UTF_8),
+        sentTimestamp = 1_000L,
+        replyTimeout = 0L,
+        checks = Nil,
+        session = session,
+        next = next,
+        requestName = "request-reply",
+        onComplete = () => onComplete.incrementAndGet(),
+      ),
+    )
+    behavior(ConsumerFailure("boom"))
+
+    val responses = statsEngine.responses.get()
+    assertEquals(responses.size, 1)
+
+    val response = responses.head
+    assertEquals(response.requestName, "request-reply")
+    assertEquals(response.status, KO)
+    assertEquals(response.startTimestamp, 1_000L)
+    assertEquals(response.endTimestamp, 2_000L)
+    assertEquals(response.message, Some("Consumer failure: boom"))
+
+    val nextSession = next.lastSession.get()
+    assert(nextSession != null)
+    assert(nextSession.isFailed)
+    assertEquals(onComplete.get(), 1)
+  }
+
+  private final class StubClock(now: Long) extends Clock {
+    override def nowMillis: Long = now
+  }
+
+  private final class RecordingAction(val name: String) extends Action {
+    val lastSession: AtomicReference[Session] = new AtomicReference[Session]()
+
+    override def !(session: Session): Unit =
+      execute(session)
+
+    override def execute(session: Session): Unit =
+      lastSession.set(session)
+  }
+}


### PR DESCRIPTION
## Summary

- Consumer poll/subscribe failures now propagate immediately to all waiting request-reply trackers
- Affected requests fail with a clear `Consumer failure: <reason>` message instead of generic reply timeouts
- Stats and logs distinguish infrastructure failures from reply timeout behavior

## Changes

- **KafkaMessageTracker**: Added `ConsumerFailure` message type and handler that fails all pending requests with explicit error
- **DynamicKafkaConsumer**: Fatal exceptions now invoke `onFailure` callback instead of rethrowing (which killed the consumer thread silently)
- **KafkaMessageTrackerPool**: `onFailure` handler broadcasts `ConsumerFailure` to all active tracker actors instead of only logging

## How it works

Before: Consumer thread dies → requests wait until timeout → generic "Reply timeout after X ms" error

After: Consumer thread fails → `onFailure` callback fires → `ConsumerFailure` message sent to all tracker actors → pending requests immediately fail with `Consumer failure: <actual error message>`

## Testing

- Verified compilation
- Changes are minimal and focused on the failure propagation path

Fixes galax-io/gatling-kafka-plugin#89