### PR TITLE
fix(request-reply): move tracker acquisition before send to avoid blo…

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -29,64 +29,72 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
 
   override def sendKafkaMessage(requestNameString: String, protocolMessage: KafkaProtocolMessage, session: Session): Unit = {
     val requestStartDate = clock.nowMillis
-    components.sender.send(protocolMessage)(
-      rm => {
-        if (logger.underlying.isDebugEnabled) {
-          logMessage(
-            s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${rm.topic()}",
-            protocolMessage,
-          )
-        }
-        val id = components.kafkaProtocol.messageMatcher.requestMatch(protocolMessage)
 
-        components.trackersPool match {
-          case Some(trackers) =>
-            val consumerTopic   = protocolMessage.consumerTopic
-            val matcher         = components.kafkaProtocol.messageMatcher
-            var trackerAcquired = false
-            try {
-              val tracker = trackers.tracker(
-                protocolMessage.producerTopic,
-                consumerTopic,
-                matcher,
+    components.trackersPool match {
+      case Some(trackers) =>
+        val consumerTopic = protocolMessage.consumerTopic
+        val matcher       = components.kafkaProtocol.messageMatcher
+
+        // Acquire the tracker eagerly here, on the Gatling actor thread, BEFORE calling sender.send().
+        // tracker() may block (up to the configured timeout) waiting for Kafka partition assignment
+        // via CountDownLatch.await(). It must NOT be called from inside the sender.send() onSuccess
+        // callback, which runs on the Kafka producer network thread. Blocking that thread starves
+        // consumer heartbeats, causing the broker to evict the consumer group after session.timeout.ms
+        // and permanently poisoning the tracker pool for all subsequent virtual users. See issue #143.
+        val tracker =
+          try {
+            trackers.tracker(
+              protocolMessage.producerTopic,
+              consumerTopic,
+              matcher,
+              None,
+              components.kafkaProtocol.timeout,
+            )
+          } catch {
+            case e: Exception =>
+              val requestEndDate = clock.nowMillis
+              logger.error(e.getMessage, e)
+              statsEngine.logResponse(
+                session.scenario,
+                session.groups,
+                requestNameString,
+                requestStartDate,
+                requestEndDate,
+                KO,
                 None,
-                components.kafkaProtocol.timeout,
+                Some(e.getMessage),
               )
-              trackerAcquired = true
-              tracker ! KafkaMessageTracker
-                .MessagePublished(
-                  id,
-                  clock.nowMillis,
-                  components.kafkaProtocol.timeout.toMillis,
-                  attributes.checks,
-                  session,
-                  next,
-                  requestNameString,
-                  onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
-                )
-            } catch {
-              case e: Exception =>
-                if (trackerAcquired) trackers.releaseTracker(consumerTopic, matcher)
-                val requestEndDate = clock.nowMillis
-                logger.error(e.getMessage, e)
-                statsEngine.logResponse(
-                  session.scenario,
-                  session.groups,
-                  requestNameString,
-                  requestStartDate,
-                  requestEndDate,
-                  KO,
-                  None,
-                  Some(e.getMessage),
-                )
-                next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
+              next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
+              return
+          }
+
+        components.sender.send(protocolMessage)(
+          rm => {
+            if (logger.underlying.isDebugEnabled) {
+              logMessage(
+                s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${rm.topic()}",
+                protocolMessage,
+              )
             }
-          case None           =>
+            val id = components.kafkaProtocol.messageMatcher.requestMatch(protocolMessage)
+            tracker ! KafkaMessageTracker
+              .MessagePublished(
+                id,
+                clock.nowMillis,
+                components.kafkaProtocol.timeout.toMillis,
+                attributes.checks,
+                session,
+                next,
+                requestNameString,
+                onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
+              )
+          },
+          e => {
+            // The send failed after the tracker was already acquired — release it to
+            // avoid a ref-count leak that would prevent topic unsubscription.
+            trackers.releaseTracker(consumerTopic, matcher)
             val requestEndDate = clock.nowMillis
-            val msg            =
-              s"Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration, " +
-                s"otherwise the virtual user will hang for ${components.kafkaProtocol.timeout} with no reply"
-            logger.error(msg)
+            logger.error(e.getMessage, e)
             statsEngine.logResponse(
               session.scenario,
               session.groups,
@@ -94,15 +102,19 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
               requestStartDate,
               requestEndDate,
               KO,
-              None,
-              Some(msg),
+              Some("500"),
+              Some(e.getMessage),
             )
             next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
-        }
-      },
-      e => {
+          },
+        )
+
+      case None =>
         val requestEndDate = clock.nowMillis
-        logger.error(e.getMessage, e)
+        val msg            =
+          s"Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration, " +
+            s"otherwise the virtual user will hang for ${components.kafkaProtocol.timeout} with no reply"
+        logger.error(msg)
         statsEngine.logResponse(
           session.scenario,
           session.groups,
@@ -110,11 +122,10 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
           requestStartDate,
           requestEndDate,
           KO,
-          Some("500"),
-          Some(e.getMessage),
+          None,
+          Some(msg),
         )
         next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
-      },
-    )
+    }
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -29,29 +29,43 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
 
   override def sendKafkaMessage(requestNameString: String, protocolMessage: KafkaProtocolMessage, session: Session): Unit = {
     val requestStartDate = clock.nowMillis
-
     components.trackersPool match {
       case Some(trackers) =>
-        val consumerTopic = protocolMessage.consumerTopic
-        val matcher       = components.kafkaProtocol.messageMatcher
-
-        // Acquire the tracker eagerly here, on the Gatling actor thread, BEFORE calling sender.send().
-        // tracker() may block (up to the configured timeout) waiting for Kafka partition assignment
-        // via CountDownLatch.await(). It must NOT be called from inside the sender.send() onSuccess
-        // callback, which runs on the Kafka producer network thread. Blocking that thread starves
-        // consumer heartbeats, causing the broker to evict the consumer group after session.timeout.ms
-        // and permanently poisoning the tracker pool for all subsequent virtual users. See issue #143.
-        val tracker =
-          try {
-            trackers.tracker(
-              protocolMessage.producerTopic,
-              consumerTopic,
-              matcher,
-              None,
-              components.kafkaProtocol.timeout,
-            )
-          } catch {
-            case e: Exception =>
+        val consumerTopic   = protocolMessage.consumerTopic
+        val matcher         = components.kafkaProtocol.messageMatcher
+        var trackerAcquired = false
+        try {
+          val tracker = trackers.tracker(
+            protocolMessage.producerTopic,
+            consumerTopic,
+            matcher,
+            None,
+            components.kafkaProtocol.timeout,
+          )
+          trackerAcquired = true
+          components.sender.send(protocolMessage)(
+            rm => {
+              if (logger.underlying.isDebugEnabled) {
+                logMessage(
+                  s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${rm.topic()}",
+                  protocolMessage,
+                )
+              }
+              val id = components.kafkaProtocol.messageMatcher.requestMatch(protocolMessage)
+              tracker ! KafkaMessageTracker
+                .MessagePublished(
+                  id,
+                  clock.nowMillis,
+                  components.kafkaProtocol.timeout.toMillis,
+                  attributes.checks,
+                  session,
+                  next,
+                  requestNameString,
+                  onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
+                )
+            },
+            e => {
+              if (trackerAcquired) trackers.releaseTracker(consumerTopic, matcher)
               val requestEndDate = clock.nowMillis
               logger.error(e.getMessage, e)
               statsEngine.logResponse(
@@ -61,38 +75,15 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
                 requestStartDate,
                 requestEndDate,
                 KO,
-                None,
+                Some("500"),
                 Some(e.getMessage),
               )
               next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
-              return
-          }
-
-        components.sender.send(protocolMessage)(
-          rm => {
-            if (logger.underlying.isDebugEnabled) {
-              logMessage(
-                s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${rm.topic()}",
-                protocolMessage,
-              )
-            }
-            val id = components.kafkaProtocol.messageMatcher.requestMatch(protocolMessage)
-            tracker ! KafkaMessageTracker
-              .MessagePublished(
-                id,
-                clock.nowMillis,
-                components.kafkaProtocol.timeout.toMillis,
-                attributes.checks,
-                session,
-                next,
-                requestNameString,
-                onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
-              )
-          },
-          e => {
-            // The send failed after the tracker was already acquired — release it to
-            // avoid a ref-count leak that would prevent topic unsubscription.
-            trackers.releaseTracker(consumerTopic, matcher)
+            },
+          )
+        } catch {
+          case e: Exception =>
+            if (trackerAcquired) trackers.releaseTracker(consumerTopic, matcher)
             val requestEndDate = clock.nowMillis
             logger.error(e.getMessage, e)
             statsEngine.logResponse(
@@ -102,14 +93,12 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
               requestStartDate,
               requestEndDate,
               KO,
-              Some("500"),
+              None,
               Some(e.getMessage),
             )
             next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
-          },
-        )
-
-      case None =>
+        }
+      case None           =>
         val requestEndDate = clock.nowMillis
         val msg            =
           s"Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration, " +


### PR DESCRIPTION
…cking producer network thread

trackers.tracker() may block on CountDownLatch.await() while waiting for Kafka partition assignment. Previously this was called inside the sender.send() onSuccess callback, which runs on the Kafka producer network thread. Blocking that thread starves consumer heartbeats and causes the broker to evict the consumer group after session.timeout.ms, permanently poisoning the tracker pool.

Fix: acquire the tracker eagerly on the Gatling actor thread before calling sender.send(). If acquisition fails, fail the request without sending. If the send itself fails, release the already-acquired tracker to avoid a ref-count leak.

Fixes #143