### PR TITLE
fix(tooling): scope linkage-guard to real git commands

### DIFF
--- a/.claude/hooks/linkage-guard.sh
+++ b/.claude/hooks/linkage-guard.sh
@@ -1,31 +1,83 @@
 #!/usr/bin/env bash
 # PreToolUse(Bash) guard — gate ONLY release tagging. ~0 tokens. Обычный push/merge не трогает.
+# Fires ONLY on a real git tag/push command, never on text that merely mentions one.
+# Bypass a deliberate release: LINKAGE_OFF=1 <cmd>
 set -uo pipefail
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
 [ -n "$cmd" ] || exit 0
-case "$cmd" in *"git "*) ;; *) exit 0 ;; esac
+[ "${LINKAGE_OFF:-}" = "1" ] && exit 0
+case "$cmd" in *LINKAGE_OFF=1*) exit 0 ;; esac
+case "$cmd" in *git*) ;; *) exit 0 ;; esac
 root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 checker="$root/scripts/check-linkage.sh"
 block() { printf 'BLOCKED by linkage-guard:\n%s\n' "$1" >&2; exit 2; }
+
+# Scope the guard to what the shell would actually RUN. Matching the raw command string
+# made any *argument* mentioning a tag look like a release — a `gh pr create` whose heredoc
+# body documented this hook was blocked, reporting a version that came from prose.
+# So: drop heredoc bodies, split on shell separators, keep only segments that invoke git.
+strip_heredocs() {
+  local line trimmed term="" re='<<-?[[:space:]]*["'"'"']?([A-Za-z_][A-Za-z0-9_]*)["'"'"']?'
+  while IFS= read -r line; do
+    if [ -n "$term" ]; then
+      trimmed="${line#"${line%%[![:space:]]*}"}"
+      [ "$trimmed" = "$term" ] && term=""
+      continue
+    fi
+    printf '%s\n' "$line"
+    [[ $line =~ $re ]] && term="${BASH_REMATCH[1]}"
+  done
+}
+
+split_segments() {
+  local s="$1"
+  s="${s//&&/$'\n'}"; s="${s//||/$'\n'}"; s="${s//;/$'\n'}"; s="${s//|/$'\n'}"
+  printf '%s\n' "$s"
+}
+
+# Peel leading env assignments and wrappers so `rtk proxy git tag …` still counts as git.
+peel() {
+  local s="$1" head
+  s="${s#"${s%%[![:space:]]*}"}"
+  while :; do
+    head="${s%% *}"
+    case "$head" in
+      [A-Za-z_]*=*) s="${s#"$head"}" ;;
+      rtk|proxy|sudo|env|nohup|time|command|builtin|exec|xargs) s="${s#"$head"}" ;;
+      *) break ;;
+    esac
+    s="${s#"${s%%[![:space:]]*}"}"
+  done
+  printf '%s' "$s"
+}
+
 is_tag=0
-# Any `git tag …` carrying a vX.Y.Z, in any flag order — upstream required the version
-# to sit immediately after `tag`, so the documented annotated form (`git tag -a vX.Y.Z -m …`)
-# slipped through. Read-only/destructive subcommands (-l/--list, -d/--delete, -v/--verify,
-# -n) are not release creation and stay out of scope.
-if printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+tag\b' \
-   && printf '%s' "$cmd" | grep -qE '\bv?[0-9]+\.[0-9]+\.[0-9]+' \
-   && ! printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+tag[[:space:]]+(-l\b|--list\b|-d\b|--delete\b|-v\b|--verify\b|-n)'; then
-  is_tag=1
-fi
-if printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+push\b' \
-   && printf '%s' "$cmd" | grep -qE '(--tags|refs/tags/|[[:space:]](origin[[:space:]]+)?v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)|release/[0-9])'; then
-  is_tag=1
-fi
-printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+(commit|log|show)\b' && is_tag=0
+hit=""
+segments=$(split_segments "$(printf '%s\n' "$cmd" | strip_heredocs)")
+while IFS= read -r seg; do
+  seg=$(peel "$seg")
+  case "$seg" in git|git\ *) ;; *) continue ;; esac
+  # Non-release subcommands are out of scope. Scoped to THIS segment: the old global
+  # reset let `git commit -m … && git tag vX.Y.Z` through ungated.
+  printf '%s' "$seg" | grep -qE '^git[[:space:]]+(commit|log|show)\b' && continue
+  # Any `git tag …` carrying a vX.Y.Z, in any flag order — upstream required the version
+  # to sit immediately after `tag`, so the documented annotated form (`git tag -a vX.Y.Z -m …`)
+  # slipped through. Read-only/destructive subcommands (-l/--list, -d/--delete, -v/--verify,
+  # -n) are not release creation and stay out of scope.
+  if printf '%s' "$seg" | grep -qE '^git[[:space:]]+tag\b' \
+     && printf '%s' "$seg" | grep -qE '\bv?[0-9]+\.[0-9]+\.[0-9]+' \
+     && ! printf '%s' "$seg" | grep -qE '^git[[:space:]]+tag[[:space:]]+(-l\b|--list\b|-d\b|--delete\b|-v\b|--verify\b|-n)'; then
+    is_tag=1; hit="$seg"; break
+  fi
+  if printf '%s' "$seg" | grep -qE '^git[[:space:]]+push\b' \
+     && printf '%s' "$seg" | grep -qE '(--tags|refs/tags/|[[:space:]](origin[[:space:]]+)?v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)|release/[0-9])'; then
+    is_tag=1; hit="$seg"; break
+  fi
+done <<<"$segments"
 [ "$is_tag" = 1 ] || exit 0
 [ -x "$checker" ] || block "checker missing ($checker) — release cannot be verified"
