### PR TITLE
fix(ci): create release from main after tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
             git push origin "$NEXT_TAG"
           fi
       - name: Publish to Sonatype via sbt-ci-release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -209,7 +209,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          TAG="${GITHUB_REF##*/}"
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF##*/}"
+          else
+            TAG="${{ steps.bump.outputs.tag }}"
+          fi
           VERSION="${TAG#v}"
           echo "Publishing version $VERSION (tag $TAG)"
 
@@ -225,9 +229,11 @@ jobs:
       - name: Generate Changelog
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v5
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           mode: "COMMIT"
+          fromTag: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.last_tag || '' }}
+          toTag: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || github.ref_name }}
           configurationJson: |
             {
               "template": "# Changelog\n\n#{{CHANGELOG}}",
@@ -254,9 +260,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || github.ref_name }}
           body: ${{ steps.changelog.outputs.changelog }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary\n\nThe release job was being skipped on  because the workflow created the tag with , which does not trigger a second tag push run. This change lets the same  run publish Sonatype artifacts, build the changelog, and create the GitHub release immediately after the bump step.\n\n## Testing\n\n- Parsed  with Ruby YAML loader\n