### PR TITLE
docs: use @AGENTS.md include directive in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-Use AGENTS.md as the primary repository instruction file for this project.
+@AGENTS.md


### PR DESCRIPTION
## Summary

Replaces the text reference to AGENTS.md with the `@AGENTS.md` include directive so Claude Code always loads the full instructions into context.

Fixes the issue where agents would see "Use AGENTS.md" but not actually read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)