### PR TITLE
fix: override GITHUB_REF for sbt-ci-release on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,10 @@ jobs:
             TAG="${GITHUB_REF##*/}"
           else
             TAG="${{ steps.bump.outputs.tag }}"
+            # sbt-ci-release detects release vs snapshot from GITHUB_REF;
+            # override so it sees a tag context, not refs/heads/main
+            export GITHUB_REF="refs/tags/${TAG}"
+            export GITHUB_REF_NAME="${TAG}"
           fi
           VERSION="${TAG#v}"
           echo "Publishing version $VERSION (tag $TAG)"
@@ -227,11 +231,7 @@ jobs:
             echo "$PGP_SECRET" | base64 --decode | gpg --batch --import
           fi
 
-          if sbt 'show dynver' >/dev/null 2>&1; then
-            sbt ci-release
-          else
-            sbt "set ThisBuild/version := \"${VERSION}\"" ci-release
-          fi
+          sbt "set ThisBuild/version := \"${VERSION}\"" ci-release
       - name: Generate Changelog
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v5


### PR DESCRIPTION
## Summary

- `sbt-ci-release` checks `GITHUB_REF` to decide release vs snapshot
- On main branch pushes `GITHUB_REF=refs/heads/main` → ci-release logs _"Snapshot releases must have -SNAPSHOT version number, doing nothing"_ and skips
- **No version since `1.0.0-RC1` has reached Maven Central** because of this
- Fix: export `GITHUB_REF=refs/tags/<tag>` / `GITHUB_REF_NAME=<tag>` before `sbt ci-release` on main
- Also remove the unreliable `dynver` detection path — always use explicit `set ThisBuild/version`

## Test plan

- [ ] Merge to main → CI release job → check that SBT outputs publish/upload lines (not "doing nothing")
- [ ] Verify artifact appears on Maven Central under `org.galaxio:gatling-kafka-plugin_2.13`

🤖 Generated with [Claude Code](https://claude.com/claude-code)