### PR TITLE
docs(speckit): ratify constitution v1.0.0 and sync process templates

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,50 +1,194 @@
-# [PROJECT_NAME] Constitution
-<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+<!--
+Sync Impact Report
+==================
+Version change: (unversioned template) → 1.0.0
+Bump rationale: Initial ratification. Every placeholder replaced with concrete,
+enforceable rules derived from the repository's existing process (AGENTS.md,
+.github/workflows/, scripts/, README.md). No prior version existed, so this is
+1.0.0 rather than a MAJOR bump of something.
+
+Modified principles (template placeholder → ratified name):
+  [PRINCIPLE_1_NAME] → I. Published API Compatibility (NON-NEGOTIABLE)
+  [PRINCIPLE_2_NAME] → II. Real Broker Over Mocks
+  [PRINCIPLE_3_NAME] → III. Layer Separation & Single Wire Contract
+  [PRINCIPLE_4_NAME] → IV. Test-First for Behavior Change
+  [PRINCIPLE_5_NAME] → V. One Concern per Change, Always Green
+
+Added sections:
+  [SECTION_2_NAME] → Technology & Compatibility Constraints
+  [SECTION_3_NAME] → Development Workflow & Quality Gates
+  Governance → concrete amendment procedure, versioning policy, compliance review
+
+Removed sections: none
+
+Templates requiring updates:
+  ✅ .specify/templates/plan-template.md — Constitution Check filled with concrete gates
+  ✅ .specify/templates/tasks-template.md — test-optionality note reconciled with
+     Principle IV; path conventions corrected to this repo's Scala/sbt layout
+  ✅ .specify/templates/spec-template.md — reviewed, already aligned (no mandatory
+     section added or removed by this constitution)
+  ✅ AGENTS.md — reviewed, consistent; constitution governs where they diverge
+  ✅ README.md — reviewed, consistent (Compatibility, Migration Guide, Releasing)
+  ⚠ .specify/templates/commands/*.md — directory does not exist in this install; N/A
+
+Deferred TODOs: none
+-->
+
+# Gatling Kafka Plugin Constitution
 
 ## Core Principles
 
-### [PRINCIPLE_1_NAME]
-<!-- Example: I. Library-First -->
-[PRINCIPLE_1_DESCRIPTION]
-<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+### I. Published API Compatibility (NON-NEGOTIABLE)
 
-### [PRINCIPLE_2_NAME]
-<!-- Example: II. CLI Interface -->
-[PRINCIPLE_2_DESCRIPTION]
-<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+The Scala DSL under `org.galaxio.gatling.kafka`, the Java facade under
+`org.galaxio.gatling.kafka.javaapi`, default protocol settings, and serialized wire formats form a
+published contract consumed by downstream Gatling simulations. Sonatype releases are permanent and
+cannot be withdrawn.
 
-### [PRINCIPLE_3_NAME]
-<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
-[PRINCIPLE_3_DESCRIPTION]
-<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+- Changes to public signatures, observable behavior, or serialized formats MUST be proposed and
+  approved before implementation. They are never a side effect of another change.
+- A breaking change MUST carry a `!:` or `BREAKING CHANGE` Conventional Commit marker so it drives
+  a major version, and MUST ship with a Migration Guide entry in `README.md` in the same PR.
+- Deprecate before removing: a replaced entry point MUST keep compiling for at least one minor
+  release, annotated as deprecated with its replacement named.
+- `ExampleSmokeValidation` MUST keep constructing every README and example simulation against the
+  current API. A failure there is an API break to reconsider, not a check to relax.
 
-### [PRINCIPLE_4_NAME]
-<!-- Example: IV. Integration Testing -->
-[PRINCIPLE_4_DESCRIPTION]
-<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+**Rationale**: Users pin one plugin version against one Gatling version. Silent signature or
+default drift breaks load-test suites at runtime, in the environment where they are hardest to
+diagnose, and the broken artifact can never be unpublished.
 
-### [PRINCIPLE_5_NAME]
-<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
-[PRINCIPLE_5_DESCRIPTION]
-<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+### II. Real Broker Over Mocks
 
-## [SECTION_2_NAME]
-<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+Kafka behavior MUST be validated against a real broker — Testcontainers under `sbt test`, or the
+`docker-compose.kafka.yml` stack for the Gatling simulations CI runs.
 
-[SECTION_2_CONTENT]
-<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+- Mocks and stubs are permitted only for units with no Kafka interaction: matchers, serializers,
+  check materialization, and builder wiring.
+- Consumer lifecycle, tracker-pool concurrency, reply correlation, timeout handling, and error
+  propagation MUST be exercised end-to-end against a broker, never asserted against a stub.
+- Where a real integration path exists, substituting a mock for it MUST be treated as a gap in
+  coverage rather than as coverage.
 
-## [SECTION_3_NAME]
-<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+**Rationale**: Rebalancing, offset-commit timing, and correlation races are precisely the behaviors
+a mock reproduces incorrectly, and precisely the behaviors this plugin exists to get right.
 
-[SECTION_3_CONTENT]
-<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+### III. Layer Separation & Single Wire Contract
+
+`KafkaSender` sends, `KafkaMessageTracker` and `KafkaMessageTrackerPool` track, and
+`DynamicKafkaConsumer` consumes. These responsibilities MUST NOT be merged into one another.
+
+- `KafkaProtocolMessage` is the single wire representation and `KafkaMatcher` the single matching
+  contract. Extend them. Parallel message or matcher types MUST NOT be introduced.
+- Actions MUST receive their collaborators by injection and MUST NOT construct them internally, so
+  each layer stays independently testable.
+- Control flow MUST NOT be expressed through exceptions, and dead or duplicated code MUST NOT be
+  merged.
+- Abstraction is introduced when a second real caller exists, not in anticipation of one. In public
+  API surface a speculative abstraction immediately becomes a compatibility obligation under
+  Principle I.
+
+**Rationale**: Send, track, and consume fail independently and under different conditions. Keeping
+them separate is what makes a failure attributable to one of them; one wire type and one matching
+contract are what keep that attribution meaningful across the Scala and Java surfaces.
+
+### IV. Test-First for Behavior Change
+
+Every behavior change MUST land with a test that fails before the change and passes after it.
+
+- Follow red-green-refactor where practical. At minimum, add a focused regression test that names
+  the behavior being introduced or fixed.
+- A bug fix MUST include a test that reproduces the bug against the pre-fix code.
+- Tests are NOT optional for behavior work, in specs, plans, or task lists. A feature specification
+  cannot waive this principle.
+- Pure refactors that change no observable behavior are exempt from new tests and MUST be
+  demonstrable as such by the existing suite passing unchanged.
+
+**Rationale**: This plugin's failures are asynchronous and intermittent — a missed reply, a
+mistimed commit, a leaked consumer. Only a test written to fail first proves the fix addresses the
+reported behavior rather than coincidentally hiding it.
+
+### V. One Concern per Change, Always Green
+
+- Spec-first: `specs/NNN-*/` artifacts land as their own `docs(speckit): …` commit BEFORE any
+  `feat` or `fix` commit. Spec artifacts MUST NOT be folded into implementation commits.
+- One tracked issue maps to one semantic commit (`feat(scope): … (#NNN)`), and each such commit
+  MUST be green on its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`.
+- One concern per PR. Documentation, refactors, and opportunistic improvements go in separate PRs
+  and MUST NOT be mixed into an issue commit.
+- Commits express intent, not path: no add-then-remove churn within a PR. Squash before review.
+- Every PR MUST be assigned to the active milestone and MUST close its issue via `Closes #NNN`. A
+  PR without a milestone MUST NOT merge.
+- Conventional Commit subjects MUST be accurate. git-cliff derives the release notes from them and
+  the release version is chosen from them.
+
+**Rationale**: The changelog, the released version number, and the milestone release gate are all
+generated from commit and PR metadata. Inaccurate metadata produces a wrong release, not merely an
+untidy history.
+
+## Technology & Compatibility Constraints
+
+- Scala 2.13 on sbt, Java 17+. `build.sbt`, `project/Dependencies.scala`, and
+  `project/plugins.sbt` are the single source of truth for language, Gatling, Kafka, and Avro
+  versions. This constitution MUST NOT restate those version numbers.
+- Avro4s and Confluent Schema Registry support is `provided` scope and MUST remain optional: the
+  plugin MUST stay usable with plain serialization and no Schema Registry on the classpath.
+- New dependencies and non-Scala-Steward upgrades require approval before merge. Adding a
+  dependency to the published artifact's `compile` scope is an API-surface decision governed by
+  Principle I.
+- Gatling compatibility is per-release-line and published in the README compatibility table. That
+  table MUST be updated in the same PR that changes a supported Gatling version.
+- `.github/workflows/` is the source of truth for formatting, compile, test, coverage, and release
+  behavior. Local commands mirror CI; where the two disagree, CI is correct and the local command
+  is fixed.
+
+## Development Workflow & Quality Gates
+
+**Branching**: Trunk-based. Branch from `main`; `release/*` branches are cut from `main` for
+stabilization. Rebase only — merge commits MUST NOT appear in PR branches. Never force-push to
+`main` and never commit directly to `main`.
+
+**Before every push**: format with `sbt scalafmtAll scalafmtSbt`, then verify with
+`sbt scalafmtCheckAll scalafmtSbtCheck compile test`. The shared `.githooks/pre-commit` hook,
+enabled once per clone via `scripts/install-hooks.sh`, enforces formatting on every commit;
+compile and tests are enforced by CI.
+
+**Full CI gate** requires the Compose stack (Kafka, Zookeeper, Schema Registry) and runs
+`KafkaGatlingTest` and `KafkaJavaapiMethodsGatlingTest` under coverage alongside `sbt test`. The
+exact invocation lives in `AGENTS.md` and `.github/workflows/ci.yml`.
+
+**Milestone linkage** is enforced by `scripts/check-linkage.sh` with the `linkage-guard` and
+`milestone-guard` PreToolUse hooks. A release milestone is tag-ready only when every issue in it is
+closed and every PR merged. Release milestones MUST be named `vX.Y.0 <description>`, or
+`vX.Y.Z <description>` for a dedicated patch milestone, so that `--for-tag` resolves.
+
+**Release** is manual and tag-driven. The version comes from the tag via dynver and is chosen from
+the Conventional Commits since the last tag: `feat` → minor, `!:` or `BREAKING CHANGE` → major,
+otherwise patch. Tags are valid only on `main` or `release/*`. A published tag MUST NEVER be
+deleted and a version number MUST NEVER be reused.
 
 ## Governance
-<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
 
-[GOVERNANCE_RULES]
-<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+This constitution supersedes ad-hoc practice. Where it and `AGENTS.md` disagree, this document
+governs and `AGENTS.md` MUST be corrected in the same PR that surfaces the conflict. `AGENTS.md`
+remains the runtime development guide and carries the operational detail; this document carries the
+non-negotiables.
 
-**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
-<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->
+**Amendment procedure**: an amendment is a PR that (a) edits this file, (b) updates the Sync Impact
+Report at the top of it, and (c) updates every dependent artifact the change touches —
+`.specify/templates/plan-template.md`, `.specify/templates/spec-template.md`,
+`.specify/templates/tasks-template.md`, `AGENTS.md`, and `README.md`. An amendment that leaves a
+dependent artifact contradicting a principle is incomplete and MUST NOT merge.
+
+**Versioning policy** for this document, semantic and independent of the plugin's release version:
+
+- **MAJOR**: a principle is removed, or redefined in a way that invalidates previously compliant
+  work.
+- **MINOR**: a principle or section is added, or existing guidance is materially expanded.
+- **PATCH**: clarification, wording, or typo fix that changes no obligation.
+
+**Compliance review**: every PR review MUST verify the change against these principles. A deviation
+is permitted only when it is recorded in the plan's Complexity Tracking table with the rejected
+simpler alternative named. An undocumented deviation blocks merge.
+
+**Version**: 1.0.0 | **Ratified**: 2026-07-31 | **Last Amended**: 2026-07-31

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -40,7 +40,32 @@
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-[Gates determined based on constitution file]
+*Source: `.specify/memory/constitution.md` v1.0.0. Answer each gate; any NO must be justified in
+Complexity Tracking below or the plan does not proceed.*
+
+- [ ] **I. Published API Compatibility**: Does this feature change any public Scala DSL or
+      `javaapi` signature, default protocol setting, or serialized format? If YES — approval
+      obtained, `!:`/`BREAKING CHANGE` marker planned where breaking, README Migration Guide entry
+      planned, deprecation path kept compiling for one minor release, and `ExampleSmokeValidation`
+      still constructs every README/example simulation.
+- [ ] **II. Real Broker Over Mocks**: Every Kafka interaction this feature touches — consumer
+      lifecycle, tracker-pool concurrency, reply correlation, timeouts, error propagation — is
+      validated against Testcontainers or the `docker-compose.kafka.yml` stack. Mocks are confined
+      to units with no Kafka interaction.
+- [ ] **III. Layer Separation & Single Wire Contract**: `KafkaSender` / `KafkaMessageTracker` /
+      `DynamicKafkaConsumer` responsibilities stay separate; `KafkaProtocolMessage` and
+      `KafkaMatcher` are extended rather than duplicated; collaborators are injected into actions,
+      not constructed inside them; no new abstraction without a second real caller.
+- [ ] **IV. Test-First for Behavior Change**: Every behavior change in this plan has a test that
+      fails first. Bug fixes reproduce the bug before fixing it. Tests are not deferred to a later
+      phase and are not marked optional.
+- [ ] **V. One Concern per Change, Always Green**: Spec artifacts commit separately and first; work
+      decomposes to one issue per semantic commit, each green under
+      `sbt scalafmtCheckAll scalafmtSbtCheck compile test`; PRs are single-concern and carry a
+      milestone plus `Closes #NNN`.
+- [ ] **Constraints**: No new dependency (or non-Scala-Steward upgrade) without approval; Avro and
+      Schema Registry support stays `provided` and optional; README compatibility table updated if
+      a supported Gatling version changes.
 
 ## Project Structure
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -9,7 +9,7 @@ description: "Task list template for feature implementation"
 
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
-**Tests**: The examples below include test tasks. Tests are OPTIONAL - only include them if explicitly requested in the feature specification.
+**Tests**: Per Constitution Principle IV (Test-First for Behavior Change), test tasks are MANDATORY for any task that changes observable behavior, and each must be written to fail before its implementation task. A feature specification cannot waive this. Only pure refactors that change no observable behavior may omit new tests, and those must be identifiable as such by the existing suite passing unchanged. Per Principle II, Kafka interactions are tested against Testcontainers or the `docker-compose.kafka.yml` stack — not mocks.
 
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
 
@@ -21,10 +21,15 @@ description: "Task list template for feature implementation"
 
 ## Path Conventions
 
-- **Single project**: `src/`, `tests/` at repository root
-- **Web app**: `backend/src/`, `frontend/src/`
-- **Mobile**: `api/src/`, `ios/src/` or `android/src/`
-- Paths shown below assume single project - adjust based on plan.md structure
+This is a single-module Scala/sbt project (`gatling-kafka-plugin`):
+
+- **Scala plugin sources**: `src/main/scala/org/galaxio/gatling/kafka/{protocol,actions,client,checks,request}/`
+- **Java facade**: `src/main/java/org/galaxio/gatling/kafka/javaapi/`
+- **Tests**: `src/test/scala/`, `src/test/java/`, `src/test/kotlin/`
+- **Build/dependency truth**: `build.sbt`, `project/Dependencies.scala`, `project/plugins.sbt`
+
+The sample tasks below use generic placeholder paths — replace them with real paths from the tree
+above per plan.md.
 
 <!--
   ============================================================================
@@ -80,19 +85,19 @@ Examples of foundational tasks (adjust based on your project):
 
 **Independent Test**: [How to verify this story works on its own]
 
-### Tests for User Story 1 (OPTIONAL - only if tests requested) ⚠️
+### Tests for User Story 1 (MANDATORY for behavior change — Principle IV) ⚠️
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T010 [P] [US1] Contract test for [endpoint] in tests/contract/test_[name].py
-- [ ] T011 [P] [US1] Integration test for [user journey] in tests/integration/test_[name].py
+- [ ] T010 [P] [US1] Unit test for [component] in src/test/scala/[path]/[Name]Spec.scala
+- [ ] T011 [P] [US1] Testcontainers integration test for [Kafka journey] in src/test/scala/[path]/[Name]IntegrationSpec.scala
 
 ### Implementation for User Story 1
 
-- [ ] T012 [P] [US1] Create [Entity1] model in src/models/[entity1].py
-- [ ] T013 [P] [US1] Create [Entity2] model in src/models/[entity2].py
-- [ ] T014 [US1] Implement [Service] in src/services/[service].py (depends on T012, T013)
-- [ ] T015 [US1] Implement [endpoint/feature] in src/[location]/[file].py
+- [ ] T012 [P] [US1] Create [type] in src/main/scala/org/galaxio/gatling/kafka/[layer]/[Name].scala
+- [ ] T013 [P] [US1] Extend KafkaProtocolMessage/KafkaMatcher if needed (Principle III: extend, don't duplicate)
+- [ ] T014 [US1] Implement [component] in src/main/scala/org/galaxio/gatling/kafka/[layer]/[Name].scala (depends on T012, T013)
+- [ ] T015 [US1] Wire into action/builder in src/main/scala/org/galaxio/gatling/kafka/actions/[Name].scala (inject collaborators — Principle III)
 - [ ] T016 [US1] Add validation and error handling
 - [ ] T017 [US1] Add logging for user story 1 operations
 
@@ -106,16 +111,16 @@ Examples of foundational tasks (adjust based on your project):
 
 **Independent Test**: [How to verify this story works on its own]
 
-### Tests for User Story 2 (OPTIONAL - only if tests requested) ⚠️
+### Tests for User Story 2 (MANDATORY for behavior change — Principle IV) ⚠️
 
-- [ ] T018 [P] [US2] Contract test for [endpoint] in tests/contract/test_[name].py
-- [ ] T019 [P] [US2] Integration test for [user journey] in tests/integration/test_[name].py
+- [ ] T018 [P] [US2] Unit test for [component] in src/test/scala/[path]/[Name]Spec.scala
+- [ ] T019 [P] [US2] Testcontainers integration test for [Kafka journey] in src/test/scala/[path]/[Name]IntegrationSpec.scala
 
 ### Implementation for User Story 2
 
-- [ ] T020 [P] [US2] Create [Entity] model in src/models/[entity].py
-- [ ] T021 [US2] Implement [Service] in src/services/[service].py
-- [ ] T022 [US2] Implement [endpoint/feature] in src/[location]/[file].py
+- [ ] T020 [P] [US2] Create [type] in src/main/scala/org/galaxio/gatling/kafka/[layer]/[Name].scala
+- [ ] T021 [US2] Implement [component] in src/main/scala/org/galaxio/gatling/kafka/[layer]/[Name].scala
+- [ ] T022 [US2] Expose via DSL in src/main/scala/org/galaxio/gatling/kafka/KafkaDsl.scala (Principle I: API-surface change)
 - [ ] T023 [US2] Integrate with User Story 1 components (if needed)
 
 **Checkpoint**: At this point, User Stories 1 AND 2 should both work independently
@@ -128,16 +133,16 @@ Examples of foundational tasks (adjust based on your project):
 
 **Independent Test**: [How to verify this story works on its own]
 
-### Tests for User Story 3 (OPTIONAL - only if tests requested) ⚠️
+### Tests for User Story 3 (MANDATORY for behavior change — Principle IV) ⚠️
 
-- [ ] T024 [P] [US3] Contract test for [endpoint] in tests/contract/test_[name].py
-- [ ] T025 [P] [US3] Integration test for [user journey] in tests/integration/test_[name].py
+- [ ] T024 [P] [US3] Unit test for [component] in src/test/scala/[path]/[Name]Spec.scala
+- [ ] T025 [P] [US3] Testcontainers integration test for [Kafka journey] in src/test/scala/[path]/[Name]IntegrationSpec.scala
 
 ### Implementation for User Story 3
 
-- [ ] T026 [P] [US3] Create [Entity] model in src/models/[entity].py
-- [ ] T027 [US3] Implement [Service] in src/services/[service].py
-- [ ] T028 [US3] Implement [endpoint/feature] in src/[location]/[file].py
+- [ ] T026 [P] [US3] Create [type] in src/main/scala/org/galaxio/gatling/kafka/[layer]/[Name].scala
+- [ ] T027 [US3] Implement [component] in src/main/scala/org/galaxio/gatling/kafka/[layer]/[Name].scala
+- [ ] T028 [US3] Mirror on the Java facade in src/main/java/org/galaxio/gatling/kafka/javaapi/[Name].java
 
 **Checkpoint**: All user stories should now be independently functional
 
@@ -151,11 +156,12 @@ Examples of foundational tasks (adjust based on your project):
 
 **Purpose**: Improvements that affect multiple user stories
 
-- [ ] TXXX [P] Documentation updates in docs/
-- [ ] TXXX Code cleanup and refactoring
+- [ ] TXXX [P] Documentation updates in README.md (separate PR — Principle V, one concern per PR)
+- [ ] TXXX Code cleanup and refactoring (separate PR)
 - [ ] TXXX Performance optimization across all stories
-- [ ] TXXX [P] Additional unit tests (if requested) in tests/unit/
-- [ ] TXXX Security hardening
+- [ ] TXXX [P] Additional unit tests in src/test/scala/
+- [ ] TXXX Run `sbt scalafmtAll scalafmtSbt` then `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [ ] TXXX Run `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` (API-compat gate, Principle I)
 - [ ] TXXX Run quickstart.md validation
 
 ---
@@ -179,7 +185,8 @@ Examples of foundational tasks (adjust based on your project):
 
 ### Within Each User Story
 
-- Tests (if included) MUST be written and FAIL before implementation
+- Tests MUST be written and MUST FAIL before implementation (Principle IV; exempt only for pure
+  refactors with no observable behavior change)
 - Models before services
 - Services before endpoints
 - Core implementation before integration
@@ -199,13 +206,13 @@ Examples of foundational tasks (adjust based on your project):
 ## Parallel Example: User Story 1
 
 ```bash
-# Launch all tests for User Story 1 together (if tests requested):
-Task: "Contract test for [endpoint] in tests/contract/test_[name].py"
-Task: "Integration test for [user journey] in tests/integration/test_[name].py"
+# Launch all tests for User Story 1 together:
+Task: "Unit test for [component] in src/test/scala/[path]/[Name]Spec.scala"
+Task: "Testcontainers integration test for [Kafka journey] in src/test/scala/[path]/[Name]IntegrationSpec.scala"
 
-# Launch all models for User Story 1 together:
-Task: "Create [Entity1] model in src/models/[entity1].py"
-Task: "Create [Entity2] model in src/models/[entity2].py"
+# Launch all independent types for User Story 1 together:
+Task: "Create [type] in src/main/scala/org/galaxio/gatling/kafka/[layer]/[Name].scala"
+Task: "Extend KafkaProtocolMessage/KafkaMatcher as needed"
 ```
 
 ---
@@ -247,6 +254,7 @@ With multiple developers:
 - [Story] label maps task to specific user story for traceability
 - Each user story should be independently completable and testable
 - Verify tests fail before implementing
-- Commit after each task or logical group
+- Commit per tracked issue, not per task: one issue = one semantic commit, green on its own under
+  `sbt scalafmtCheckAll scalafmtSbtCheck compile test` (Principle V)
 - Stop at any checkpoint to validate story independently
 - Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence


### PR DESCRIPTION
## What

Fills in `.specify/memory/constitution.md`, which was still the unmodified spec-kit template — every principle, section and governance rule was a bracketed placeholder (`[PRINCIPLE_1_NAME]`, `[SECTION_2_NAME]`, `[GOVERNANCE_RULES]`, …). Ratified at **v1.0.0**, and propagated to the templates that depend on it.

## Why

`plan-template.md` gates every plan behind a *Constitution Check*, but that section read `[Gates determined based on constitution file]` and the constitution had no gates in it. So `/speckit-plan` had nothing to check and the gate was decorative.

## Principles

Derived from the process this repo already follows (`AGENTS.md`, `.github/workflows/`, `scripts/`, `README.md`) rather than invented:

| # | Principle | Core rule |
|---|---|---|
| I | **Published API Compatibility** (NON-NEGOTIABLE) | Scala DSL, `javaapi`, defaults and wire formats are a permanent published contract. Breaking → `!:` marker + README Migration Guide entry. Deprecate one minor before removing. `ExampleSmokeValidation` is the gate. |
| II | **Real Broker Over Mocks** | Testcontainers / `docker-compose.kafka.yml`. Mocks confined to units with no Kafka interaction. |
| III | **Layer Separation & Single Wire Contract** | `KafkaSender` / `KafkaMessageTracker` / `DynamicKafkaConsumer` stay separate. `KafkaProtocolMessage` and `KafkaMatcher` extended, never duplicated. Collaborators injected. |
| IV | **Test-First for Behavior Change** | Test fails before, passes after. Bug fixes reproduce first. Pure refactors exempt. |
| V | **One Concern per Change, Always Green** | Spec-first commit; 1 issue = 1 semantic commit green on its own; 1 concern per PR; milestone + `Closes #NNN`. |

Plus **Technology & Compatibility Constraints** and **Development Workflow & Quality Gates**.

## Template changes

- **`plan-template.md`** — the empty `[Gates determined based on constitution file]` becomes six concrete checkbox gates, one per principle plus constraints.
- **`tasks-template.md`** — resolves a direct contradiction: the template declared *"Tests are OPTIONAL - only include them if explicitly requested in the feature specification"*, which Principle IV forbids for behavior change. Also swaps the Python-shaped sample paths (`src/models/*.py`, `tests/contract/`) for this repo's real Scala/sbt/`javaapi` layout, and points the polish phase at the actual verification commands including the `ExampleSmokeValidation` API-compat gate.
- **`spec-template.md`**, **`AGENTS.md`**, **`README.md`** — reviewed, already consistent. No change.

## Reviewer notes

- **Docs only.** No Scala, Java or Kotlin source touched, no build or dependency change. `sbt scalafmtAll scalafmtSbt` ran via the pre-commit hook and reformatted nothing.
- **The constitution deliberately restates no dependency versions**, deferring to `build.sbt` and `project/Dependencies.scala` as the single source of truth. Worth noting the reason: `AGENTS.md` currently says Confluent `7.9.2-ccs` while `project/Dependencies.scala` says `7.9.5-ccs`. That drift is out of scope here and left untouched, but it is exactly the failure mode the constitution avoids by not duplicating version numbers.
- **No milestone attached** — the repository has no milestones defined at all (`gh api …/milestones?state=all` returns 0), so `scripts/current-milestone.sh` prints nothing and there is nothing valid to assign. `AGENTS.md` already records this as a known gap: a `vX.Y.0 …` milestone must exist before the next release, since `linkage-guard.sh` will otherwise block the release tag. Flagging it rather than fixing it, since creating release milestones is a maintainer call.
- **No `Closes #NNN`** — no tracked issue exists for this work.
- The constitution's own amendment procedure requires future edits to update the Sync Impact Report at the top of the file and every dependent artifact in the same PR.

## Tooling defects found while opening this PR

Opening this PR was blocked by `.claude/hooks/linkage-guard.sh`, which is meant to gate release tagging only. Two separate bugs, both worth a follow-up:

1. **False positive on any command that merely mentions tagging.** The guard greps the whole command string, so a `gh pr create` whose *body text* contains the words `git`+`tag` and a `X.Y.Z` version is treated as a release tag and blocked. No tag was being created. Filed as a text-matching problem: the guard needs to inspect the invoked command, not arbitrary payload text such as a heredoc body or `-m` message.
2. **The documented bypass does not exist.** `AGENTS.md` documents `LINKAGE_OFF=1 <cmd>` as the escape hatch, but `linkage-guard.sh` never reads that variable, so the bypass silently has no effect.

Neither was worked around by disabling the guard — the PR body was simply moved into a file so the text left the command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
