### PR TITLE
fix: make codecov upload non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
+        continue-on-error: true
 
   release:
     name: Release (tag-driven)


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the Codecov upload step
- Prevents transient Codecov failures from blocking the `release` job
- Root cause of v0.20.5 never reaching Maven Central (run [#26484485119](https://github.com/galax-io/gatling-kafka-plugin/actions/runs/26484485119) failed on codecov, release job skipped)

## Test plan

- [ ] CI passes on this PR
- [ ] Verify future tag pushes publish to Sonatype even when codecov is flaky

🤖 Generated with [Claude Code](https://claude.com/claude-code)