-ver=$(printf '%s' "$cmd" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+ver=$(printf '%s' "$hit" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 [ -n "$ver" ] || block "tag/release push without explicit vX.Y.Z — verify: scripts/check-linkage.sh --for-tag <version>"
 out=$("$checker" --for-tag "$ver" 2>&1) || block "$out"
 exit 0

--- a/scripts/test-linkage-guard.sh
+++ b/scripts/test-linkage-guard.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# test-linkage-guard.sh — regression suite for .claude/hooks/linkage-guard.sh.
+#
+# The guard must gate release tagging and nothing else. Two symmetric failures matter:
+# blocking a command that merely *mentions* tagging, and waving through a real tag hidden
+# in a compound command. Both are covered below.
+#
+# The real scripts/check-linkage.sh is replaced by a stub, so the suite is deterministic,
+# offline, and independent of milestone state. It asserts only the guard's scope decision:
+# exit 0 = passed through, exit 2 = gated.
+#
+# Usage: bash scripts/test-linkage-guard.sh   [GUARD=/path/to/linkage-guard.sh]
+# Exit:  0 all green | 1 at least one case failed
+set -uo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GUARD="${GUARD:-$root/.claude/hooks/linkage-guard.sh}"
+[ -r "$GUARD" ] || { echo "guard not found: $GUARD" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+fake=$(mktemp -d)
+trap 'rm -rf "$fake"' EXIT
+mkdir -p "$fake/scripts"
+cat >"$fake/scripts/check-linkage.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "stub check-linkage: $*"
+exit 1
+STUB
+chmod +x "$fake/scripts/check-linkage.sh"
+
+pass=0
+fail=0
+
+run() { # run <expected rc> <label> <command>
+  local want="$1" label="$2" cmd="$3" out rc
+  out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | CLAUDE_PROJECT_DIR="$fake" bash "$GUARD" 2>&1)
+  rc=$?
+  if [ "$rc" = "$want" ]; then
+    pass=$((pass + 1))
+    printf '  ok   [%s] %s\n' "$rc" "$label"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL want=%s got=%s  %s\n       cmd: %s\n       out: %s\n' \
+      "$want" "$rc" "$label" "$cmd" "$out"
+  fi
+}
+
+echo "== must pass through (0) — not a release =="
+run 0 'gh pr create, heredoc body mentions tagging' \
+  "$(printf 'gh pr create --body-file - <<%sEOF%s\nRatified at v1.0.0.\nlinkage-guard blocks git tag vX.Y.Z until the milestone passes.\nEOF' "'" "'")"
+run 0 'gh pr create, quoted body mentions tagging' \
+  'rtk proxy gh pr create --title "x" --body "the guard blocks git tag v1.2.3"'
+run 0 'gh issue create quoting a tag command' \
+  'gh issue create --body "repro: git tag v2.3.4 then git push origin v2.3.4"'
+run 0 'echo of a tag command'        'echo "git tag v9.9.9"'
+run 0 'git status'                   'git status --short'
+run 0 'git log over a tag range'     'git log --oneline v1.0.6..origin/main'
+run 0 'git show a tag'               'git show v1.0.6'
+run 0 'git push a feature branch'    'git push -u origin feat/some-work'
+run 0 'git commit mentioning a tag'  'git commit -m "docs: describe git tag v1.0.7 flow"'
+run 0 'git tag --list glob'          "git tag -l 'v1.*'"
+run 0 'git tag --list long flag'     'git tag --list v1.0.0'
+run 0 'git tag --delete'             'git tag -d v1.0.0'
+run 0 'git tag --verify'             'git tag -v v1.0.0'
+run 0 'git branch'                   'git branch -a'
+run 0 'LINKAGE_OFF prefix bypass'    'LINKAGE_OFF=1 git tag v1.0.7'
+run 0 'no git anywhere'              'ls -la'
+
+echo "== must gate (2) — a real release =="
+run 2 'lightweight tag'              'git tag v1.0.7'
+run 2 'annotated tag'                'git tag -a v1.0.7 -m "release 1.0.7"'
+run 2 'tag behind the rtk wrapper'   'rtk proxy git tag v1.0.7'
+run 2 'push a version tag'           'git push origin v1.0.7'
+run 2 'push --tags'                  'git push --tags'
+run 2 'push refs/tags'               'git push origin refs/tags/v1.0.7'
+run 2 'push a release branch'        'git push origin release/1.0'
+run 2 'commit && tag'                'git commit -m "prep" && git tag v1.0.7'
+run 2 'cd && tag'                    'cd /tmp && git tag v1.0.7'
+run 2 'log && tag'                   'git log --oneline -1 && git tag v1.0.7'
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" = 0 ]


### PR DESCRIPTION
Closes #147

## What

`.claude/hooks/linkage-guard.sh` decided whether a command was a release by grepping the raw command string. That is the wrong input, and it failed in both directions. This scopes the decision to what the shell would actually run, and adds a regression suite.

## The three defects

**1. Fired on payload text.** Any command whose *arguments* mentioned tagging was blocked. Hit while opening #146 — a `gh pr create` whose heredoc body documented this very hook was rejected:

```
BLOCKED by linkage-guard:
error: no milestone titled 'v1.0.0 …' or 'v1.0.0 …' for tag v1.0.0
```

`v1.0.0` there was the *constitution document version*, quoted in prose. Nothing was being tagged. Same for any quoted argument — `gh issue create --body`, `echo`, a commit message.

**2. Leaked across compound commands.** The old line 25 cleared the verdict for the whole command whenever the string contained `git commit`, `git log` or `git show`:

```bash
printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+(commit|log|show)\b' && is_tag=0
```

Unscoped, so `git commit -m … && git tag vX.Y.Z` went through **ungated** — the opposite failure, and the more serious one, since the guard exists to stop exactly that.

**3. The documented bypass did not exist.** `AGENTS.md` documents `LINKAGE_OFF=1 <cmd>`. The script never read `LINKAGE_OFF`, from the environment or the command string, so the escape hatch silently did nothing. `milestone-guard.sh:7` already implements this pattern for `MILESTONE_GUARD_OFF`; this brings the two hooks to parity.

## Approach

Decide scope from the invoked command, not the string:

1. strip heredoc bodies;
2. split on shell separators (`&&`, `||`, `;`, `|`, newline);
3. keep only segments whose command word is `git`, after peeling leading env assignments and wrappers (`rtk proxy`, `sudo`, `env`, …) — so `rtk proxy git tag vX.Y.Z` still counts;
4. apply the tag/push tests **and** the `commit`/`log`/`show` exclusion per segment, so an exclusion cannot leak across `&&`;
5. honour `LINKAGE_OFF=1` as both a command prefix and an exported variable.

## Tests

`scripts/test-linkage-guard.sh` — 26 cases, both directions. It stubs `check-linkage.sh`, so it is offline, deterministic and independent of milestone state; it asserts only the guard's scope decision (exit 0 = passed through, exit 2 = gated).

```bash
bash scripts/test-linkage-guard.sh
```

| Guard | Result |
|---|---|
| pre-fix (`origin/main`) | **19 passed, 7 failed** |
| this PR | **26 passed, 0 failed** |

The 7 pre-fix failures are exactly the reported defects: four payload-text false positives, the missing `LINKAGE_OFF` bypass, and two compound-command leaks (`commit && tag`, `log && tag`).

## Reviewer notes

- **Gating behaviour for real releases is unchanged.** `git tag vX.Y.Z`, the annotated `git tag -a vX.Y.Z -m …` form, `git push origin vX.Y.Z`, `git push --tags`, `refs/tags/` and `release/*` pushes all stay gated — each is a case in the suite.
- **Verified end to end**, not just against the stub: `scripts/check-linkage.sh --for-tag v1.0.7` resolves milestone #1 and correctly fails while #147 is open, so a genuine tag is now blocked for the right reason rather than a fabricated one.
- **Self-validating commit**: this PR's own commit message contains the words `git tag vX.Y.Z` in a heredoc. Under the old guard that commit would have been blocked; under the fix it went through.
- **`AGENTS.md` deliberately untouched.** Its `LINKAGE_OFF=1` documentation was already correct — the code was what disagreed with it, and now matches.
- **Known remaining gap, not addressed here**: `git -C <path> tag vX.Y.Z` still evades detection, because the tag test requires `tag` immediately after `git`. Pre-existing, orthogonal to these three defects, and left for a separate change rather than widened silently.
- Shell only. No Scala, Java or Kotlin source touched, no build or dependency change. `shellcheck -S warning` is clean on both files; `sbt scalafmtAll scalafmtSbt` ran via the pre-commit hook and reformatted nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
