### PR TITLE
fix(client): keep tracker acquisition off the producer I/O thread (#163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           KAFKA_INTER_BROKER_LISTENER_NAME: BROKER
           KAFKA_BROKER_ID: "1"
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+          # Mirrors docker-compose.kafka.yml: Kafka's 3s default delays the first assignment of every
+          # new consumer group past the point where KafkaGatlingTest's scenarios publish each other's
+          # replies, which fails the simulation. This is the only setting the two stacks agree on —
+          # broker and Schema Registry generations still differ; consolidating them is issue #192.
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
           KAFKA_CREATE_TOPICS: "myTopic1:1:1, test.t1:1:1, myTopic2:1:1, test.t2:1:1, myTopic3:1:1, test.t3:1:1"
         ports:
           - '9092:9092'

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-nonblocking-tracker-acquisition"
+}

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -22,6 +22,10 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      # Kafka's 3s default delays the first assignment of every new consumer group, which is far
+      # longer than the simulations wait before publishing replies. Test brokers set this to 0
+      # (Testcontainers' Kafka module does the same).
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
     ports:
       - "9092:9092"
       - "9093:9093"

--- a/specs/001-nonblocking-tracker-acquisition/checklists/requirements.md
+++ b/specs/001-nonblocking-tracker-acquisition/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Non-blocking Reply-Tracker Acquisition for Request-Reply Sends
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- Validation pass 1 (2026-08-03): all items pass. No [NEEDS CLARIFICATION] markers were needed —
+  failure semantics, measurement semantics, and scope boundaries all have established defaults in
+  current behavior, recorded in the spec's Assumptions section.
+- "Key Entities" section omitted: the feature changes execution behavior, not data.
+- Scope boundary vs sibling milestone issues (#143, #164, #165, #166) is stated explicitly in
+  Assumptions; none are prerequisites.

--- a/specs/001-nonblocking-tracker-acquisition/contracts/internal-api.md
+++ b/specs/001-nonblocking-tracker-acquisition/contracts/internal-api.md
@@ -1,0 +1,100 @@
+# Internal API & Threading Contract
+
+**Feature**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md)
+
+The plugin's *published* contract (Scala DSL, `javaapi`, protocol defaults, wire formats) is
+intentionally unchanged — see spec FR-008. This document is the contract between the three
+internal collaborators the feature touches. It is normative for implementation and review.
+
+## 1. `DynamicKafkaConsumer`
+
+```scala
+/** Requests that `topic` join the consumer subscription.
+  *
+  * Non-blocking: enqueues the request and returns immediately. The returned future completes
+  * when the consumer is assigned partitions for a subscription including `topic` (or the topic
+  * is already subscribed), and fails if the consumer has failed or is closed. The future carries
+  * no deadline — callers own timeout policy.
+  */
+def requestTopicSubscription(topic: String): CompletableFuture[Void]
+
+// removed: def addTopicForSubscription(newTopic: String, assignTimeout: FiniteDuration): Boolean
+def removeTopicSubscription(topic: String): Unit   // unchanged
+```
+
+**Guarantees**:
+
+- G1. Never blocks the calling thread (queue add + possible `initLatch.countDown` only).
+- G2. If the consumer already failed, returns an already-failed future with the existing
+  `IllegalStateException("Kafka consumer failed; dynamic consumer can no longer be used")` cause
+  chain — it does **not** throw.
+- G3. Completion may occur on the **consumer poll thread** (rebalance listener /
+  already-subscribed branch) or the closing thread. Work attached by callers MUST be dispatched
+  off-thread (`whenCompleteAsync` with an explicit executor) unless O(µs) and non-blocking.
+- G4. On consumer failure (`markConsumerFailed`) every queued future fails with the failure
+  cause. On close / run-loop exit, remaining queued futures fail exceptionally ("consumer
+  closed") — no future is left forever-pending (spec edge case: shutdown mid-preparation).
+- G5. Queue/coalescing semantics vs `removeTopicSubscription` are unchanged from today,
+  including the #164 no-op-subscribe defect (documented, out of scope).
+
+## 2. `KafkaMessageTrackerPool`
+
+```scala
+/** Obtains (or creates) the tracker for (consumerTopic, matcher-identity) without blocking.
+  *
+  * Exactly one of `onReady` / `onFailure` is invoked, exactly once.
+  */
+def acquireTracker(
+    producerTopic: String,
+    consumerTopic: String,
+    messageMatcher: KafkaMatcher,
+    responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
+    timeout: FiniteDuration,
+)(onReady: ActorRef[KafkaMessageTracker.TrackerMessage] => Unit, onFailure: Throwable => Unit): Unit
+
+// removed: def tracker(...): ActorRef[KafkaMessageTracker.TrackerMessage]  (blocking)
+def releaseTracker(consumerTopic: String, messageMatcher: KafkaMatcher): Unit   // unchanged
+```
+
+**Guarantees**:
+
+- G6. `acquireTracker` never blocks the calling thread. Fast path (entry exists): refcount
+  incremented and `onReady` invoked **inline on the caller's thread** before the method returns.
+  Slow path: returns immediately; continuations run on the setup executor.
+- G7. Pool-poisoned state (`consumerFailure` set) reports through `onFailure` — synchronously on
+  the calling thread — never by throwing.
+- G8. Timeout produces `onFailure` with a `RuntimeException` whose message names the topic and
+  the timeout (existing text: `Timed out waiting for consumer assignment to topic 'T' after t`).
+  A timed-out acquisition has touched no refcount and created no `TrackerEntry`; a later
+  `acquireTracker` for the same topic issues a fresh readiness request (FR-003).
+- G9. Refcount/registration atomicity is unchanged: insert-or-increment under
+  `trackers.compute`; concurrent slow-path winners converge on one `TrackerEntry` (second
+  completes as increment). `onComplete`-driven `releaseTracker` pairing is preserved 1:1 with
+  successful acquisitions.
+- G10. The setup executor is single-threaded, daemon, owned by the pool, shut down via
+  `registerOnTermination`; tasks scheduled on it MUST be non-blocking and MUST NOT call broker
+  APIs.
+
+## 3. `KafkaRequestReplyAction` (caller obligations)
+
+- G11. The producer-callback body performs only: debug logging guard, `requestMatch`, and
+  `acquireTracker` wiring. No waiting of any kind on the delivery-callback thread (FR-001/002).
+- G12. `onReady` body: record `sentTimestamp = clock.nowMillis`, then
+  `tracker ! MessagePublished(..., onComplete = releaseTracker(...))` — identical timestamp
+  semantics to today (FR-005). It may execute inline on the producer I/O thread (fast path) or on
+  the setup executor (slow path); both are non-blocking actor tells.
+- G13. `onFailure` body: the existing KO path — `statsEngine.logResponse(..., KO, ...)` with the
+  failure message, `next ! session.markAsFailed` — timing spans request start → failure
+  detection. `StatsEngine` and actor tells are thread-safe from any thread; no release call is
+  needed (G8: nothing was reserved).
+- G14. Send-failure path (`onFailure` of `KafkaSender.send`) is byte-for-byte unchanged; it can
+  never hold a tracking reservation (acquisition starts only after a successful ack) — FR-006.
+
+## Thread-role summary
+
+| Thread | May do | Must never do |
+|--------|--------|---------------|
+| Producer I/O (ack callback) | fast-path CHM ops, refcount incr, actor tells, enqueue readiness request, schedule timeout | park/await, `Future.get`, broker calls |
+| Consumer poll thread | complete/fail readiness futures (O(µs)) | run acquisition continuations inline, call `producer.send`, tracker bookkeeping |
+| Setup executor (1 daemon thread) | create+register tracker actors, `onReady`/`onFailure` continuations, timeout firing | block, call broker APIs, run user checks |
+| Gatling VU / event-loop threads | initiate `sender.send` | acquire trackers synchronously |

--- a/specs/001-nonblocking-tracker-acquisition/contracts/internal-api.md
+++ b/specs/001-nonblocking-tracker-acquisition/contracts/internal-api.md
@@ -34,8 +34,12 @@ def removeTopicSubscription(topic: String): Unit   // unchanged
 - G4. On consumer failure (`markConsumerFailed`) every queued future fails with the failure
   cause. On close / run-loop exit, remaining queued futures fail exceptionally ("consumer
   closed") — no future is left forever-pending (spec edge case: shutdown mid-preparation).
-- G5. Queue/coalescing semantics vs `removeTopicSubscription` are unchanged from today,
-  including the #164 no-op-subscribe defect (documented, out of scope).
+- G5. Readiness is resolved from the consumer's actual assignment, not from a rebalance callback:
+  pending futures are held on the consumer (`awaitingAssignment`), never captured by a
+  `ConsumerRebalanceListener`, because a later `subscribe()` replaces the listener and would strand
+  anything the previous one held. A future completes when its topic appears in
+  `consumer.assignment()` — so an assignment that excludes the topic no longer completes it, and
+  `subscribe()` is skipped when the topic set is unchanged.
 
 ## 2. `KafkaMessageTrackerPool`
 

--- a/specs/001-nonblocking-tracker-acquisition/data-model.md
+++ b/specs/001-nonblocking-tracker-acquisition/data-model.md
@@ -1,0 +1,93 @@
+# Phase 1 Data Model: Non-blocking Reply-Tracker Acquisition
+
+**Feature**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+No persisted data; all entities are in-memory runtime state inside the `client` layer. Existing
+entities are listed where their lifecycle participates in the change.
+
+## Entities
+
+### PendingSubscription (changed representation)
+
+Queue element in `DynamicKafkaConsumer` awaiting consumer readiness for one topic request.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `topic` | `String` | Reply (consumer) topic requested for subscription |
+| `readiness` | `CompletableFuture[Void]` | Replaces today's `CountDownLatch`; one per request, never shared across requests (N concurrent first-users of a topic = N queue entries, as today) |
+
+**Validation rules**: created only after a consumer-failure fast check; carries no timeout (the
+caller owns deadlines — FR-003 keeps timeout policy in the pool/protocol layer).
+
+**State transitions**:
+
+```text
+Queued ──(updateSubscription: topic already in subscription, not being removed)──▶ Completed
+Queued ──(subscribe() → onPartitionsAssigned)───────────────────────────────────▶ Completed
+Queued ──(markConsumerFailed)──────────────────────────────▶ Failed(consumer failure, cause)
+Queued ──(consumer close / run-loop exit drains queue)─────▶ Failed(consumer closed)
+```
+
+Completion is idempotent (`complete`/`completeExceptionally` after completion is a no-op), which
+absorbs the race between assignment, failure, and shutdown.
+
+### AcquisitionRequest (new, transient)
+
+One request-reply operation's attempt to obtain a tracker, held as closure state on the slow
+path in `KafkaMessageTrackerPool.acquireTracker`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `consumerTopic` / `producerTopic` | `String` | Identity of the exchange |
+| `matcher` | `KafkaMatcher` (by reference) | Same reference-identity semantics as today's `MatcherRef` |
+| `timeout` | `FiniteDuration` | Protocol reply timeout; bounds the readiness wait |
+| `timeoutTask` | `ScheduledFuture[_]` | Cancelled when readiness completes first; fires `completeExceptionally(RuntimeException("Timed out waiting for consumer assignment to topic 'T' after t"))` otherwise |
+| `onReady` | `ActorRef[TrackerMessage] => Unit` | Action's continuation: record sent timestamp, register `MessagePublished` |
+| `onFailure` | `Throwable => Unit` | Action's continuation: existing KO reporting path |
+
+**States**:
+
+```text
+FastPath(found) ──────────────────────────────▶ Ready        (onReady inline, caller thread)
+SlowPath ──▶ AwaitingReadiness ──(complete)───▶ Ready        (onReady on setup executor)
+             AwaitingReadiness ──(timeout)────▶ TimedOut     (onFailure on setup executor)
+             AwaitingReadiness ──(cons. fail)─▶ Failed       (onFailure on setup executor)
+```
+
+Exactly one of `onReady`/`onFailure` is invoked, exactly once (guaranteed by
+`CompletableFuture.whenCompleteAsync` single-fire semantics).
+
+### TrackerEntry (existing, unchanged)
+
+`(actor: ActorRef[TrackerMessage], refCount: AtomicInteger)` in the
+`consumerTopic → (MatcherRef → TrackerEntry)` two-level `ConcurrentHashMap`.
+
+- Insert-or-increment stays inside `trackers.compute` (bin-lock atomicity vs `releaseTracker`
+  unchanged).
+- On the slow path the increment happens in the readiness continuation — i.e. only once tracking
+  is actually ready. A timed-out acquisition therefore never touches a refcount (nothing to roll
+  back; FR-006's no-residual-reservation guarantee).
+- `releaseTracker` (decrement, remove at zero, queue unsubscribe) is untouched — its defects are
+  #165/#166 scope.
+
+### SetupExecutor (new)
+
+Pool-owned `ScheduledThreadPoolExecutor(1)`, daemon, thread name
+`gatling-kafka-tracker-setup`.
+
+**Lifecycle**: created with `KafkaMessageTrackerPool`; `shutdownNow()` added to the existing
+`actorSystem.registerOnTermination` block (alongside consumer close), satisfying the spec's
+clean-shutdown edge case. Tasks must be non-blocking; nothing on it may call broker APIs.
+
+## Relationships
+
+```text
+KafkaRequestReplyAction ──acquireTracker(onReady,onFailure)──▶ KafkaMessageTrackerPool
+KafkaMessageTrackerPool ──requestTopicSubscription──▶ DynamicKafkaConsumer (PendingSubscription)
+DynamicKafkaConsumer ──complete/fail readiness──▶ (setup executor) ──▶ TrackerEntry upsert ──▶ onReady
+KafkaMessageTracker (actor) ◀─MessagePublished── onReady closure   [unchanged message protocol]
+```
+
+`KafkaProtocolMessage`, `KafkaMatcher`, and the tracker actor message protocol
+(`MessagePublished` / `MessageConsumed` / `ConsumerFailure` / `TimeoutScan`) are **not** modified
+— single wire representation and matching contract preserved (constitution Principle III).

--- a/specs/001-nonblocking-tracker-acquisition/plan.md
+++ b/specs/001-nonblocking-tracker-acquisition/plan.md
@@ -1,0 +1,205 @@
+# Implementation Plan: Non-blocking Reply-Tracker Acquisition for Request-Reply Sends
+
+**Branch**: `001-nonblocking-tracker-acquisition` | **Date**: 2026-08-03 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/001-nonblocking-tracker-acquisition/spec.md`
+
+Fixes [#163](https://github.com/galax-io/gatling-kafka-plugin/issues/163).
+
+## Summary
+
+`KafkaRequestReplyAction` currently performs tracker acquisition inside the producer send
+callback. On first use of a reply topic, `KafkaMessageTrackerPool.tracker(...)` reaches
+`DynamicKafkaConsumer.addTopicForSubscription(...)`, which parks on a `CountDownLatch` for up to
+the protocol reply timeout (60 s default) — on the producer's single I/O thread, stalling delivery
+callbacks for every in-flight send in the simulation.
+
+The fix keeps the current send-then-track order but makes readiness asynchronous:
+
+1. `DynamicKafkaConsumer` exposes promise-based subscription readiness
+   (`requestTopicSubscription(topic): CompletableFuture[Void]`), completed by the existing
+   rebalance-listener / already-subscribed / failure paths instead of counting down latches.
+2. `KafkaMessageTrackerPool` replaces blocking `tracker(...)` with callback-based
+   `acquireTracker(...)(onReady, onFailure)`. Fast path (tracker exists) invokes `onReady` inline
+   — pure non-blocking map ops. Slow path attaches a continuation and a scheduled timeout on a
+   pool-owned single-thread daemon `ScheduledExecutorService`; the producer callback never waits.
+3. `KafkaRequestReplyAction` wires `onReady` (record `sentTimestamp`, register
+   `MessagePublished`) and `onFailure` (existing KO reporting), so acquisition timeout fails only
+   the affected request while the shared producer keeps flowing.
+
+No public DSL, `javaapi`, default, or wire-format change. No new dependency (JDK
+`java.util.concurrent` only).
+
+## Technical Context
+
+**Language/Version**: Scala 2.13.18 (core), Java 17+ (Temurin in CI); Java facade untouched
+
+**Primary Dependencies**: Gatling 3.13.5 (actor system, StatsEngine, Clock), Confluent Kafka
+clients 7.9.2-ccs (`KafkaProducer` callback semantics, `KafkaConsumer` rebalance listener); JDK
+`CompletableFuture` + `ScheduledExecutorService` (no new library)
+
+**Storage**: N/A
+
+**Testing**: MUnit + ScalaTest, Testcontainers (real broker; constitution forbids mocking Kafka
+behavior), Gatling simulations `KafkaGatlingTest` / `KafkaJavaapiMethodsGatlingTest` via
+`docker-compose.kafka.yml` in CI
+
+**Target Platform**: JVM library (Gatling plugin), Linux CI / macOS dev
+
+**Project Type**: Single sbt project — published library
+
+**Performance Goals**: Producer callback path O(µs), allocation-light: fast path stays two CHM
+reads + one atomic increment + actor tell; slow path adds one future, one scheduled timeout task,
+one small closure per first-use-of-topic (not per request)
+
+**Constraints**: Producer I/O thread and consumer poll thread must never block on plugin
+bookkeeping; setup-executor tasks must be non-blocking (µs-scale); reported latency semantics
+unchanged (sent timestamp recorded at tracking-ready instant, as today); per-request failure
+isolation preserved
+
+**Scale/Scope**: 3 main-source files changed (`KafkaRequestReplyAction`, `KafkaMessageTrackerPool`,
+`DynamicKafkaConsumer`), 4 test files touched + 1 new integration spec; sibling issues #143, #164,
+#165, #166 explicitly out of scope
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*Source: `.specify/memory/constitution.md` v1.0.0.*
+
+- [x] **I. Published API Compatibility**: PASS — no public Scala DSL or `javaapi` signature,
+      default, or serialized format changes. Replaced methods (`KafkaMessageTrackerPool.tracker`,
+      `DynamicKafkaConsumer.addTopicForSubscription`) are internal `client` collaborators wired by
+      the protocol layer; they appear in no README example, no `javaapi` type, and no DSL surface
+      (verified by usage scan — consumers are `KafkaRequestReplyAction` and this repo's tests
+      only). `ExampleSmokeValidation` must stay green as the gate's witness.
+- [x] **II. Real Broker Over Mocks**: PASS — the regression scenario (stalled callback), timeout
+      isolation, and retry-after-timeout are validated against Testcontainers in a new integration
+      spec (broker configured with topic auto-creation disabled to make assignment genuinely
+      unavailable). Existing queue-semantics unit specs keep their no-broker scope.
+- [x] **III. Layer Separation & Single Wire Contract**: PASS — `DynamicKafkaConsumer` still owns
+      subscription readiness, `KafkaMessageTrackerPool` still owns acquisition/refcounting,
+      `KafkaSender` untouched, the action only wires injected collaborators. Error propagation
+      moves from thrown exceptions to an explicit `onFailure` channel (removes
+      control-flow-by-exception from the callback path). No new parallel message/matcher types; no
+      speculative abstraction — the future-based readiness has a real caller (the pool) and a real
+      forcing function (this defect).
+- [x] **IV. Test-First for Behavior Change**: PASS — the plan's primary test reproduces the stall
+      against pre-fix code (fails red), plus focused red-first tests for timeout KO isolation and
+      async readiness completion. See quickstart.md for the red/green run order.
+- [x] **V. One Concern per Change, Always Green**: PASS — spec/plan/tasks artifacts land first as
+      `docs(speckit): …`; implementation is a single `fix(client): non-blocking tracker
+      acquisition (#163)` commit, green under `sbt scalafmtCheckAll scalafmtSbtCheck compile
+      test`; PR carries milestone `v1.1.0 Request-reply reliability` and `Closes #163`.
+- [x] **Constraints**: PASS — zero new dependencies; Avro/Schema Registry scope untouched; Gatling
+      version unchanged (no README compatibility-table update needed).
+
+**Post-design re-check (after Phase 1)**: all six gates still PASS — design artifacts introduce no
+public-surface change and no new dependency; Complexity Tracking stays empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-nonblocking-tracker-acquisition/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0: decisions & alternatives
+├── data-model.md        # Phase 1: entities, states, transitions
+├── quickstart.md        # Phase 1: validation guide (red/green runs)
+├── contracts/
+│   └── internal-api.md  # Phase 1: internal API + threading contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (done)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/org/galaxio/gatling/kafka/
+├── actions/
+│   └── KafkaRequestReplyAction.scala      # callback → non-blocking; onReady/onFailure wiring
+└── client/
+    ├── DynamicKafkaConsumer.scala         # promise-based requestTopicSubscription; latch removal
+    └── KafkaMessageTrackerPool.scala      # acquireTracker(onReady, onFailure); setup executor
+
+src/test/scala/org/galaxio/gatling/kafka/
+├── client/
+│   ├── DynamicKafkaConsumerSpec.scala     # queue semantics migrated to future API
+│   ├── KafkaMessageTrackerPoolSpec.scala  # tracker() call site → acquireTracker
+│   └── TrackerRefCountSpec.scala          # refcount invariants over async acquisition
+└── integration/
+    ├── KafkaIntegrationSpec.scala         # existing sync-API sites migrated to future API
+    └── TrackerAcquisitionIsolationSpec.scala  # NEW: regression + isolation (red-first)
+```
+
+**Structure Decision**: Existing single-project sbt layout; no new modules. One new test file
+(`TrackerAcquisitionIsolationSpec`) because the regression scenario needs its own broker container
+configured with `auto.create.topics.enable=false`, which the shared container in
+`KafkaIntegrationSpec` does not use.
+
+## Design
+
+### Flow after the change (request-reply success path)
+
+```text
+VU thread          producer I/O thread              setup executor / consumer thread
+────────────       ─────────────────────────        ────────────────────────────────
+send(msg) ───────▶ ack callback:
+                     requestMatch(msg)      (µs)
+                     acquireTracker(...):
+                       fast path? ──yes──▶ onReady inline:
+                                             sentTimestamp = now
+                                             tracker ! MessagePublished
+                       └─no (first use) ──▶ requestTopicSubscription(topic)   [enqueue only]
+                                            schedule timeout(replyTimeout)
+                     ◀── callback returns; producer thread free ──
+
+                                            consumer thread: onPartitionsAssigned
+                                              → future.complete()             (µs)
+                                            setup executor (whenCompleteAsync):
+                                              success → create/register actor,
+                                                        onReady → MessagePublished
+                                              timeout/failure → onFailure → KO,
+                                                        VU continues
+```
+
+### Key decisions (full rationale in research.md)
+
+1. **Send-first order preserved** — acquisition still starts at the delivery callback, so
+   measured-latency semantics and the reply-matching window are byte-for-byte today's (FR-004,
+   FR-005). Acquire-before-send was rejected: it moves `producer.send` onto continuation threads
+   (risking `max.block.ms` stalls on the consumer thread) for no requirement the spec needs.
+2. **JDK `CompletableFuture` + pool-owned single-thread daemon `ScheduledExecutorService`** — no
+   new dependency, explicit thread ownership, shut down with the pool via the existing
+   `registerOnTermination` block. Timeout = scheduled `completeExceptionally` with the exact
+   message text used today (`Timed out waiting for consumer assignment to topic 'T' after t`).
+3. **Blocking internal APIs are replaced, not kept alongside** — a blocking `tracker(...)` left in
+   place invites exactly the regression this feature removes. The four test call sites of
+   `addTopicForSubscription` migrate to `requestTopicSubscription(...).get(timeout)`-style waits
+   (blocking is fine on test threads).
+4. **FR-006 is satisfied structurally**: acquisition begins only after a successful ack, so no
+   code path holds a tracking reservation for a send that then fails. The pool's
+   insert-or-increment `compute` and `releaseTracker` refcount logic are unchanged.
+5. **Failure semantics preserved**: consumer failure fails pending futures
+   (`markConsumerFailed`), close/shutdown drains the queue exceptionally (spec edge case
+   "shutdown while preparation in flight"), and a timed-out topic remains eligible for a fresh
+   attempt — the already-subscribed fast-ack in `updateSubscription` still completes retries on
+   the next poll cycle. The known no-op-subscribe latch defect stays tracked as #164 and is
+   neither fixed nor worsened here.
+
+### Explicitly out of scope (sibling milestone issues)
+
+- #143 — poll after full unsubscribe crashes the consumer and poisons the pool
+- #164 — coalesced add+remove produces a no-op `subscribe`, readiness never signals
+- #165 — per-request subscription churn / rebalance
+- #166 — tracker timer + actor leak on release
+
+This feature removes the *amplification* of slow readiness across the shared producer; the
+siblings remove the *causes* of slow readiness.
+
+## Complexity Tracking
+
+No constitution violations — table intentionally empty.

--- a/specs/001-nonblocking-tracker-acquisition/plan.md
+++ b/specs/001-nonblocking-tracker-acquisition/plan.md
@@ -190,6 +190,61 @@ send(msg) ───────▶ ack callback:
    the next poll cycle. The known no-op-subscribe latch defect stays tracked as #164 and is
    neither fixed nor worsened here.
 
+### Discovered during implementation (design deltas from the original outline)
+
+1. **Readiness must not live in the rebalance listener.** `updateSubscription` captured the pending
+   latches (now futures) in the `ConsumerRebalanceListener` closure. Kafka keeps only the most
+   recent listener, so a second `subscribe()` issued before the first rebalance completed silently
+   discarded the first listener *and the readiness it held* — the caller then waited out its full
+   timeout for a topic that was subscribed and healthy. Blocking acquisition hid this by
+   serialising subscriptions; making acquisition concurrent exposed it immediately (traced on the
+   CI simulation: `Timed out waiting for consumer assignment to topic 'test.t1' after 60 seconds`).
+   Readiness therefore lives on the consumer in `awaitingAssignment: topic -> pending futures`, and
+   is resolved from `consumer.assignment()` by `completeAssignedReadiness()`, called from the
+   listener and after every poll. Side effects: readiness now completes only when the topic is
+   genuinely assigned (previously *any* assignment completed *all* pending latches), and
+   `subscribe()` is skipped when the topic set is unchanged, since readiness no longer depends on a
+   rebalance being triggered.
+
+2. **`docker-compose.kafka.yml` needed `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0`.** The test
+   broker was inheriting Kafka's 3 s default, so the first assignment of every new consumer group
+   took ~3 s. `KafkaGatlingTest` has no echo service — its "replies" are published by sibling
+   scenarios at +1 s and +2 s — so with `auto.offset.reset` at its `latest` default those replies
+   landed before the reply consumer was assigned and were skipped. The simulation passed only
+   because the blocking acquisition froze the shared producer I/O thread and thereby also delayed
+   the sibling scenario's publish until after the assignment: it was green *because of* the defect
+   under fix. Zeroing the delay on the test broker (what Testcontainers' own Kafka module does)
+   makes the simulation deterministic instead of dependent on that stall. Verified: KO rate is back
+   to the baseline 1-of-9 (11.11%), the one KO being `scnRRwo`, which is failing by design.
+
+3. **Making acquisition non-blocking moved failure handling, and the first cut lost some of it.** A
+   review pass over this branch found several guarantees that the pre-fix code held only because the
+   producer's I/O thread serialised everything, and that the asynchronous version had to re-establish
+   explicitly:
+   - The action's `try`/`catch` around acquisition was deleted, but `acquireTracker` can still throw
+     synchronously (`RejectedExecutionException` once the setup executor is shut down). The slow path
+     is now wrapped and reports through `onFailure`; both paths hand the tracker over via
+     `deliverReady`, which keeps a throwing `onReady` from escaping into the delivery callback and
+     from being reported as a second, contradictory outcome for a request already in the mailbox.
+   - `registerTracker` created the tracker actor *before* the deduplicating `compute`. With callbacks
+     no longer serialised, N concurrent first uses of a topic all reach it and N-1 actors were started
+     and orphaned, each still running its own periodic timeout scan. The actor is now created inside
+     the insert branch.
+   - `close()` drains `topicsQueue` from its own thread, so `updateSubscription`'s
+     `val (topic, readiness) = topicsQueue.poll()` could destructure `null` and take the whole pool
+     down through `markConsumerFailed`. Null-guarded.
+   - The readiness continuation did not re-check `consumerFailure`, dropping a guard the pre-fix code
+     had on both sides of the blocking wait; and `setupExecutor.shutdownNow()` discarded exactly the
+     continuations the shutdown ordering exists to preserve (a `ScheduledThreadPoolExecutor` cancels
+     even zero-delay queued tasks on shutdown unless told otherwise). Both restored.
+   - Readiness parked for a topic that is then unsubscribed is now failed explicitly instead of
+     waiting out the caller's full timeout on a topic nobody listens to.
+
+   Two review findings are deliberately left open: readiness now requires the topic in this member's
+   own `assignment()`, which changes behaviour for a user-supplied shared `group.id` (a decision, not
+   a repair), and `awaitingAssignment` still retains entries for readiness resolved purely by the
+   pool's timeout.
+
 ### Explicitly out of scope (sibling milestone issues)
 
 - #143 — poll after full unsubscribe crashes the consumer and poisons the pool

--- a/specs/001-nonblocking-tracker-acquisition/quickstart.md
+++ b/specs/001-nonblocking-tracker-acquisition/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: Validating Non-blocking Reply-Tracker Acquisition
+
+**Feature**: [spec.md](spec.md) | Contracts: [contracts/internal-api.md](contracts/internal-api.md)
+
+## Prerequisites
+
+- JDK 17+, sbt, Docker running (Testcontainers pulls the Kafka image on first run)
+- For the full CI-equivalent Gatling line: `docker compose -f docker-compose.kafka.yml up -d`
+
+## Red first (constitution IV)
+
+The regression spec lands before the fix and must fail against pre-fix code:
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.integration.TrackerAcquisitionIsolationSpec"
+```
+
+Expected **pre-fix**: the "healthy topic unaffected by a stalled topic" assertion fails — the
+healthy request's completion time is dragged to ≈ the poisoned topic's full reply timeout because
+the producer callback thread is parked (spec SC-001/SC-003).
+
+## Green (post-fix)
+
+Same command. Expected assertions, mapping to spec success criteria:
+
+| Assertion | Spec |
+|-----------|------|
+| Healthy-topic request-reply completes in normal time (≪ reply timeout) while the poisoned topic's preparation is pending | SC-001, US1 |
+| Delivery confirmations keep flowing during the entire stall window (follow-up sends confirm promptly) | SC-002, FR-002 |
+| Poisoned-topic request KOs at ≈ reply timeout with an error naming the topic and duration | SC-004, US2 |
+| After the KO: a healthy request still OK; a fresh poisoned-topic request attempts preparation again (KOs again, not instantly poisoned) | FR-003 |
+| Concurrent first use of one new topic: channel prepared once, all requests proceed | FR-007 |
+
+## Full verification (must all pass unchanged — SC-005, FR-008)
+
+```bash
+sbt scalafmtCheckAll scalafmtSbtCheck compile test
+```
+
+```bash
+sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"
+```
+
+CI-equivalent Gatling simulations against the Compose stack (latency-semantics witness for
+FR-005 — request-reply timings in the report stay in line with current releases):
+
+```bash
+sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport
+```
+
+## What changed where (for reviewers)
+
+- `client/DynamicKafkaConsumer.scala` — readiness futures replace latches;
+  `requestTopicSubscription` (contract G1–G5)
+- `client/KafkaMessageTrackerPool.scala` — `acquireTracker(onReady, onFailure)` + setup executor
+  (G6–G10)
+- `actions/KafkaRequestReplyAction.scala` — non-blocking callback wiring (G11–G14)
+- Tests: `TrackerAcquisitionIsolationSpec` (new), migrations in `DynamicKafkaConsumerSpec`,
+  `KafkaMessageTrackerPoolSpec`, `TrackerRefCountSpec`, `KafkaIntegrationSpec`
+
+Detailed task breakdown arrives with `/speckit-tasks` → `tasks.md`.

--- a/specs/001-nonblocking-tracker-acquisition/research.md
+++ b/specs/001-nonblocking-tracker-acquisition/research.md
@@ -1,0 +1,131 @@
+# Phase 0 Research: Non-blocking Reply-Tracker Acquisition
+
+**Feature**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md) | **Date**: 2026-08-03
+
+No `NEEDS CLARIFICATION` markers existed in the Technical Context; research resolved the five
+design unknowns below. Code references are to the current `main`
+(`24306fe`).
+
+## R1. Where acquisition runs relative to the send
+
+**Decision**: Keep the current send → ack → acquire-tracking order; make the acquisition itself
+asynchronous.
+
+**Rationale**:
+- Measured-latency semantics stay identical: `MessagePublished.sentTimestamp` is recorded at the
+  tracking-ready instant, exactly as today (`KafkaRequestReplyAction.scala:56-59`), satisfying
+  FR-005 without re-deriving what "sent" means.
+- The reply-matching window keeps today's structure (FR-004): the subscription request is issued
+  at ack time in both designs, so no new interval appears in which a reply can be lost relative
+  to current behavior.
+- Send stays on the VU/action path. Gatling actions must not block, and nothing here adds
+  blocking to them.
+
+**Alternatives considered**:
+- *Acquire before send* (issue's first suggestion): closes a pre-existing latent gap (reply
+  produced before the consumer's first assignment can be missed under `auto.offset.reset=latest`)
+  but moves `producer.send` into readiness continuations. `KafkaProducer.send` may block up to
+  `max.block.ms` (metadata fetch, buffer-full), which would put a potentially-blocking call on
+  the setup executor or — worse — the consumer thread. Fixing the latent gap belongs with the
+  subscription-lifecycle rework (#165), not here.
+- *Blocking acquisition on the VU thread before send*: blocks a shared Gatling event-loop thread
+  for up to 60 s — trades one shared-thread stall for another.
+
+## R2. Async primitive and executor model
+
+**Decision**: `java.util.concurrent.CompletableFuture[Void]` for readiness; one pool-owned
+single-thread daemon `ScheduledThreadPoolExecutor` (name prefix `gatling-kafka-tracker-setup`)
+used for both timeout scheduling and slow-path continuations (`whenCompleteAsync`). Shut down in
+the existing `actorSystem.registerOnTermination` block in `KafkaMessageTrackerPool`.
+
+**Rationale**:
+- Zero new dependencies (constitution Technology Constraints; Scala stdlib `Future` would drag an
+  `ExecutionContext` decision into every signature for no gain — completion sources here are
+  Java-thread callbacks, not for-comprehensions).
+- Explicit thread ownership: completions may fire from the consumer thread
+  (`onPartitionsAssigned`), from `markConsumerFailed`, or from the timeout task; bouncing
+  continuations to one named executor makes the threading contract auditable and keeps the
+  consumer's poll loop free of tracker bookkeeping.
+- A single thread suffices: every continuation is O(µs) (CHM compute, `actorOf`, actor tell, KO
+  logging). The waiting itself lives in the future, not in a thread, so there is no head-of-line
+  blocking across topics (US1 scenario 1 holds even with many topics preparing concurrently).
+- `ScheduledThreadPoolExecutor` gives cancellable timeout tasks: the timeout is cancelled when
+  readiness completes first, so no garbage timer fires per successful acquisition.
+
+**Alternatives considered**:
+- `CompletableFuture.orTimeout`: uses the JVM-global `CompletableFuture.Delayer` thread —
+  functional, but pending timeouts survive pool shutdown and the thread is shared process-wide;
+  a pool-owned scheduler keeps lifecycle and naming explicit for thread-dump diagnosis.
+- Scala `Promise`/`Future`: needs an `ExecutionContext` at every combinator; interop noise for a
+  Java-callback-driven flow.
+- Gatling's actor `scheduler` (as used by `KafkaMessageTracker`): tied to actor context, not
+  available in the pool without threading it through; and it schedules fixed-rate jobs, while we
+  need cancellable one-shots plus an execution queue.
+- Per-acquisition threads / cached pool running the *blocking* API: under subscription churn
+  (#165 makes every request slow-path) thread count balloons; a bounded pool reintroduces
+  cross-topic head-of-line blocking.
+
+## R3. Fate of the blocking internal APIs
+
+**Decision**: Replace, don't accumulate. `KafkaMessageTrackerPool.tracker(...)` →
+`acquireTracker(...)(onReady, onFailure)`; `DynamicKafkaConsumer.addTopicForSubscription(topic,
+timeout): Boolean` → `requestTopicSubscription(topic): CompletableFuture[Void]`. Test call sites
+(4 in `DynamicKafkaConsumerSpec`, `KafkaIntegrationSpec`; 1 in `KafkaMessageTrackerPoolSpec`)
+migrate to explicit waits on the future from test threads.
+
+**Rationale**:
+- A surviving blocking acquisition method is a loaded footgun — the defect being fixed is someone
+  calling it from a callback. One way to acquire = the non-blocking way.
+- Neither method is published contract: not in the Scala DSL, not in `javaapi`, not in README or
+  examples (usage scan: `KafkaRequestReplyAction`, `KafkaComponents`/`KafkaProtocol` wiring, and
+  this repo's tests only). Constitution Principle I therefore permits the internal replacement;
+  `ExampleSmokeValidation` remains the witness.
+
+**Alternatives considered**: deprecate-and-keep blocking wrappers — rejected: dead main-code kept
+alive for tests invites the exact misuse being removed, and Principle III forbids dead code.
+
+## R4. Reproducing the stall deterministically against a real broker
+
+**Decision**: New `TrackerAcquisitionIsolationSpec` (Testcontainers) with its own Kafka container
+configured `KAFKA_AUTO_CREATE_TOPICS_ENABLE=false`. A request-reply against a nonexistent reply
+topic then subscribes but never receives an assignment, holding readiness open until the
+configured timeout — a genuine, broker-real "slow topic". Scenario: short protocol reply timeout
+(~3 s); fire the poisoned-topic request first, a healthy-topic request immediately after, through
+one shared protocol/producer.
+
+- **Red (pre-fix)**: the healthy request's completion is delayed by ≈ the poisoned topic's full
+  timeout (its ack callback queues behind the blocked producer I/O thread) — assertion "healthy
+  request completes ≪ timeout" fails.
+- **Green (post-fix)**: healthy request completes in normal time while the poisoned request KOs
+  at ~timeout with the message naming topic and duration; a follow-up healthy request and a
+  retry against the poisoned topic both behave per FR-003.
+
+**Rationale**: constitution Principle II — consumer lifecycle and timeout behavior must be
+exercised against a real broker; an unassignable-but-subscribable topic is the one condition that
+produces an honest indefinite-readiness state without mocking or clock games.
+
+**Alternatives considered**:
+- Latency injection into `DynamicKafkaConsumer` via a test seam — a mock of exactly the behavior
+  Principle II says not to mock.
+- Pausing the broker container mid-test — flaky timing, and stalls *all* topics including the
+  healthy one, invalidating the isolation assertion.
+- Asserting on producer-thread identity (that the callback thread never parks) — brittle against
+  Kafka client internals; behavioral latency assertions test what the spec actually promises.
+
+## R5. Retry-after-timeout semantics
+
+**Decision**: Preserve current mechanics unchanged: a timed-out acquisition leaves the topic
+queued for subscription; a later `acquireTracker` for the same topic issues a fresh readiness
+request. If the consumer has meanwhile subscribed the topic, `updateSubscription`'s
+already-subscribed branch (`DynamicKafkaConsumer.scala:105-106`) completes the new future on the
+next poll cycle (≤ 1 s).
+
+**Rationale**: FR-003 requires that a later request *can attempt* preparation again and that
+nothing is permanently poisoned — both hold today at the queue level and keep holding with
+futures substituted for latches. The known case where a retry can still time out spuriously
+(add+remove coalesced into a no-op `subscribe`, readiness never signalled) is issue #164 —
+adjacent by design, not a prerequisite, and this change neither fixes nor worsens it.
+
+**Alternatives considered**: cancelling the queued topic on timeout (rollback) — racy against the
+consumer thread applying the very same queue entry, and it would *change* subscription-lifecycle
+behavior that #164/#165 own; rejected as scope creep.

--- a/specs/001-nonblocking-tracker-acquisition/spec.md
+++ b/specs/001-nonblocking-tracker-acquisition/spec.md
@@ -1,0 +1,196 @@
+# Feature Specification: Non-blocking Reply-Tracker Acquisition for Request-Reply Sends
+
+**Feature Branch**: `001-nonblocking-tracker-acquisition`
+
+**Created**: 2026-08-03
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/gatling-kafka-plugin/issues/163"
+
+Issue #163: preparing reply tracking for a request-reply operation (acquiring a tracker for the
+reply topic, which on first use waits for the reply channel to become ready) currently runs on the
+shared delivery-notification path of the message producer. That path serves every in-flight send in
+the simulation. While one operation waits — up to the configured reply timeout, 60 seconds by
+default — delivery confirmations for **all** other sends stall, inflating measured latencies and
+cascading into spurious send timeouts on unrelated traffic. In a tool whose purpose is accurate
+latency measurement, this makes results wrong exactly when the system is under the load it exists
+to measure.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Slow reply-channel setup on one topic must not stall other traffic (Priority: P1)
+
+A performance engineer runs a simulation containing request-reply scenarios against several topic
+pairs, all sharing one message producer. Reply-channel preparation for one topic is slow (e.g. the
+reply consumer takes long to become ready). Requests on every other topic must keep flowing:
+their sends are confirmed promptly, their replies are matched, and their reported latencies are
+unaffected by the slow topic.
+
+**Why this priority**: This is the defect itself. One slow topic today freezes delivery
+confirmations for the whole simulation, corrupting every measurement and causing spurious
+failures on unrelated scenarios. Fixing it restores the core promise of the tool: numbers that
+reflect the system under test, not the plugin's internals.
+
+**Independent Test**: Run a simulation with request-reply on two topic pairs where reply-channel
+readiness for topic B is artificially delayed close to the configured timeout. Verify topic A's
+requests complete with the same latency profile as a baseline run without topic B, and that no
+send on any topic fails with a send-pipeline timeout.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running simulation with request-reply scenarios on topic pairs A and B sharing one
+   producer, **When** reply-channel preparation for B stalls for a period approaching the reply
+   timeout, **Then** requests on A continue to be sent, confirmed, matched to replies, and reported
+   with latencies matching a baseline run without B.
+2. **Given** the same simulation, **When** reply-channel preparation for B is in progress,
+   **Then** delivery confirmations for already-sent messages on any topic are processed without
+   waiting for B's preparation to finish.
+3. **Given** a simulation where many virtual users hit the same new reply topic concurrently,
+   **When** the reply channel for that topic becomes ready, **Then** all waiting requests proceed,
+   the channel was prepared only once, and at no point did any of them delay delivery
+   confirmations for other messages.
+
+---
+
+### User Story 2 - Reply-channel setup failure affects only the requesting operation (Priority: P2)
+
+A performance engineer runs a simulation where reply-channel preparation for a topic ultimately
+fails (for example, times out because the reply topic is misconfigured). Only the requests that
+needed that topic are marked as failed, each with a descriptive error; every other scenario keeps
+running and measuring normally, and a later request to the same topic may attempt preparation
+again.
+
+**Why this priority**: Failure isolation is what makes a long soak test survivable: one
+misconfigured scenario must produce clearly attributed failures for itself, not poison the shared
+send machinery for the rest of the run.
+
+**Independent Test**: Configure a request-reply scenario against a reply topic that can never
+become ready, alongside a healthy scenario on another topic. Verify the doomed requests fail with
+a descriptive error after the configured timeout, the healthy scenario's results are unaffected,
+and the run completes normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** a request-reply scenario whose reply topic never becomes ready, **When** preparation
+   reaches the configured timeout, **Then** that request is reported as failed with an error
+   naming the topic and the timeout, and the virtual user continues its scenario.
+2. **Given** the same failure, **When** other scenarios continue running, **Then** their sends,
+   confirmations, and reply matching proceed unaffected, with no send-pipeline errors attributable
+   to the failed preparation.
+3. **Given** a preparation failure for a topic, **When** a later request targets the same topic,
+   **Then** preparation is attempted again rather than the topic being permanently failed.
+
+---
+
+### User Story 3 - Reported latency reflects the system under test, not plugin setup (Priority: P3)
+
+A performance engineer reads the simulation report. Request-reply response times measure the
+round-trip of the message exchange — from the message being sent to the reply arriving — and do
+not include time the plugin spent preparing its own reply tracking, consistent with how successful
+requests are measured today.
+
+**Why this priority**: Even with stalls eliminated, silently folding setup cost into response
+times would shift reported percentiles and mislead capacity decisions. Measurement semantics must
+stay stable across plugin versions.
+
+**Independent Test**: Run a scenario where the first request to a topic triggers reply-channel
+preparation with an induced delay. Verify the first request's reported response time is in line
+with subsequent requests' (round-trip only), not inflated by the preparation delay.
+
+**Acceptance Scenarios**:
+
+1. **Given** a topic whose reply-channel preparation is slow, **When** the first request to it
+   completes successfully, **Then** its reported response time reflects the message round-trip
+   and excludes the preparation delay, matching current behavior for successful requests.
+2. **Given** a request that fails during preparation, **When** it is reported, **Then** its
+   failure timing spans from request start to failure detection, matching current behavior for
+   failed requests.
+
+---
+
+### Edge Cases
+
+- Preparation times out: only the affected request fails (descriptive error); the shared send
+  pipeline stays healthy; the topic remains eligible for a fresh preparation attempt.
+- The send itself fails after reply tracking was already prepared for the request: the tracking
+  reservation made for that request is released — no leaked reservations or reply-channel
+  subscriptions accumulate from failed sends.
+- A reply arrives immediately after the send: it is still matched. The change in when tracking is
+  prepared relative to the send must not introduce any new window in which a reply can arrive
+  before the system is able to match it (replies that would be matched today must still match).
+- The shared reply consumer has already failed: a request-reply attempt fails fast for that
+  request with the existing "consumer failed" error, without occupying the shared
+  delivery-notification path.
+- Simulation shuts down while a preparation is in flight: shutdown completes cleanly; the waiting
+  request is resolved (failed or abandoned per existing shutdown semantics) rather than blocking
+  termination.
+- Request-reply and fire-and-forget scenarios share one producer: fire-and-forget sends and their
+  confirmations are never delayed by any request-reply preparation.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Preparing reply tracking for a request-reply operation MUST NOT block or delay the
+  shared delivery-notification path that serves all sends of the simulation. Waiting for a reply
+  channel to become ready happens off that path.
+- **FR-002**: Processing of a delivery confirmation for any message MUST NOT wait on reply-tracking
+  preparation of any other message, regardless of topic.
+- **FR-003**: When reply-tracking preparation for a topic fails or times out, the system MUST fail
+  only the affected request(s) — reported as failed with an error naming the topic and cause —
+  while the virtual user continues its scenario and the shared send machinery remains fully
+  usable. A subsequent request to the same topic MUST be able to attempt preparation again.
+- **FR-004**: Replies MUST NOT be lost as a consequence of reordering preparation relative to
+  sending: every reply that is matched under current behavior MUST still be matched. No new
+  interval may exist in which a request has been sent but its reply cannot be matched.
+- **FR-005**: Reported response-time semantics MUST remain unchanged: successful request-reply
+  response time measures from message sent to reply received, excluding reply-tracking
+  preparation; failed requests continue to span request start to failure detection.
+- **FR-006**: If a send fails after reply tracking was prepared for that request, the tracking
+  reservation made for it MUST be released, leaving no residual reservation or reply-channel
+  subscription attributable to the failed send.
+- **FR-007**: Concurrent first use of the same reply topic by multiple virtual users MUST result
+  in the channel being prepared once, with every waiting request proceeding when it is ready and
+  none of them occupying the shared delivery-notification path while waiting.
+- **FR-008**: The published Scala and Java DSLs, protocol configuration options, defaults, and
+  observable result semantics MUST remain unchanged. The fix is internal to the request-reply
+  execution flow.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a two-topic-pair simulation where one pair's reply-channel readiness is delayed
+  to near the configured timeout, the unaffected pair's response-time distribution (median and
+  p95) matches a baseline run without the delayed pair, and 100% of its requests complete without
+  send-pipeline errors.
+- **SC-002**: During the entire preparation-delay window, delivery confirmations for unrelated
+  in-flight sends continue to be processed — zero unrelated sends fail with pipeline timeouts
+  attributable to the delay (today: cascading timeouts on the shared producer).
+- **SC-003**: A regression test that reproduces the stalled-confirmation scenario fails against
+  the pre-fix behavior and passes after the fix.
+- **SC-004**: When preparation for a topic times out, exactly the requests targeting that topic
+  are reported failed, each with an error naming the topic and timeout; 100% of other in-flight
+  requests complete and report normally.
+- **SC-005**: The complete existing verification suite — unit and integration tests, the CI
+  Gatling simulations, and construction of every README/example simulation — passes unchanged.
+
+## Assumptions
+
+- Per-request failure remains the contract for preparation timeout: the request is reported
+  failed and the virtual user continues; no automatic in-request retry is introduced.
+- Successful-request response time today excludes reply-tracking preparation (the timer starts at
+  the message-sent moment recorded after preparation); this existing semantic is preserved rather
+  than redefined.
+- The single shared producer per protocol instance remains the delivery model; this feature does
+  not introduce per-scenario producers.
+- Scope is bounded to issue #163 — keeping reply-tracking preparation off the shared
+  delivery-notification path and its direct failure/release semantics (FR-001 … FR-008).
+  Sibling milestone defects remain separately tracked and are not prerequisites: the consumer
+  crash after full unsubscription (#143), the no-op re-subscription that never signals readiness
+  (#164), per-request subscription churn (#165), and the tracker timer/actor leak (#166). Those
+  issues make slow preparation *common*; this feature removes its *amplification* across the
+  shared pipeline.
+- Reply-channel preparation may still legitimately take up to the configured reply timeout; this
+  feature changes where that waiting happens and who it affects, not how long it may take.

--- a/specs/001-nonblocking-tracker-acquisition/tasks.md
+++ b/specs/001-nonblocking-tracker-acquisition/tasks.md
@@ -36,8 +36,8 @@ Single-module Scala/sbt project. All paths below are real and repo-relative:
 
 **Purpose**: Baseline sanity and the compatibility evidence the plan's Constitution gate cites.
 
-- [ ] T001 Verify clean baseline on branch `001-nonblocking-tracker-acquisition`: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` green with Docker running (Testcontainers pulls images on first run)
-- [ ] T002 [P] Record the published-surface evidence for research.md R3: grep `src/main/java/ README.md src/test/scala/org/galaxio/gatling/kafka/examples/` for `addTopicForSubscription`, `tracker(`, `KafkaMessageTrackerPool`, `DynamicKafkaConsumer` and confirm the only call sites are `KafkaRequestReplyAction.scala`, protocol wiring, and the four test files named in plan.md; abort and re-plan if anything else appears
+- [X] T001 Verify clean baseline on branch `001-nonblocking-tracker-acquisition`: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` green with Docker running (Testcontainers pulls images on first run)
+- [X] T002 [P] Record the published-surface evidence for research.md R3: grep `src/main/java/ README.md src/test/scala/org/galaxio/gatling/kafka/examples/` for `addTopicForSubscription`, `tracker(`, `KafkaMessageTrackerPool`, `DynamicKafkaConsumer` and confirm the only call sites are `KafkaRequestReplyAction.scala`, protocol wiring, and the four test files named in plan.md; abort and re-plan if anything else appears
 
 ---
 
@@ -49,10 +49,10 @@ the repo compiles at this checkpoint; it is deleted in US1 (T010) once the pool 
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T003 Write FAILING unit tests for `requestTopicSubscription` in src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala: (a) returns a future, queue holds `(topic, future)` (replaces latch-based test at lines 34–64); (b) returns an already-failed future after consumer failure without throwing — G2 (replaces throw-based test at lines 66–95); (c) `close()` fails still-pending futures exceptionally ("consumer closed") — G4
-- [ ] T004 [P] Migrate the three `addTopicForSubscription` call sites in src/test/scala/org/galaxio/gatling/kafka/integration/KafkaIntegrationSpec.scala (lines 245, 439–464) to `requestTopicSubscription(topic).get(timeout)`-style waits on the test thread; the "very short timeout returns false" test becomes "very short `get` timeout throws `java.util.concurrent.TimeoutException` while the future stays pending" (does not compile until T005 — that is the red state)
-- [ ] T005 Implement promise-based readiness in src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala: `topicsQueue` element type `(String, CompletableFuture[Void])`; new `requestTopicSubscription(topic): CompletableFuture[Void]` (fail-fast already-failed future per G2, enqueue, poke `initLatch`, never block — G1); `updateSubscription` already-subscribed branch and `onPartitionsAssigned` complete futures (was `countDown`); `markConsumerFailed` completes queued futures exceptionally with the failure cause; `run()` finally-block and `close()` drain remaining queue entries exceptionally ("consumer closed") — G4; keep `addTopicForSubscription(topic, timeout): Boolean` as a temporary thin blocking delegate over the future preserving today's return/throw semantics
-- [ ] T006 Green gate for Phase 2: `sbt "testOnly org.galaxio.gatling.kafka.client.DynamicKafkaConsumerSpec"` and `sbt "testOnly org.galaxio.gatling.kafka.integration.KafkaIntegrationSpec"` pass; full `sbt compile test` still green
+- [X] T003 Write FAILING unit tests for `requestTopicSubscription` in src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala: (a) returns a future, queue holds `(topic, future)` (replaces latch-based test at lines 34–64); (b) returns an already-failed future after consumer failure without throwing — G2 (replaces throw-based test at lines 66–95); (c) `close()` fails still-pending futures exceptionally ("consumer closed") — G4
+- [X] T004 [P] Migrate the three `addTopicForSubscription` call sites in src/test/scala/org/galaxio/gatling/kafka/integration/KafkaIntegrationSpec.scala (lines 245, 439–464) to `requestTopicSubscription(topic).get(timeout)`-style waits on the test thread; the "very short timeout returns false" test becomes "very short `get` timeout throws `java.util.concurrent.TimeoutException` while the future stays pending" (does not compile until T005 — that is the red state)
+- [X] T005 Implement promise-based readiness in src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala: `topicsQueue` element type `(String, CompletableFuture[Void])`; new `requestTopicSubscription(topic): CompletableFuture[Void]` (fail-fast already-failed future per G2, enqueue, poke `initLatch`, never block — G1); `updateSubscription` already-subscribed branch and `onPartitionsAssigned` complete futures (was `countDown`); `markConsumerFailed` completes queued futures exceptionally with the failure cause; `run()` finally-block and `close()` drain remaining queue entries exceptionally ("consumer closed") — G4; keep `addTopicForSubscription(topic, timeout): Boolean` as a temporary thin blocking delegate over the future preserving today's return/throw semantics
+- [X] T006 Green gate for Phase 2: `sbt "testOnly org.galaxio.gatling.kafka.client.DynamicKafkaConsumerSpec"` and `sbt "testOnly org.galaxio.gatling.kafka.integration.KafkaIntegrationSpec"` pass; full `sbt compile test` still green
 
 **Checkpoint**: Readiness is future-based and fully covered; consumer never leaves a pending
 future unresolved (assignment / already-subscribed / failure / close all resolve it).
@@ -69,16 +69,16 @@ readiness hangs affects only its own requests (spec US1, FR-001/FR-002/FR-007, S
 
 ### Tests for User Story 1 (write FIRST, observe FAIL) ⚠️
 
-- [ ] T007 [US1] Create src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala with its own Testcontainers Kafka container configured `KAFKA_AUTO_CREATE_TOPICS_ENABLE=false` (research R4) and a harness mirroring KafkaIntegrationSpec (real `KafkaSender`, `KafkaMessageTrackerPool`, short ~3 s reply timeout, pre-created healthy topic pair, nonexistent "poisoned" reply topic). Three FAILING tests: (1) fire poisoned-topic request-reply then healthy-topic request-reply through the shared producer — healthy completes in ≪ reply timeout (SC-001; red today: it queues behind the parked callback thread for the full timeout); (2) while the poisoned preparation is pending, additional healthy sends get delivery confirmations promptly (SC-002/FR-002); (3) N concurrent first-use requests against one new (pre-created) topic all proceed once assigned, with a single subscription request and no callback-thread stall (FR-007). Run the spec and record the red failures
+- [X] T007 [US1] Create src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala with its own Testcontainers Kafka container configured `KAFKA_AUTO_CREATE_TOPICS_ENABLE=false` (research R4) and a harness mirroring KafkaIntegrationSpec (real `KafkaSender`, `KafkaMessageTrackerPool`, short ~3 s reply timeout, pre-created healthy topic pair, nonexistent "poisoned" reply topic). Three FAILING tests: (1) fire poisoned-topic request-reply then healthy-topic request-reply through the shared producer — healthy completes in ≪ reply timeout (SC-001; red today: it queues behind the parked callback thread for the full timeout); (2) while the poisoned preparation is pending, additional healthy sends get delivery confirmations promptly (SC-002/FR-002); (3) N concurrent first-use requests against one new (pre-created) topic all proceed once assigned, with a single subscription request and no callback-thread stall (FR-007). Run the spec and record the red failures
 
 ### Implementation for User Story 1
 
-- [ ] T008 [US1] Implement `acquireTracker` in src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala per contract G6–G10: add single-thread daemon `ScheduledThreadPoolExecutor` field (thread name `gatling-kafka-tracker-setup`), shut down in the existing `registerOnTermination` block; fast path = existing `computeIfPresent` refcount++ then `onReady` inline; poisoned-pool check reports via `onFailure` synchronously (G7); slow path = `consumer.requestTopicSubscription(topic)` + scheduled timeout task completing the future exceptionally with `RuntimeException("Timed out waiting for consumer assignment to topic '<topic>' after <timeout>")` (G8, cancelled if readiness wins) + `whenCompleteAsync` on the setup executor running the existing insert-or-increment `trackers.compute` then `onReady(actor)` / `onFailure(cause)` (G9); delete the blocking `tracker(...)` method
-- [ ] T009 [US1] Rewire src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala per G11–G14: success callback keeps only debug log + `requestMatch` + `acquireTracker(...)` call; `onReady` records `sentTimestamp = clock.nowMillis` and sends `MessagePublished(..., onComplete = releaseTracker(...))` (G12); `onFailure` reuses the existing KO reporting extracted into a private helper shared with the send-failure branch (G13); remove the `trackerAcquired` try/catch-release block (pool owns registration consistency); send-failure branch stays byte-for-byte (G14/FR-006)
-- [ ] T010 [US1] Delete the temporary `addTopicForSubscription` delegate from src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala (no callers remain after T004/T008) and verify with `grep -rn addTopicForSubscription src/` → zero hits
-- [ ] T011 [P] [US1] Migrate the `pool.tracker(...)` call site (line 36) in src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala to `acquireTracker` with a small await-both-callbacks test helper; assertions unchanged
-- [ ] T012 [P] [US1] Migrate acquire/release call sites in src/test/scala/org/galaxio/gatling/kafka/client/TrackerRefCountSpec.scala to the same helper; all existing refcount/release invariants must pass unchanged (G9; guards FR-006's no-residual-reservation property)
-- [ ] T013 [US1] Green gate for US1: TrackerAcquisitionIsolationSpec tests 1–3 pass; full `sbt compile test` green
+- [X] T008 [US1] Implement `acquireTracker` in src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala per contract G6–G10: add single-thread daemon `ScheduledThreadPoolExecutor` field (thread name `gatling-kafka-tracker-setup`), shut down in the existing `registerOnTermination` block; fast path = existing `computeIfPresent` refcount++ then `onReady` inline; poisoned-pool check reports via `onFailure` synchronously (G7); slow path = `consumer.requestTopicSubscription(topic)` + scheduled timeout task completing the future exceptionally with `RuntimeException("Timed out waiting for consumer assignment to topic '<topic>' after <timeout>")` (G8, cancelled if readiness wins) + `whenCompleteAsync` on the setup executor running the existing insert-or-increment `trackers.compute` then `onReady(actor)` / `onFailure(cause)` (G9); delete the blocking `tracker(...)` method
+- [X] T009 [US1] Rewire src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala per G11–G14: success callback keeps only debug log + `requestMatch` + `acquireTracker(...)` call; `onReady` records `sentTimestamp = clock.nowMillis` and sends `MessagePublished(..., onComplete = releaseTracker(...))` (G12); `onFailure` reuses the existing KO reporting extracted into a private helper shared with the send-failure branch (G13); remove the `trackerAcquired` try/catch-release block (pool owns registration consistency); send-failure branch stays byte-for-byte (G14/FR-006)
+- [X] T010 [US1] Delete the temporary `addTopicForSubscription` delegate from src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala (no callers remain after T004/T008) and verify with `grep -rn addTopicForSubscription src/` → zero hits
+- [X] T011 [P] [US1] Migrate the `pool.tracker(...)` call site (line 36) in src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala to `acquireTracker` with a small await-both-callbacks test helper; assertions unchanged
+- [X] T012 [P] [US1] Migrate acquire/release call sites in src/test/scala/org/galaxio/gatling/kafka/client/TrackerRefCountSpec.scala to the same helper; all existing refcount/release invariants must pass unchanged (G9; guards FR-006's no-residual-reservation property)
+- [X] T013 [US1] Green gate for US1: TrackerAcquisitionIsolationSpec tests 1–3 pass; full `sbt compile test` green
 
 **Checkpoint**: The defect in #163 is neutralized — MVP. Delivery callbacks are non-blocking;
 cross-topic isolation proven against a real broker.
@@ -95,9 +95,9 @@ the pool stays usable and the topic retryable (spec US2, FR-003, SC-004).
 
 ### Tests for User Story 2 (write FIRST, observe FAIL) ⚠️
 
-- [ ] T014 [P] [US2] Add FAILING integration tests to src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala: (4) poisoned-topic request is reported KO at ≈ the reply timeout with an error message naming the topic and the timeout, and the virtual-user chain continues (SC-004); (5) after that KO — a healthy-topic request still completes OK, and a fresh poisoned-topic request attempts preparation again, KO-ing after its own full timeout rather than instantly (FR-003, retry-not-poisoned)
-- [ ] T015 [P] [US2] Add FAILING unit test to src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala: after the pool's consumer-failure callback has fired, `acquireTracker` invokes `onFailure` synchronously on the calling thread with the existing "Kafka consumer failed; tracker pool can no longer be used" cause — and never invokes `onReady` (G7)
-- [ ] T016 [US2] Close any gaps the red tests expose in src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala and src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala (expected near-no-op if T008/T009 followed the contract: exact timeout message text, timeout-task cancellation on success, KO timing spanning request start → failure detection); green gate: US2 tests + full `sbt test`
+- [X] T014 [P] [US2] Add FAILING integration tests to src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala: (4) poisoned-topic request is reported KO at ≈ the reply timeout with an error message naming the topic and the timeout, and the virtual-user chain continues (SC-004); (5) after that KO — a healthy-topic request still completes OK, and a fresh poisoned-topic request attempts preparation again, KO-ing after its own full timeout rather than instantly (FR-003, retry-not-poisoned)
+- [X] T015 [P] [US2] Add FAILING unit test to src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala: after the pool's consumer-failure callback has fired, `acquireTracker` invokes `onFailure` synchronously on the calling thread with the existing "Kafka consumer failed; tracker pool can no longer be used" cause — and never invokes `onReady` (G7)
+- [X] T016 [US2] Close any gaps the red tests expose in src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala and src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala (expected near-no-op if T008/T009 followed the contract: exact timeout message text, timeout-task cancellation on success, KO timing spanning request start → failure detection); green gate: US2 tests + full `sbt test`
 
 **Checkpoint**: Failure isolation proven — one misconfigured topic produces attributed KOs only.
 
@@ -113,8 +113,8 @@ TrackerAcquisitionIsolationSpec; CI Gatling simulations corroborate at the repor
 
 ### Tests for User Story 3 (write FIRST, observe FAIL if semantics drift) ⚠️
 
-- [ ] T017 [US3] Add integration test (6) to src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala using the recording-StatsEngine pattern from src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala: initiate a request-reply whose reply topic does not exist yet, create the topic via AdminClient after ~2 s (readiness then completes), have the responder reply immediately; assert the logged OK response duration is ≪ the 2 s readiness delay (sent timestamp recorded at tracking-ready instant — FR-005), and assert the KO case from T014 logs duration ≈ request-start → failure-detection. This test must FAIL if `sentTimestamp` is ever recorded at ack time or send-initiation time instead of `onReady`
-- [ ] T018 [US3] Verify `sentTimestamp` placement in src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala matches G12 exactly (recorded inside `onReady`, immediately before `MessagePublished`); adjust if T017 is red; green gate: full `sbt test`
+- [X] T017 [US3] Add integration test (6) to src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala using the recording-StatsEngine pattern from src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala: initiate a request-reply whose reply topic does not exist yet, create the topic via AdminClient after ~2 s (readiness then completes), have the responder reply immediately; assert the logged OK response duration is ≪ the 2 s readiness delay (sent timestamp recorded at tracking-ready instant — FR-005), and assert the KO case from T014 logs duration ≈ request-start → failure-detection. This test must FAIL if `sentTimestamp` is ever recorded at ack time or send-initiation time instead of `onReady`
+- [X] T018 [US3] Verify `sentTimestamp` placement in src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala matches G12 exactly (recorded inside `onReady`, immediately before `MessagePublished`); adjust if T017 is red; green gate: full `sbt test`
 
 **Checkpoint**: All three stories independently verified.
 
@@ -124,12 +124,12 @@ TrackerAcquisitionIsolationSpec; CI Gatling simulations corroborate at the repor
 
 **Purpose**: Repo-wide gates from quickstart.md (SC-005, FR-008) and contract conformance.
 
-- [ ] T019 Format: `sbt scalafmtAll scalafmtSbt`
-- [ ] T020 Full local gate green: `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
-- [ ] T021 [P] API-compat witness (Principle I): `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` passes unchanged
-- [ ] T022 CI-equivalent Gatling run against the Compose stack (`docker compose -f docker-compose.kafka.yml up -d` first): `sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport` — request-reply timings in the report in line with current release (US3 witness)
-- [ ] T023 [P] Contract conformance sweep: `grep -rn "addTopicForSubscription\|def tracker(" src/main/` → zero hits (no blocking acquisition API survives); review the three changed main files against the thread-role table in contracts/internal-api.md (no `get`/`await`/`join` on producer-callback or consumer-thread paths)
-- [ ] T024 Execute [quickstart.md](quickstart.md) top to bottom and confirm every assertion-to-spec mapping row holds; then assemble the single `fix(client): keep tracker acquisition off the producer I/O thread (#163)` commit on top of the `docs(speckit)` commit, PR with milestone `v1.1.0 Request-reply reliability` + `Closes #163` (gate: `scripts/check-linkage.sh --pr <N>`)
+- [X] T019 Format: `sbt scalafmtAll scalafmtSbt`
+- [X] T020 Full local gate green: `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [X] T021 [P] API-compat witness (Principle I): `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` passes unchanged
+- [X] T022 CI-equivalent Gatling run against the Compose stack (`docker compose -f docker-compose.kafka.yml up -d` first): `sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport` — request-reply timings in the report in line with current release (US3 witness)
+- [X] T023 [P] Contract conformance sweep: `grep -rn "addTopicForSubscription\|def tracker(" src/main/` → zero hits (no blocking acquisition API survives); review the three changed main files against the thread-role table in contracts/internal-api.md (no `get`/`await`/`join` on producer-callback or consumer-thread paths)
+- [X] T024 Execute [quickstart.md](quickstart.md) top to bottom and confirm every assertion-to-spec mapping row holds; then assemble the single `fix(client): keep tracker acquisition off the producer I/O thread (#163)` commit on top of the `docs(speckit)` commit, PR with milestone `v1.1.0 Request-reply reliability` + `Closes #163` (gate: `scripts/check-linkage.sh --pr <N>`)
 
 ---
 
@@ -175,6 +175,31 @@ longer be parked by tracker acquisition — the reported defect is gone and inde
 US2 then locks failure attribution, US3 locks measurement semantics; both are thin verification
 layers over the same machinery. Stop-and-validate is possible at every checkpoint; the feature
 still ships as one semantic commit at the end (Principle V — tasks are steps, not commits).
+
+## Execution record (deviations from the plan as written)
+
+- **T005/T008 landed together; no temporary `addTopicForSubscription` delegate.** The delegate
+  existed only to keep Phase 2 compiling on its own; adding and deleting it inside one PR is the
+  add-then-remove churn Principle V forbids. Both phases were verified at one checkpoint instead.
+- **T012 required no migration.** `TrackerRefCountSpec` mirrors the `ConcurrentHashMap` refcount
+  algorithm locally and never calls the pool, so it guards the unchanged `registerTracker` /
+  `releaseTracker` logic as-is (10/10 green throughout).
+- **Red-first verification method.** The isolation spec cannot fail against the pre-fix *API* (it
+  would not compile), so the pre-fix *behaviour* was restored instead by making `acquireTracker`
+  wait inline on the readiness future. 4 of 6 tests went red with the intended diagnostics
+  (`delivery callback was held for 5252 ms waiting for the assignment`; `unrelated traffic took
+  5039 ms to get through while one reply topic was being assigned`), then green once the
+  asynchronous version was restored. Tests 4 and 5 cover failure attribution and pass either way,
+  by design.
+- **The isolation spec induces the stall with `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS`, not with an
+  unassignable topic.** Subscribing to a nonexistent topic still fires `onPartitionsAssigned`, so
+  it produces no stall. A broker-side initial rebalance delay is a genuine slow assignment and needs
+  no `auto.create.topics.enable=false`.
+- **Two defects surfaced during T022 that the plan had not predicted** — the readiness-in-listener
+  strand and the test broker's 3 s rebalance delay. Both are written up in
+  [plan.md](plan.md#discovered-during-implementation-design-deltas-from-the-original-outline);
+  the second required the only file change outside the planned set,
+  `docker-compose.kafka.yml`.
 
 ## Notes
 

--- a/specs/001-nonblocking-tracker-acquisition/tasks.md
+++ b/specs/001-nonblocking-tracker-acquisition/tasks.md
@@ -1,0 +1,185 @@
+# Tasks: Non-blocking Reply-Tracker Acquisition for Request-Reply Sends
+
+**Input**: Design documents from `/specs/001-nonblocking-tracker-acquisition/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md),
+[data-model.md](data-model.md), [contracts/internal-api.md](contracts/internal-api.md),
+[quickstart.md](quickstart.md)
+
+**Tests**: MANDATORY — this feature is a behavior change end-to-end (Constitution Principle IV).
+Every test task below must be written first and observed to FAIL before its implementation task.
+Kafka behavior is tested against Testcontainers, not mocks (Principle II).
+
+**Organization**: Grouped by user story from spec.md. Contract guarantees G1–G14 refer to
+[contracts/internal-api.md](contracts/internal-api.md).
+
+**Commit mapping (Principle V)**: tasks ≠ commits. All implementation tasks converge into ONE
+semantic commit `fix(client): keep tracker acquisition off the producer I/O thread (#163)` on top
+of the `docs(speckit): add 001-nonblocking-tracker-acquisition spec/plan/tasks` commit. The PR
+carries milestone `v1.1.0 Request-reply reliability` and `Closes #163`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+
+## Path Conventions
+
+Single-module Scala/sbt project. All paths below are real and repo-relative:
+
+- Main: `src/main/scala/org/galaxio/gatling/kafka/{actions,client}/`
+- Tests: `src/test/scala/org/galaxio/gatling/kafka/{client,actions,integration}/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Baseline sanity and the compatibility evidence the plan's Constitution gate cites.
+
+- [ ] T001 Verify clean baseline on branch `001-nonblocking-tracker-acquisition`: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` green with Docker running (Testcontainers pulls images on first run)
+- [ ] T002 [P] Record the published-surface evidence for research.md R3: grep `src/main/java/ README.md src/test/scala/org/galaxio/gatling/kafka/examples/` for `addTopicForSubscription`, `tracker(`, `KafkaMessageTrackerPool`, `DynamicKafkaConsumer` and confirm the only call sites are `KafkaRequestReplyAction.scala`, protocol wiring, and the four test files named in plan.md; abort and re-plan if anything else appears
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Promise-based readiness in `DynamicKafkaConsumer` (contract G1–G5) — both US1 and
+US2 build on it. The blocking `addTopicForSubscription` temporarily remains as a thin delegate so
+the repo compiles at this checkpoint; it is deleted in US1 (T010) once the pool stops calling it.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T003 Write FAILING unit tests for `requestTopicSubscription` in src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala: (a) returns a future, queue holds `(topic, future)` (replaces latch-based test at lines 34–64); (b) returns an already-failed future after consumer failure without throwing — G2 (replaces throw-based test at lines 66–95); (c) `close()` fails still-pending futures exceptionally ("consumer closed") — G4
+- [ ] T004 [P] Migrate the three `addTopicForSubscription` call sites in src/test/scala/org/galaxio/gatling/kafka/integration/KafkaIntegrationSpec.scala (lines 245, 439–464) to `requestTopicSubscription(topic).get(timeout)`-style waits on the test thread; the "very short timeout returns false" test becomes "very short `get` timeout throws `java.util.concurrent.TimeoutException` while the future stays pending" (does not compile until T005 — that is the red state)
+- [ ] T005 Implement promise-based readiness in src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala: `topicsQueue` element type `(String, CompletableFuture[Void])`; new `requestTopicSubscription(topic): CompletableFuture[Void]` (fail-fast already-failed future per G2, enqueue, poke `initLatch`, never block — G1); `updateSubscription` already-subscribed branch and `onPartitionsAssigned` complete futures (was `countDown`); `markConsumerFailed` completes queued futures exceptionally with the failure cause; `run()` finally-block and `close()` drain remaining queue entries exceptionally ("consumer closed") — G4; keep `addTopicForSubscription(topic, timeout): Boolean` as a temporary thin blocking delegate over the future preserving today's return/throw semantics
+- [ ] T006 Green gate for Phase 2: `sbt "testOnly org.galaxio.gatling.kafka.client.DynamicKafkaConsumerSpec"` and `sbt "testOnly org.galaxio.gatling.kafka.integration.KafkaIntegrationSpec"` pass; full `sbt compile test` still green
+
+**Checkpoint**: Readiness is future-based and fully covered; consumer never leaves a pending
+future unresolved (assignment / already-subscribed / failure / close all resolve it).
+
+---
+
+## Phase 3: User Story 1 — Slow reply-channel setup on one topic must not stall other traffic (Priority: P1) 🎯 MVP
+
+**Goal**: The producer delivery callback never waits on tracker acquisition; a topic whose
+readiness hangs affects only its own requests (spec US1, FR-001/FR-002/FR-007, SC-001/SC-002/SC-003).
+
+**Independent Test**: `sbt "testOnly org.galaxio.gatling.kafka.integration.TrackerAcquisitionIsolationSpec"`
+— red before T008–T012, green after.
+
+### Tests for User Story 1 (write FIRST, observe FAIL) ⚠️
+
+- [ ] T007 [US1] Create src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala with its own Testcontainers Kafka container configured `KAFKA_AUTO_CREATE_TOPICS_ENABLE=false` (research R4) and a harness mirroring KafkaIntegrationSpec (real `KafkaSender`, `KafkaMessageTrackerPool`, short ~3 s reply timeout, pre-created healthy topic pair, nonexistent "poisoned" reply topic). Three FAILING tests: (1) fire poisoned-topic request-reply then healthy-topic request-reply through the shared producer — healthy completes in ≪ reply timeout (SC-001; red today: it queues behind the parked callback thread for the full timeout); (2) while the poisoned preparation is pending, additional healthy sends get delivery confirmations promptly (SC-002/FR-002); (3) N concurrent first-use requests against one new (pre-created) topic all proceed once assigned, with a single subscription request and no callback-thread stall (FR-007). Run the spec and record the red failures
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] Implement `acquireTracker` in src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala per contract G6–G10: add single-thread daemon `ScheduledThreadPoolExecutor` field (thread name `gatling-kafka-tracker-setup`), shut down in the existing `registerOnTermination` block; fast path = existing `computeIfPresent` refcount++ then `onReady` inline; poisoned-pool check reports via `onFailure` synchronously (G7); slow path = `consumer.requestTopicSubscription(topic)` + scheduled timeout task completing the future exceptionally with `RuntimeException("Timed out waiting for consumer assignment to topic '<topic>' after <timeout>")` (G8, cancelled if readiness wins) + `whenCompleteAsync` on the setup executor running the existing insert-or-increment `trackers.compute` then `onReady(actor)` / `onFailure(cause)` (G9); delete the blocking `tracker(...)` method
+- [ ] T009 [US1] Rewire src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala per G11–G14: success callback keeps only debug log + `requestMatch` + `acquireTracker(...)` call; `onReady` records `sentTimestamp = clock.nowMillis` and sends `MessagePublished(..., onComplete = releaseTracker(...))` (G12); `onFailure` reuses the existing KO reporting extracted into a private helper shared with the send-failure branch (G13); remove the `trackerAcquired` try/catch-release block (pool owns registration consistency); send-failure branch stays byte-for-byte (G14/FR-006)
+- [ ] T010 [US1] Delete the temporary `addTopicForSubscription` delegate from src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala (no callers remain after T004/T008) and verify with `grep -rn addTopicForSubscription src/` → zero hits
+- [ ] T011 [P] [US1] Migrate the `pool.tracker(...)` call site (line 36) in src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala to `acquireTracker` with a small await-both-callbacks test helper; assertions unchanged
+- [ ] T012 [P] [US1] Migrate acquire/release call sites in src/test/scala/org/galaxio/gatling/kafka/client/TrackerRefCountSpec.scala to the same helper; all existing refcount/release invariants must pass unchanged (G9; guards FR-006's no-residual-reservation property)
+- [ ] T013 [US1] Green gate for US1: TrackerAcquisitionIsolationSpec tests 1–3 pass; full `sbt compile test` green
+
+**Checkpoint**: The defect in #163 is neutralized — MVP. Delivery callbacks are non-blocking;
+cross-topic isolation proven against a real broker.
+
+---
+
+## Phase 4: User Story 2 — Reply-channel setup failure affects only the requesting operation (Priority: P2)
+
+**Goal**: Preparation timeout/failure KOs exactly the affected request with a descriptive error;
+the pool stays usable and the topic retryable (spec US2, FR-003, SC-004).
+
+**Independent Test**: the failure-semantics tests below run standalone via
+`sbt "testOnly org.galaxio.gatling.kafka.integration.TrackerAcquisitionIsolationSpec org.galaxio.gatling.kafka.client.KafkaMessageTrackerPoolSpec"`.
+
+### Tests for User Story 2 (write FIRST, observe FAIL) ⚠️
+
+- [ ] T014 [P] [US2] Add FAILING integration tests to src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala: (4) poisoned-topic request is reported KO at ≈ the reply timeout with an error message naming the topic and the timeout, and the virtual-user chain continues (SC-004); (5) after that KO — a healthy-topic request still completes OK, and a fresh poisoned-topic request attempts preparation again, KO-ing after its own full timeout rather than instantly (FR-003, retry-not-poisoned)
+- [ ] T015 [P] [US2] Add FAILING unit test to src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala: after the pool's consumer-failure callback has fired, `acquireTracker` invokes `onFailure` synchronously on the calling thread with the existing "Kafka consumer failed; tracker pool can no longer be used" cause — and never invokes `onReady` (G7)
+- [ ] T016 [US2] Close any gaps the red tests expose in src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala and src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala (expected near-no-op if T008/T009 followed the contract: exact timeout message text, timeout-task cancellation on success, KO timing spanning request start → failure detection); green gate: US2 tests + full `sbt test`
+
+**Checkpoint**: Failure isolation proven — one misconfigured topic produces attributed KOs only.
+
+---
+
+## Phase 5: User Story 3 — Reported latency reflects the system under test, not plugin setup (Priority: P3)
+
+**Goal**: Successful first-use requests report round-trip time excluding readiness preparation;
+failed requests keep request-start → failure-detection timing (spec US3, FR-005).
+
+**Independent Test**: latency-semantics test runs standalone inside
+TrackerAcquisitionIsolationSpec; CI Gatling simulations corroborate at the report level.
+
+### Tests for User Story 3 (write FIRST, observe FAIL if semantics drift) ⚠️
+
+- [ ] T017 [US3] Add integration test (6) to src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala using the recording-StatsEngine pattern from src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala: initiate a request-reply whose reply topic does not exist yet, create the topic via AdminClient after ~2 s (readiness then completes), have the responder reply immediately; assert the logged OK response duration is ≪ the 2 s readiness delay (sent timestamp recorded at tracking-ready instant — FR-005), and assert the KO case from T014 logs duration ≈ request-start → failure-detection. This test must FAIL if `sentTimestamp` is ever recorded at ack time or send-initiation time instead of `onReady`
+- [ ] T018 [US3] Verify `sentTimestamp` placement in src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala matches G12 exactly (recorded inside `onReady`, immediately before `MessagePublished`); adjust if T017 is red; green gate: full `sbt test`
+
+**Checkpoint**: All three stories independently verified.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Verification
+
+**Purpose**: Repo-wide gates from quickstart.md (SC-005, FR-008) and contract conformance.
+
+- [ ] T019 Format: `sbt scalafmtAll scalafmtSbt`
+- [ ] T020 Full local gate green: `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [ ] T021 [P] API-compat witness (Principle I): `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` passes unchanged
+- [ ] T022 CI-equivalent Gatling run against the Compose stack (`docker compose -f docker-compose.kafka.yml up -d` first): `sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport` — request-reply timings in the report in line with current release (US3 witness)
+- [ ] T023 [P] Contract conformance sweep: `grep -rn "addTopicForSubscription\|def tracker(" src/main/` → zero hits (no blocking acquisition API survives); review the three changed main files against the thread-role table in contracts/internal-api.md (no `get`/`await`/`join` on producer-callback or consumer-thread paths)
+- [ ] T024 Execute [quickstart.md](quickstart.md) top to bottom and confirm every assertion-to-spec mapping row holds; then assemble the single `fix(client): keep tracker acquisition off the producer I/O thread (#163)` commit on top of the `docs(speckit)` commit, PR with milestone `v1.1.0 Request-reply reliability` + `Closes #163` (gate: `scripts/check-linkage.sh --pr <N>`)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```text
+Setup (T001–T002)
+  └─▶ Foundational (T003–T006)  ← consumer readiness futures; BLOCKS all stories
+        └─▶ US1 (T007–T013)     ← pool + action + isolation proof; MVP
+              ├─▶ US2 (T014–T016)  ← failure semantics on US1 machinery
+              └─▶ US3 (T017–T018)  ← measurement semantics on US1 machinery
+                    └─▶ Polish (T019–T024)
+```
+
+- **US2 and US3 both depend on US1** (they assert semantics of the machinery US1 builds) but are
+  independent of each other; run sequentially P2 → P3 by default because both edit
+  `TrackerAcquisitionIsolationSpec.scala` (coordinate if parallelizing).
+- Within every story: red test task strictly before its implementation task (Principle IV).
+
+### Parallel Opportunities
+
+- Phase 1: T002 alongside T001.
+- Phase 2: T003 ∥ T004 (different test files) before T005.
+- US1: T011 ∥ T012 (different test files) after T008; T009 after T008 (uses the new signature);
+  T010 after T004+T008.
+- US2: T014 ∥ T015 (different files) before T016.
+- Polish: T021 ∥ T023 after T020.
+
+## Parallel Example: User Story 1
+
+```bash
+# After T008 lands, run the two test migrations in parallel (different files):
+Task: "Migrate pool.tracker call site in src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala"
+Task: "Migrate acquire/release sites in src/test/scala/org/galaxio/gatling/kafka/client/TrackerRefCountSpec.scala"
+```
+
+## Implementation Strategy
+
+**MVP = Setup + Foundational + US1 (T001–T013)**: after T013 the producer I/O thread can no
+longer be parked by tracker acquisition — the reported defect is gone and independently proven.
+US2 then locks failure attribution, US3 locks measurement semantics; both are thin verification
+layers over the same machinery. Stop-and-validate is possible at every checkpoint; the feature
+still ships as one semantic commit at the end (Principle V — tasks are steps, not commits).
+
+## Notes
+
+- Verify each red test actually fails before implementing — record the failure in the task log.
+- No new dependencies at any point (JDK `java.util.concurrent` only) — Constitution constraints.
+- Sibling issues #143/#164/#165/#166 stay untouched even where adjacent code invites fixes
+  (Boundaries: no opportunistic refactors; `releaseTracker` and `updateSubscription` churn logic
+  are modified by their own issues, not here).

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -29,6 +29,22 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
 
   override def sendKafkaMessage(requestNameString: String, protocolMessage: KafkaProtocolMessage, session: Session): Unit = {
     val requestStartDate = clock.nowMillis
+
+    def reportFailure(message: String, responseCode: Option[String]): Unit = {
+      val requestEndDate = clock.nowMillis
+      statsEngine.logResponse(
+        session.scenario,
+        session.groups,
+        requestNameString,
+        requestStartDate,
+        requestEndDate,
+        KO,
+        responseCode,
+        Some(message),
+      )
+      next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
+    }
+
     components.sender.send(protocolMessage)(
       rm => {
         if (logger.underlying.isDebugEnabled) {
@@ -41,79 +57,45 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
 
         components.trackersPool match {
           case Some(trackers) =>
-            val consumerTopic   = protocolMessage.consumerTopic
-            val matcher         = components.kafkaProtocol.messageMatcher
-            var trackerAcquired = false
-            try {
-              val tracker = trackers.tracker(
-                protocolMessage.producerTopic,
-                consumerTopic,
-                matcher,
-                None,
-                components.kafkaProtocol.timeout,
-              )
-              trackerAcquired = true
-              tracker ! KafkaMessageTracker
-                .MessagePublished(
-                  id,
-                  clock.nowMillis,
-                  components.kafkaProtocol.timeout.toMillis,
-                  attributes.checks,
-                  session,
-                  next,
-                  requestNameString,
-                  onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
-                )
-            } catch {
-              case e: Exception =>
-                if (trackerAcquired) trackers.releaseTracker(consumerTopic, matcher)
-                val requestEndDate = clock.nowMillis
+            val consumerTopic = protocolMessage.consumerTopic
+            val matcher       = components.kafkaProtocol.messageMatcher
+            // This body runs on the producer's I/O thread: acquisition hands back a tracker without
+            // waiting here, so a reply topic that is slow to be assigned cannot stall that thread.
+            trackers.acquireTracker(
+              protocolMessage.producerTopic,
+              consumerTopic,
+              matcher,
+              None,
+              components.kafkaProtocol.timeout,
+            )(
+              tracker =>
+                tracker ! KafkaMessageTracker
+                  .MessagePublished(
+                    id,
+                    clock.nowMillis,
+                    components.kafkaProtocol.timeout.toMillis,
+                    attributes.checks,
+                    session,
+                    next,
+                    requestNameString,
+                    onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
+                  ),
+              e => {
                 logger.error(e.getMessage, e)
-                statsEngine.logResponse(
-                  session.scenario,
-                  session.groups,
-                  requestNameString,
-                  requestStartDate,
-                  requestEndDate,
-                  KO,
-                  None,
-                  Some(e.getMessage),
-                )
-                next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
-            }
+                reportFailure(e.getMessage, None)
+              },
+            )
           case None           =>
-            val requestEndDate = clock.nowMillis
-            val msg            =
+            val msg =
               s"Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration, " +
                 s"otherwise the virtual user will hang for ${components.kafkaProtocol.timeout} with no reply"
             logger.error(msg)
-            statsEngine.logResponse(
-              session.scenario,
-              session.groups,
-              requestNameString,
-              requestStartDate,
-              requestEndDate,
-              KO,
-              None,
-              Some(msg),
-            )
-            next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
+            reportFailure(msg, None)
         }
       },
       e => {
-        val requestEndDate = clock.nowMillis
         logger.error(e.getMessage, e)
-        statsEngine.logResponse(
-          session.scenario,
-          session.groups,
-          requestNameString,
-          requestStartDate,
-          requestEndDate,
-          KO,
-          Some("500"),
-          Some(e.getMessage),
-        )
-        next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
+        reportFailure(e.getMessage, Some("500"))
       },
     )
   }

--- a/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
@@ -9,9 +9,9 @@ import java.time.Duration
 import java.util
 import java.util.Properties
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
-import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
+import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, ConcurrentLinkedQueue, CountDownLatch}
 import scala.collection.mutable
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
 
 object DynamicKafkaConsumer {
@@ -27,7 +27,9 @@ object DynamicKafkaConsumer {
     new DynamicKafkaConsumer[K, V](settings, topics, onRecord, onFailure)
   }
   private val initializationTimeout = 90.seconds
-  private val defaultAssignTimeout  = 60.seconds
+
+  private[client] val consumerFailedMessage = "Kafka consumer failed; dynamic consumer can no longer be used"
+  private[client] val consumerClosedMessage = "Kafka consumer is closed; topic subscription will not complete"
 }
 
 final class DynamicKafkaConsumer[K, V] private (
@@ -37,10 +39,19 @@ final class DynamicKafkaConsumer[K, V] private (
     onFailure: Exception => Unit,
 ) extends Runnable with AutoCloseable with StrictLogging {
 
-  private val topicsQueue: java.util.Queue[(String, CountDownLatch)] = new ConcurrentLinkedQueue[(String, CountDownLatch)]()
-  topicsQueue.addAll(topics.map((_, new CountDownLatch(0))).asJava)
+  private val topicsQueue: java.util.Queue[(String, CompletableFuture[Void])] =
+    new ConcurrentLinkedQueue[(String, CompletableFuture[Void])]()
+  topicsQueue.addAll(topics.map((_, CompletableFuture.completedFuture[Void](null))).asJava)
 
   private val topicsToRemove: java.util.Queue[String] = new ConcurrentLinkedQueue[String]()
+
+  /** Readiness waiting for its topic to show up in the assignment.
+    *
+    * Deliberately kept on the consumer rather than captured by the rebalance listener: a later `subscribe` replaces the
+    * listener, and anything the previous one was holding would never be signalled.
+    */
+  private val awaitingAssignment: ConcurrentHashMap[String, java.util.Queue[CompletableFuture[Void]]] =
+    new ConcurrentHashMap[String, java.util.Queue[CompletableFuture[Void]]]()
 
   private val running: AtomicBoolean                      = new AtomicBoolean(true)
   private val consumer: KafkaConsumer[K, V]               = new KafkaConsumer[K, V](settings)
@@ -50,36 +61,60 @@ final class DynamicKafkaConsumer[K, V] private (
   def removeTopicSubscription(topic: String): Unit =
     topicsToRemove.add(topic)
 
-  def addTopicForSubscription(
-      newTopic: String,
-      assignTimeout: FiniteDuration = DynamicKafkaConsumer.defaultAssignTimeout,
-  ): Boolean = {
-    failIfConsumerFailed()
-    val latch    = new CountDownLatch(1)
-    this.topicsQueue.add(newTopic, latch)
-    if (initLatch.getCount > 0) {
-      initLatch.countDown()
+  /** Requests that `topic` joins the subscription. Returns immediately; the future completes once the consumer holds an
+    * assignment covering the topic, and fails if the consumer failed or was closed before that happened. The future carries no
+    * deadline of its own — callers own their timeout policy.
+    */
+  def requestTopicSubscription(topic: String): CompletableFuture[Void] = {
+    val readiness = new CompletableFuture[Void]()
+    subscriptionUnavailable match {
+      case Some(cause) => readiness.completeExceptionally(cause)
+      case None        =>
+        this.topicsQueue.add((topic, readiness))
+        if (initLatch.getCount > 0) {
+          initLatch.countDown()
+        }
+        // A failure or close racing with the enqueue above would have drained the queue before this
+        // entry landed in it, leaving the future pending forever; resolve it here instead.
+        subscriptionUnavailable.foreach(readiness.completeExceptionally)
     }
-    val assigned = latch.await(assignTimeout.length, assignTimeout.unit)
-    failIfConsumerFailed()
-    assigned
+    readiness
   }
 
-  private def failIfConsumerFailed(): Unit = {
+  private def subscriptionUnavailable: Option[Throwable] = {
     val failure = consumerFailure.get()
-    if (failure != null) {
-      throw new IllegalStateException("Kafka consumer failed; dynamic consumer can no longer be used", failure)
-    }
+    if (failure != null) Some(new IllegalStateException(DynamicKafkaConsumer.consumerFailedMessage, failure))
+    else if (!running.get) Some(new IllegalStateException(DynamicKafkaConsumer.consumerClosedMessage))
+    else None
   }
+
+  private def failPendingSubscriptions(cause: Throwable): Unit = {
+    while (!topicsQueue.isEmpty) {
+      val pending = topicsQueue.poll()
+      if (pending != null) {
+        pending._2.completeExceptionally(cause)
+      }
+    }
+    awaitingAssignment.values().forEach(_.forEach(_.completeExceptionally(cause)))
+    awaitingAssignment.clear()
+  }
+
+  /** Completes readiness for every topic the consumer currently holds partitions for. Runs on the consumer thread only, since
+    * it reads the consumer's assignment.
+    */
+  private def completeAssignedReadiness(): Unit =
+    if (!awaitingAssignment.isEmpty) {
+      consumer.assignment().asScala.map(_.topic()).toSet.foreach { (topic: String) =>
+        val pending = awaitingAssignment.remove(topic)
+        if (pending != null) {
+          pending.forEach(_.complete(null))
+        }
+      }
+    }
 
   private def markConsumerFailed(exception: Exception): Unit = {
     if (consumerFailure.compareAndSet(null, exception)) {
-      while (!topicsQueue.isEmpty) {
-        val (_, latch) = topicsQueue.poll()
-        if (latch != null) {
-          latch.countDown()
-        }
-      }
+      failPendingSubscriptions(new IllegalStateException(DynamicKafkaConsumer.consumerFailedMessage, exception))
       if (initLatch.getCount > 0) {
         initLatch.countDown()
       }
@@ -95,42 +130,67 @@ final class DynamicKafkaConsumer[K, V] private (
       toRemove.add(topicsToRemove.poll())
     }
 
-    if (topicsQueue.isEmpty && toRemove.isEmpty) return
-
-    val currentSubscription = consumer.subscription()
-    val forNewTopics        = mutable.Set.empty[(String, CountDownLatch)]
-
-    while (!topicsQueue.isEmpty) {
-      val (topic, latch) = topicsQueue.poll()
-      if (currentSubscription.contains(topic) && !toRemove.contains(topic))
-        latch.countDown()
-      else
-        forNewTopics.add((topic, latch))
-    }
-
-    if (forNewTopics.isEmpty && toRemove.isEmpty) return
-
-    val baseTopics = currentSubscription.asScala.toSet -- toRemove
-    val allTopics  = baseTopics ++ forNewTopics.map(_._1)
-    val newLatches = forNewTopics.map(_._2)
-
-    if (allTopics.isEmpty) {
-      if (!currentSubscription.isEmpty) consumer.unsubscribe()
+    if (topicsQueue.isEmpty && toRemove.isEmpty) {
+      completeAssignedReadiness()
       return
     }
 
-    consumer.subscribe(
-      allTopics.asJava,
-      new ConsumerRebalanceListener {
-        override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit =
-          logger.debug(s"revoked partitions $partitions")
+    val requestedTopics = mutable.Set.empty[String]
+    while (!topicsQueue.isEmpty) {
+      // close() drains this queue too, from its own thread, so poll can come back empty-handed
+      // between the check above and here.
+      val pending = topicsQueue.poll()
+      if (pending != null) {
+        val (topic, readiness) = pending
+        requestedTopics.add(topic)
+        awaitingAssignment
+          .computeIfAbsent(topic, _ => new ConcurrentLinkedQueue[CompletableFuture[Void]]())
+          .add(readiness)
+        // A close() racing the two calls above can drain the map in between, leaving this entry
+        // attached to a queue nothing holds any more; resolve it here instead of parking forever.
+        subscriptionUnavailable.foreach(readiness.completeExceptionally)
+      }
+    }
 
-        override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
-          logger.debug(s"assigned partitions $partitions")
-          newLatches.foreach(_.countDown())
-        }
-      },
-    )
+    val currentSubscription = consumer.subscription().asScala.toSet
+    val allTopics           = (currentSubscription -- toRemove) ++ requestedTopics
+
+    // Anything dropped from the subscription can never be assigned, so readiness still parked for it
+    // would otherwise wait out the caller's full timeout on a topic nobody is listening to.
+    toRemove.filterNot(allTopics.contains).foreach { topic =>
+      val abandoned = awaitingAssignment.remove(topic)
+      if (abandoned != null) {
+        abandoned.forEach(
+          _.completeExceptionally(
+            new IllegalStateException(s"Subscription to topic '$topic' was removed before it was assigned"),
+          ),
+        )
+      }
+    }
+
+    if (allTopics.isEmpty) {
+      if (currentSubscription.nonEmpty) consumer.unsubscribe()
+      return
+    }
+
+    // Kafka ignores a subscribe() whose topic set is unchanged, so only call it on a real change.
+    // Readiness does not depend on the resulting rebalance: it is resolved from the assignment below.
+    if (allTopics != currentSubscription) {
+      consumer.subscribe(
+        allTopics.asJava,
+        new ConsumerRebalanceListener {
+          override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit =
+            logger.debug(s"revoked partitions $partitions")
+
+          override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
+            logger.debug(s"assigned partitions $partitions")
+            completeAssignedReadiness()
+          }
+        },
+      )
+    }
+
+    completeAssignedReadiness()
   }
 
   override def run(): Unit = {
@@ -162,7 +222,7 @@ final class DynamicKafkaConsumer[K, V] private (
         markConsumerFailed(e)
         this.onFailure(e)
     } finally {
-      this.topicsQueue.clear()
+      failPendingSubscriptions(new IllegalStateException(DynamicKafkaConsumer.consumerClosedMessage))
       consumer.close()
     }
   }
@@ -172,6 +232,9 @@ final class DynamicKafkaConsumer[K, V] private (
     if (this.initLatch.getCount > 0) {
       this.initLatch.countDown()
     }
+    // The run loop drains the queue when it exits, but close() is also valid on a consumer that was
+    // never run: resolve whatever is still pending rather than leaving callers waiting on it.
+    failPendingSubscriptions(new IllegalStateException(DynamicKafkaConsumer.consumerClosedMessage))
     this.consumer.wakeup()
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -12,8 +12,17 @@ import org.galaxio.gatling.kafka.request.{KafkaProtocolMessage, KafkaSerdesImpli
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.{ConcurrentHashMap, ExecutorService, Executors}
+import java.util.concurrent.{
+  CompletionException,
+  ConcurrentHashMap,
+  ExecutorService,
+  Executors,
+  ScheduledThreadPoolExecutor,
+  ThreadFactory,
+  TimeUnit,
+}
 import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NonFatal
 
 object KafkaMessageTrackerPool {
 
@@ -27,6 +36,8 @@ object KafkaMessageTrackerPool {
       new KafkaMessageTrackerPool(consumerSettings, actorSystem, statsEngine, clock),
     )
 
+  /** How long simulation shutdown waits for queued acquisition continuations to report their outcome. */
+  private[client] val setupDrainTimeoutMillis: Long = 5000L
 }
 
 final class KafkaMessageTrackerPool(
@@ -56,6 +67,23 @@ final class KafkaMessageTrackerPool(
 
   // Per-instance executor so shutdown of one pool doesn't affect other pools or subsequent simulations.
   private val consumerExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+
+  // Subscription assignment can take until the reply timeout. Acquisition waits for it here instead of
+  // on the caller's thread, which is the producer's I/O callback thread and must never block.
+  private val setupExecutor: ScheduledThreadPoolExecutor = {
+    val executor = new ScheduledThreadPoolExecutor(
+      1,
+      new ThreadFactory {
+        override def newThread(runnable: Runnable): Thread = {
+          val thread = new Thread(runnable, "gatling-kafka-tracker-setup")
+          thread.setDaemon(true)
+          thread
+        }
+      },
+    )
+    executor.setRemoveOnCancelPolicy(true)
+    executor
+  }
 
   private val consumer: DynamicKafkaConsumer[Array[Byte], Array[Byte]] =
     DynamicKafkaConsumer(
@@ -104,26 +132,52 @@ final class KafkaMessageTrackerPool(
         logger.error(e.getMessage, e)
     }
     consumerExecutor.shutdown()
+    // Closing the consumer above failed every pending readiness, and those continuations are queued
+    // here: they still have to report that failure back to the waiting virtual users, so they must
+    // not be discarded. Shutdown drops queued tasks only when their remaining delay is positive, so
+    // this policy keeps the continuations (they are queued with no delay) while dropping the
+    // acquisition timeouts, which are scheduled up to a full reply timeout out and are moot now.
+    // Leaving it at the JDK default of true would instead hold those timeouts and stall termination
+    // until the grace period below expired.
+    setupExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false)
+    setupExecutor.shutdown()
+    if (!setupExecutor.awaitTermination(KafkaMessageTrackerPool.setupDrainTimeoutMillis, TimeUnit.MILLISECONDS)) {
+      logger.warn("Tracker setup executor did not drain in time; forcing shutdown")
+      setupExecutor.shutdownNow()
+    }
   }
 
   private def withProducerTopic(producerTopic: String): KafkaProtocolMessage => KafkaProtocolMessage =
     _.copy(producerTopic = producerTopic)
 
-  private def failIfConsumerFailed(): Unit = {
-    val failure = consumerFailure.get()
-    if (failure != null) {
-      throw new IllegalStateException("Kafka consumer failed; tracker pool can no longer be used", failure)
-    }
+  private def consumerFailedException(failure: Exception): IllegalStateException =
+    new IllegalStateException("Kafka consumer failed; tracker pool can no longer be used", failure)
+
+  private def completionCause(error: Throwable): Throwable = error match {
+    case e: CompletionException if e.getCause != null => e.getCause
+    case other                                        => other
   }
 
-  def tracker(
+  /** Obtains, creating it if needed, the tracker for `(consumerTopic, messageMatcher)` and hands it to `onReady`. Never blocks
+    * the calling thread: when the reply topic has to be subscribed first, the wait for its assignment happens on the pool's
+    * setup executor and `onReady` runs there once the assignment lands. Exactly one of `onReady` and `onFailure` is invoked,
+    * once.
+    */
+  def acquireTracker(
       producerTopic: String,
       consumerTopic: String,
       messageMatcher: KafkaMatcher,
       responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
       timeout: FiniteDuration,
-  ): ActorRef[KafkaMessageTracker.TrackerMessage] = {
-    failIfConsumerFailed()
+  )(
+      onReady: ActorRef[KafkaMessageTracker.TrackerMessage] => Unit,
+      onFailure: Throwable => Unit,
+  ): Unit = {
+    val failure = consumerFailure.get()
+    if (failure != null) {
+      onFailure(consumerFailedException(failure))
+      return
+    }
 
     val mRef = new MatcherRef(messageMatcher)
 
@@ -144,34 +198,101 @@ final class KafkaMessageTrackerPool(
         innerMap
       },
     )
-    if (found != null) return found
+    if (found != null) {
+      deliverReady(onReady, onFailure, found)
+      return
+    }
 
-    // Slow path: subscribe first (blocking, no CHM lock held), then create actor and register.
-    failIfConsumerFailed()
+    // Slow path needs the setup executor. Check it up front: once it is shut down a rejected
+    // continuation would be absorbed by the CompletableFuture that schedules it and never surface,
+    // leaving the caller with no outcome at all.
+    if (setupExecutor.isShutdown) {
+      onFailure(
+        new IllegalStateException(
+          s"Tracker pool is shutting down; cannot start tracking topic '$consumerTopic'",
+        ),
+      )
+      return
+    }
+
+    // Slow path: request the subscription and let the readiness future carry the wait.
     logger.debug(
       "Creating new tracker for topic {} matcher {}, there are currently {} other topic entries",
       consumerTopic,
       mRef,
       trackers.size(),
     )
-    val assigned        = consumer.addTopicForSubscription(consumerTopic, timeout)
-    if (!assigned) {
-      throw new RuntimeException(
-        s"Timed out waiting for consumer assignment to topic '$consumerTopic' after $timeout",
+    try {
+      val readiness   = consumer.requestTopicSubscription(consumerTopic)
+      val timeoutTask = setupExecutor.schedule(
+        new Runnable {
+          override def run(): Unit = {
+            readiness.completeExceptionally(
+              new RuntimeException(s"Timed out waiting for consumer assignment to topic '$consumerTopic' after $timeout"),
+            )
+          }
+        },
+        timeout.toMillis,
+        TimeUnit.MILLISECONDS,
       )
+
+      readiness.whenCompleteAsync(
+        (_: Void, error: Throwable) => {
+          timeoutTask.cancel(false)
+          if (error != null) onFailure(completionCause(error))
+          else {
+            // The consumer can have failed between the assignment landing and this continuation
+            // running; registering now would hand back a tracker that already missed the failure
+            // broadcast, and the caller would wait out its whole reply timeout instead.
+            val late = consumerFailure.get()
+            if (late != null) onFailure(consumerFailedException(late))
+            else {
+              var tracker: ActorRef[KafkaMessageTracker.TrackerMessage] = null
+              try tracker = registerTracker(producerTopic, consumerTopic, messageMatcher, responseTransformer, mRef)
+              catch { case NonFatal(e) => onFailure(e) }
+              if (tracker != null) deliverReady(onReady, onFailure, tracker)
+            }
+          }
+        },
+        setupExecutor,
+      )
+    } catch {
+      // The pool is being torn down: the setup executor rejects new work once it is shut down.
+      // Report it, rather than letting it escape into the producer's delivery callback where it
+      // would be swallowed and leave the virtual user with neither a success nor a failure.
+      case NonFatal(e) => onFailure(e)
     }
-    val name            = genName(trackerName)
+  }
+
+  /** Hands the tracker over, keeping a failure in `onReady` from escaping into the caller — which may be the producer's I/O
+    * callback, where it would be swallowed and leave the virtual user with no outcome at all.
+    *
+    * Such a failure is reported through `onFailure`. Handing over means telling the tracker actor, which enqueues the message
+    * before dispatching it, so in principle a request could be reported as failed and still be processed later. In practice the
+    * dispatch only rejects once the actor system's executor is shut down, which is terminal — the enqueued message can never
+    * run — so reporting the failure is right, and staying silent would drop the virtual user from the report entirely.
+    */
+  private def deliverReady(
+      onReady: ActorRef[KafkaMessageTracker.TrackerMessage] => Unit,
+      onFailure: Throwable => Unit,
+      tracker: ActorRef[KafkaMessageTracker.TrackerMessage],
+  ): Unit =
+    try onReady(tracker)
+    catch {
+      case NonFatal(e) =>
+        logger.error("Tracker was acquired but handing it to the caller failed", e)
+        onFailure(e)
+    }
+
+  private def registerTracker(
+      producerTopic: String,
+      consumerTopic: String,
+      messageMatcher: KafkaMatcher,
+      responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
+      mRef: MatcherRef,
+  ): ActorRef[KafkaMessageTracker.TrackerMessage] = {
     val transformations =
       responseTransformer.fold(withProducerTopic(producerTopic))(_.compose(withProducerTopic(producerTopic)))
-    val newActor        = actorSystem.actorOf(
-      KafkaMessageTracker.actor(
-        name,
-        statsEngine,
-        clock,
-        messageMatcher,
-        Option(transformations),
-      ),
-    )
 
     // Atomic insert-or-increment under the outer bin lock so a concurrent
     // releaseTracker cannot remove the outer entry between get-or-create and insert.
@@ -188,6 +309,20 @@ final class KafkaMessageTrackerPool(
               result = entry.actor
               entry
             } else {
+              // Started here rather than before the compute: acquisition no longer blocks, so N
+              // concurrent first uses of a topic all reach this point, and every loser of the race
+              // would otherwise leave behind a started actor that nothing ever stops — each one
+              // still running its own periodic timeout scan. Creating the actor does not touch
+              // `trackers`, so it is safe under the bin lock.
+              val newActor = actorSystem.actorOf(
+                KafkaMessageTracker.actor(
+                  genName(trackerName),
+                  statsEngine,
+                  clock,
+                  messageMatcher,
+                  Option(transformations),
+                ),
+              )
               result = newActor
               TrackerEntry(newActor, new AtomicInteger(1))
             }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
@@ -1,11 +1,12 @@
 package org.galaxio.gatling.kafka.client
 
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{CompletableFuture, ExecutionException, TimeUnit, TimeoutException}
 
 class DynamicKafkaConsumerSpec extends munit.FunSuite {
 
-  test("removeTopicSubscription queues topic for removal") {
-    val consumer = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+  private def newConsumer(): DynamicKafkaConsumer[Array[Byte], Array[Byte]] =
+    DynamicKafkaConsumer[Array[Byte], Array[Byte]](
       Map(
         "bootstrap.servers"  -> "localhost:0",
         "key.deserializer"   -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
@@ -15,6 +16,32 @@ class DynamicKafkaConsumerSpec extends munit.FunSuite {
       _ => (),
       _ => (),
     )
+
+  private def subscriptionQueue(
+      consumer: DynamicKafkaConsumer[_, _],
+  ): java.util.Queue[(String, CompletableFuture[Void])] = {
+    val field = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("topicsQueue")
+    field.setAccessible(true)
+    field.get(consumer).asInstanceOf[java.util.Queue[(String, CompletableFuture[Void])]]
+  }
+
+  private def failureRef(consumer: DynamicKafkaConsumer[_, _]): AtomicReference[Exception] = {
+    val field = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("consumerFailure")
+    field.setAccessible(true)
+    field.get(consumer).asInstanceOf[AtomicReference[Exception]]
+  }
+
+  private def markConsumerFailed(consumer: DynamicKafkaConsumer[_, _], exception: Exception): Unit = {
+    val method = classOf[DynamicKafkaConsumer[_, _]].getDeclaredMethod("markConsumerFailed", classOf[Exception])
+    method.setAccessible(true)
+    method.invoke(consumer, exception)
+  }
+
+  private def causeOf(future: CompletableFuture[Void]): Throwable =
+    intercept[ExecutionException](future.get(1, TimeUnit.SECONDS)).getCause
+
+  test("removeTopicSubscription queues topic for removal") {
+    val consumer = newConsumer()
     try {
       consumer.removeTopicSubscription("topic-1")
       consumer.removeTopicSubscription("topic-2")
@@ -31,103 +58,66 @@ class DynamicKafkaConsumerSpec extends munit.FunSuite {
     }
   }
 
-  test("addTopicForSubscription queues topic with latch") {
-    val consumer = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
-      Map(
-        "bootstrap.servers"  -> "localhost:0",
-        "key.deserializer"   -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
-        "value.deserializer" -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
-      ),
-      Set.empty,
-      _ => (),
-      _ => (),
-    )
+  // No consumer thread runs in this suite, so nothing here can complete a readiness: these tests cover
+  // queueing and the fail-fast paths only. Readiness actually resolving from an assignment needs a
+  // broker and is covered by TrackerAcquisitionIsolationSpec.
+  test("requestTopicSubscription queues the topic and returns without blocking") {
+    val consumer = newConsumer()
     try {
-      val field = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("topicsQueue")
-      field.setAccessible(true)
-      val queue =
-        field.get(consumer).asInstanceOf[java.util.Queue[(String, java.util.concurrent.CountDownLatch)]]
-
+      val queue       = subscriptionQueue(consumer)
       val initialSize = queue.size()
 
-      val thread = new Thread(() => {
-        consumer.addTopicForSubscription("new-topic", scala.concurrent.duration.DurationInt(1).second)
-      })
-      thread.start()
-      Thread.sleep(100)
+      val readiness = consumer.requestTopicSubscription("new-topic")
 
       assertEquals(queue.size(), initialSize + 1)
-      thread.join(2000)
+      assertEquals(queue.peek()._1, "new-topic")
+      intercept[TimeoutException](readiness.get(50, TimeUnit.MILLISECONDS))
     } finally {
       consumer.close()
     }
   }
 
-  test("addTopicForSubscription fails fast after consumer failure") {
-    val consumer = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
-      Map(
-        "bootstrap.servers"  -> "localhost:0",
-        "key.deserializer"   -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
-        "value.deserializer" -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
-      ),
-      Set.empty,
-      _ => (),
-      _ => (),
-    )
+  test("requestTopicSubscription returns a failed future after consumer failure") {
+    val consumer = newConsumer()
     try {
-      val queueField = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("topicsQueue")
-      queueField.setAccessible(true)
-      val queue      =
-        queueField.get(consumer).asInstanceOf[java.util.Queue[(String, java.util.concurrent.CountDownLatch)]]
+      failureRef(consumer).set(new RuntimeException("boom"))
 
-      val failureField    = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("consumerFailure")
-      failureField.setAccessible(true)
-      val consumerFailure = failureField.get(consumer).asInstanceOf[AtomicReference[Exception]]
+      val readiness = consumer.requestTopicSubscription("new-topic")
 
-      @volatile var thrown: IllegalStateException = null
-
-      val thread = new Thread(() => {
-        try {
-          consumer.addTopicForSubscription("new-topic", scala.concurrent.duration.DurationInt(10).seconds)
-        } catch {
-          case e: IllegalStateException => thrown = e
-        }
-      })
-
-      thread.start()
-
-      eventually(1000) {
-        assertEquals(queue.size(), 1)
-      }
-
-      consumerFailure.set(new RuntimeException("boom"))
-      val (_, latch) = queue.peek()
-      latch.countDown()
-
-      thread.join(2000)
-
-      assert(!thread.isAlive)
-      assert(thrown != null)
-      assert(thrown.getCause != null)
-      assertEquals(thrown.getCause.getMessage, "boom")
+      assert(readiness.isCompletedExceptionally, "expected an already-failed readiness future")
+      assertEquals(subscriptionQueue(consumer).size(), 0, "failed request must not be queued")
+      assertEquals(causeOf(readiness).getCause.getMessage, "boom")
     } finally {
       consumer.close()
     }
   }
 
-  private def eventually(timeoutMillis: Long)(assertion: => Unit): Unit = {
-    val deadline                  = System.currentTimeMillis() + timeoutMillis
-    var lastError: AssertionError = null
-    while (System.currentTimeMillis() < deadline) {
-      try {
-        assertion
-        return
-      } catch {
-        case e: AssertionError =>
-          lastError = e
-          Thread.sleep(10)
-      }
+  test("consumer failure fails readiness futures queued before it") {
+    val consumer = newConsumer()
+    try {
+      val readiness = consumer.requestTopicSubscription("new-topic")
+      assert(!readiness.isDone)
+
+      markConsumerFailed(consumer, new RuntimeException("boom"))
+
+      assert(readiness.isCompletedExceptionally, "queued readiness must fail when the consumer fails")
+      assertEquals(causeOf(readiness).getCause.getMessage, "boom")
+    } finally {
+      consumer.close()
     }
-    if (lastError != null) throw lastError
+  }
+
+  test("close fails readiness futures that are still pending") {
+    val consumer  = newConsumer()
+    val readiness = consumer.requestTopicSubscription("new-topic")
+    assert(!readiness.isDone)
+
+    consumer.close()
+
+    assert(readiness.isCompletedExceptionally, "pending readiness must not survive close")
+    assert(
+      causeOf(readiness).getMessage.contains("closed"),
+      s"unexpected failure message: ${causeOf(readiness).getMessage}",
+    )
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPoolSpec.scala
@@ -32,16 +32,21 @@ class KafkaMessageTrackerPoolSpec extends munit.FunSuite {
       field.setAccessible(true)
       field.get(pool).asInstanceOf[AtomicReference[Exception]].set(new RuntimeException("boom"))
 
-      val thrown = intercept[IllegalStateException] {
-        pool.tracker(
-          producerTopic = "producer-topic",
-          consumerTopic = "consumer-topic",
-          messageMatcher = KafkaKeyMatcher,
-          responseTransformer = None,
-          timeout = 1.second,
-        )
-      }
+      val ready   = new AtomicReference[AnyRef](null)
+      val failure = new AtomicReference[Throwable](null)
 
+      pool.acquireTracker(
+        producerTopic = "producer-topic",
+        consumerTopic = "consumer-topic",
+        messageMatcher = KafkaKeyMatcher,
+        responseTransformer = None,
+        timeout = 1.second,
+      )(tracker => ready.set(tracker), failure.set)
+
+      // Reported synchronously on the calling thread, never thrown and never as a tracker.
+      assert(ready.get() == null, "acquisition must not hand back a tracker from a failed pool")
+      val thrown = failure.get()
+      assert(thrown.isInstanceOf[IllegalStateException], s"unexpected failure type: $thrown")
       assert(thrown.getCause != null)
       assertEquals(thrown.getCause.getMessage, "boom")
     } finally {

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaConcurrencyLoadTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaConcurrencyLoadTest.scala
@@ -1,0 +1,171 @@
+package org.galaxio.gatling.kafka.examples
+
+import io.gatling.core.Predef._
+import io.gatling.core.feeder.Feeder
+import io.gatling.core.structure.ScenarioBuilder
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
+import org.galaxio.gatling.kafka.Predef._
+import org.galaxio.gatling.kafka.client.{DynamicKafkaConsumer, KafkaSender}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration.DurationInt
+
+/** Ad hoc load check for #163: sustained, meaningfully concurrent request-reply traffic through the real Gatling DSL/action
+  * pipeline (not a hand-rolled harness like TrackerAcquisitionIsolationSpec). Every request is echoed back by a dedicated
+  * responder, so — unlike KafkaGatlingTest's `scnRRwo` — no scenario here is designed to fail; the residual failures the
+  * assertion still tolerates are tracked defects, see `KnownReplyLossBudgetPercent`.
+  *
+  * Not wired into CI; run manually against the docker-compose.kafka.yml stack: sbt "Gatling / testOnly
+  * org.galaxio.gatling.kafka.examples.KafkaConcurrencyLoadTest"
+  */
+class KafkaConcurrencyLoadTest extends Simulation {
+
+  private val bootstrap     = "localhost:9093"
+  private val requestTopic  = "load.request"
+  private val replyTopic    = "load.reply"
+  private val concurrency   = 30
+  private val rampDuration  = 10.seconds
+  private val sustainFor    = 100.seconds
+  private val scenarioLoops = rampDuration + sustainFor + 15.seconds // outlasts the injection window
+  private val probeMarker   = "_probe"
+
+  /** Known-loss budget, deliberately not zero.
+    *
+    * A reply can still be dropped while its own request is being registered: `MessagePublished` and `MessageConsumed` reach the
+    * tracker's mailbox from two different threads with no ordering between them, so a round-trip of a few milliseconds can be
+    * processed before the request it answers — see [[https://github.com/galax-io/gatling-kafka-plugin/issues/191 #191]]. Losses
+    * cluster on tracker re-registration, which happens after every reply because the entry is dropped at refcount zero
+    * ([[https://github.com/galax-io/gatling-kafka-plugin/issues/165 #165]]), so each loss re-arms the next one.
+    *
+    * Measured against a local broker on this code: 0.2135, 0.2143, 0.2144, 0.2307 and 0.2470% over five runs (14–16 KO of
+    * ~6,500). Before #163 the same simulation lost ~1.4% (38 KO of 2,724, of which 7 were assignment timeouts that #163 removed
+    * outright), so this ceiling still fails a regression to that behaviour by a wide margin.
+    *
+    * The headroom above is deliberately thin — the worst measured run sits 0.003 points under the ceiling, i.e. one extra lost
+    * reply turns the run red. That is intended: a rate above this is worth looking at rather than absorbing. Be aware the
+    * losses are time-driven, not rate-driven — roughly one per reply-timeout cycle, so a run loses a near-fixed count whatever
+    * its throughput, and a slower machine reports a *higher* percentage for the same defect. If this starts failing on load
+    * rather than on a real regression, prefer a count-based ceiling (`global.failedRequests.count`) over widening this one.
+    *
+    * Tighten to 0 once #191 lands; #165 alone should already push the observed rate close to zero.
+    */
+  private val KnownReplyLossBudgetPercent = 0.25
+
+  // Stand-in for the external service under test: echoes every request straight back on the reply
+  // topic with the same key and value, so the default key-based matcher (KafkaKeyMatcher) pairs each
+  // reply with its own request regardless of how many are in flight concurrently.
+  private val responderSender = KafkaSender(
+    Map(
+      ProducerConfig.ACKS_CONFIG                   -> "1",
+      ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> bootstrap,
+      ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> classOf[ByteArraySerializer].getName,
+      ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[ByteArraySerializer].getName,
+    ),
+  )
+
+  private val responderReady: CountDownLatch = new CountDownLatch(1)
+
+  private val responder       = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+    Map(
+      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG        -> bootstrap,
+      ConsumerConfig.GROUP_ID_CONFIG                 -> "load-test-responder",
+      ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+      ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
+    ),
+    Set(requestTopic),
+    record => {
+      responderReady.countDown()
+      if (new String(record.value()) != probeMarker) {
+        responderSender.send(
+          KafkaProtocolMessage(record.key(), record.value(), replyTopic, replyTopic),
+        )(
+          _ => (),
+          // Never silent: a responder that stops echoing looks exactly like the plugin losing
+          // replies, and the run would fail its budget with nothing pointing at the real cause.
+          error => println(s"[load-test responder] failed to echo ${new String(record.key())}: $error"),
+        )
+      }
+    },
+    error => println(s"[load-test responder] consumer failed, replies stop here: $error"),
+  )
+  private val responderThread = new Thread(responder, "load-test-responder")
+
+  private def awaitResponderReady(timeoutSeconds: Int = 30): Unit = {
+    val probe    = KafkaProtocolMessage(probeMarker.getBytes, probeMarker.getBytes, requestTopic, requestTopic)
+    val deadline = System.currentTimeMillis() + timeoutSeconds * 1000L
+    while (responderReady.getCount > 0 && System.currentTimeMillis() < deadline) {
+      val sent = new CountDownLatch(1)
+      responderSender.send(probe)(_ => sent.countDown(), _ => sent.countDown())
+      sent.await(2, java.util.concurrent.TimeUnit.SECONDS)
+      responderReady.await(500, java.util.concurrent.TimeUnit.MILLISECONDS)
+    }
+    require(responderReady.getCount == 0, s"Responder not ready within ${timeoutSeconds}s")
+  }
+
+  before {
+    responderThread.setDaemon(true)
+    responderThread.start()
+    // Gatling does not run `after` when `before` throws, and a responder left in the group blocks
+    // the next run until the coordinator times its stale member out.
+    try awaitResponderReady()
+    catch {
+      case error: Throwable =>
+        responder.close()
+        responderSender.close()
+        throw error
+    }
+  }
+
+  after {
+    responder.close()
+    responderSender.close()
+  }
+
+  private val protocol: KafkaProtocol = kafka
+    .producerSettings(
+      ProducerConfig.ACKS_CONFIG                   -> "1",
+      ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> bootstrap,
+      ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> "org.apache.kafka.common.serialization.StringSerializer",
+      ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.StringSerializer",
+    )
+    .consumeSettings(
+      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrap,
+    )
+    .timeout(10.seconds)
+
+  private val keySeq: AtomicReference[Long] = new AtomicReference(0L)
+  private val feeder: Feeder[String]        = Iterator.continually {
+    val n = keySeq.updateAndGet(_ + 1)
+    Map("k" -> s"load-$n-${java.util.UUID.randomUUID()}")
+  }
+
+  private val scn: ScenarioBuilder = scenario("Concurrent Request-Reply Load")
+    .during(scenarioLoops) {
+      feed(feeder)
+        .exec(
+          kafka("Load RR").requestReply
+            .requestTopic(requestTopic)
+            .replyTopic(replyTopic)
+            .send[String, String]("#{k}", "#{k}")
+            .check(bodyString.is("#{k}")),
+        )
+        .pause(300.millis, 800.millis)
+    }
+
+  setUp(
+    scn.inject(
+      rampConcurrentUsers(1).to(concurrency).during(rampDuration),
+      constantConcurrentUsers(concurrency).during(sustainFor),
+    ),
+  ).protocols(protocol)
+    .assertions(
+      global.failedRequests.percent.lte(KnownReplyLossBudgetPercent),
+    )
+    .maxDuration(3.minutes)
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/integration/KafkaIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/KafkaIntegrationSpec.scala
@@ -12,8 +12,7 @@ import org.testcontainers.utility.DockerImageName
 
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
-import scala.concurrent.duration.DurationInt
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit, TimeoutException}
 import scala.jdk.CollectionConverters._
 
 class KafkaIntegrationSpec extends munit.FunSuite with TestContainerForAll {
@@ -242,8 +241,7 @@ class KafkaIntegrationSpec extends munit.FunSuite with TestContainerForAll {
       try {
         awaitConsumerReady(sender, initialTopic, consumerReady)
 
-        val assigned = consumer.addTopicForSubscription(dynamicTopic, 30.seconds)
-        assert(assigned, "Dynamic topic subscription timed out")
+        consumer.requestTopicSubscription(dynamicTopic).get(30, TimeUnit.SECONDS)
 
         val msg = KafkaProtocolMessage(
           key = "dk".getBytes,
@@ -436,7 +434,7 @@ class KafkaIntegrationSpec extends munit.FunSuite with TestContainerForAll {
     }
   }
 
-  test("addTopicForSubscription with very short timeout returns false") {
+  test("requestTopicSubscription stays pending until the assignment actually happens") {
     withContainers { kafka =>
       val bootstrap  = kafka.bootstrapServers
       val topic      = "test-sub-timeout"
@@ -460,9 +458,10 @@ class KafkaIntegrationSpec extends munit.FunSuite with TestContainerForAll {
       try {
         awaitConsumerReady(sender, setupTopic, consumerReady)
         sender.close()
-        // 1 nanosecond timeout — subscription cannot complete in time
-        val assigned = consumer.addTopicForSubscription(topic, scala.concurrent.duration.Duration.fromNanos(1))
-        assert(!assigned, "Expected subscription to time out")
+        // The caller owns the deadline now: readiness stays pending instead of reporting a timeout itself.
+        val readiness = consumer.requestTopicSubscription(topic)
+        intercept[TimeoutException](readiness.get(1, TimeUnit.MILLISECONDS))
+        assert(!readiness.isDone, "Expected readiness to still be pending")
       } finally {
         consumer.close()
         consumerThread.join(5000)

--- a/src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/TrackerAcquisitionIsolationSpec.scala
@@ -1,0 +1,455 @@
+package org.galaxio.gatling.kafka.integration
+
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import com.dimafeng.testcontainers.{ConfluentKafkaContainer, ContainerDef}
+import io.gatling.commons.stats.{OK, Status}
+import io.gatling.commons.util.Clock
+import io.gatling.core.action.Action
+import io.gatling.core.actor.{ActorRef, ActorSystem}
+import io.gatling.core.session.Session
+import io.gatling.core.stats.RecordingStatsEngine
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
+import org.galaxio.gatling.kafka.client.{DynamicKafkaConsumer, KafkaMessageTracker, KafkaMessageTrackerPool, KafkaSender}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.testcontainers.utility.DockerImageName
+
+import java.util.Collections
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.jdk.CollectionConverters._
+
+/** Regression coverage for issue #163 — tracker acquisition must not run its wait on the producer's I/O callback thread.
+  *
+  * The broker is started with a deliberately long `group.initial.rebalance.delay.ms`, so the first subscription of every
+  * freshly created pool (each one uses its own random group id) genuinely takes seconds to be assigned. That is a real
+  * broker-side stall, not an injected delay, and it is exactly the condition under which the reported defect froze the shared
+  * producer.
+  */
+class TrackerAcquisitionIsolationSpec extends munit.FunSuite with TestContainerForAll {
+
+  /** How long the broker holds back the first assignment of a new consumer group. */
+  private val AssignmentStall: FiniteDuration = 5.seconds
+
+  /** A callback that merely hands off work must return far faster than the stall above. */
+  private val CallbackBudget: FiniteDuration = 1500.millis
+
+  override val containerDef: ContainerDef { type Container = ConfluentKafkaContainer } =
+    new ContainerDef {
+      override type Container = ConfluentKafkaContainer
+
+      override def createContainer(): ConfluentKafkaContainer = {
+        val container = ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.9.5"))
+        container.container.withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", AssignmentStall.toMillis.toString)
+        container
+      }
+    }
+
+  override def munitTimeout: scala.concurrent.duration.Duration = 5.minutes
+
+  private def producerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> bootstrap,
+    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> classOf[ByteArraySerializer].getName,
+    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[ByteArraySerializer].getName,
+  )
+
+  // No group id on purpose: the pool then generates a random one, so every pool joins as a brand new
+  // group and pays the broker's initial rebalance delay.
+  private def consumerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG        -> bootstrap,
+    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
+  )
+
+  private def createTopics(bootstrap: String, names: String*): Unit = {
+    val admin = AdminClient.create(
+      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrap).asJava,
+    )
+    try
+      admin
+        .createTopics(names.map(new NewTopic(_, 1, 1.toShort)).asJava)
+        .all()
+        .get(30, TimeUnit.SECONDS)
+    finally admin.close()
+  }
+
+  private final class SystemClock extends Clock {
+    override def nowMillis: Long = System.currentTimeMillis()
+  }
+
+  /** Runs `body` with a pool and a sender that share one producer, tearing both down afterwards. The pool's stats engine is
+    * handed over too, so a test can assert on what the trackers it creates actually report.
+    */
+  private def withPoolAndSender(
+      bootstrap: String,
+  )(body: (KafkaMessageTrackerPool, KafkaSender, RecordingStatsEngine) => Unit): Unit = {
+    val actorSystem = new ActorSystem()
+    val sender      = KafkaSender(producerSettings(bootstrap))
+    val statsEngine = new RecordingStatsEngine
+    try {
+      val pool = new KafkaMessageTrackerPool(
+        consumerSettings(bootstrap),
+        actorSystem,
+        statsEngine,
+        new SystemClock,
+      )
+      body(pool, sender, statsEngine)
+    } finally {
+      sender.close()
+      actorSystem.close()
+    }
+  }
+
+  private final class RecordingAction extends Action {
+    override def name: String = "recording-next"
+
+    val lastSession: AtomicReference[Session] = new AtomicReference[Session]()
+
+    override def !(session: Session): Unit = execute(session)
+
+    override def execute(session: Session): Unit = lastSession.set(session)
+  }
+
+  private def message(topic: String, key: String, value: String): KafkaProtocolMessage =
+    KafkaProtocolMessage(key.getBytes, value.getBytes, topic, topic)
+
+  /** Mirrors what KafkaRequestReplyAction does: acquire the reply tracker from inside the delivery callback. */
+  private def sendAndAcquireInCallback(
+      sender: KafkaSender,
+      pool: KafkaMessageTrackerPool,
+      requestTopic: String,
+      replyTopic: String,
+      timeout: FiniteDuration,
+  ): Acquisition = {
+    val acquisition = new Acquisition
+    sender.send(message(requestTopic, "k", "request"))(
+      _ => {
+        acquisition.ackAt.set(System.currentTimeMillis())
+        acquisition.callbackEntered.countDown()
+        pool.acquireTracker(requestTopic, replyTopic, KafkaKeyMatcher, None, timeout)(
+          tracker => {
+            acquisition.readyAt.set(System.currentTimeMillis())
+            acquisition.tracker.set(tracker)
+            acquisition.settled.countDown()
+          },
+          error => {
+            acquisition.failedAt.set(System.currentTimeMillis())
+            acquisition.failure.set(error)
+            acquisition.settled.countDown()
+          },
+        )
+        acquisition.callbackReturnedAt.set(System.currentTimeMillis())
+      },
+      error => {
+        acquisition.failure.set(error)
+        acquisition.settled.countDown()
+      },
+    )
+    acquisition
+  }
+
+  private final class Acquisition {
+    val ackAt: AtomicLong                                                      = new AtomicLong(0L)
+    val callbackReturnedAt: AtomicLong                                         = new AtomicLong(0L)
+    val readyAt: AtomicLong                                                    = new AtomicLong(0L)
+    val failedAt: AtomicLong                                                   = new AtomicLong(0L)
+    val tracker: AtomicReference[ActorRef[KafkaMessageTracker.TrackerMessage]] = new AtomicReference(null)
+    val failure: AtomicReference[Throwable]                                    = new AtomicReference(null)
+    val callbackEntered: CountDownLatch                                        = new CountDownLatch(1)
+    val settled: CountDownLatch                                                = new CountDownLatch(1)
+
+    def awaitSettled(): Unit =
+      assert(settled.await(2, TimeUnit.MINUTES), "acquisition never completed")
+
+    def awaitCallbackEntered(): Unit =
+      assert(callbackEntered.await(1, TimeUnit.MINUTES), "delivery callback never ran")
+
+    def callbackDuration: Long = callbackReturnedAt.get() - ackAt.get()
+    def readyDelay: Long       = readyAt.get() - ackAt.get()
+  }
+
+  test("acquiring a reply tracker returns immediately from the delivery callback") {
+    withContainers { kafka =>
+      val bootstrap    = kafka.bootstrapServers
+      val requestTopic = "isolation-request"
+      val replyTopic   = "isolation-reply"
+      createTopics(bootstrap, requestTopic, replyTopic)
+
+      withPoolAndSender(bootstrap) { (pool, sender, _) =>
+        val acquisition = sendAndAcquireInCallback(sender, pool, requestTopic, replyTopic, 60.seconds)
+        acquisition.awaitSettled()
+
+        assert(acquisition.failure.get() == null, s"acquisition failed: ${acquisition.failure.get()}")
+        assert(
+          acquisition.readyDelay > AssignmentStall.toMillis / 2,
+          s"assignment was not actually slow (${acquisition.readyDelay} ms): the test proves nothing",
+        )
+        assert(
+          acquisition.callbackDuration < CallbackBudget.toMillis,
+          s"delivery callback was held for ${acquisition.callbackDuration} ms waiting for the assignment",
+        )
+      }
+    }
+  }
+
+  test("delivery confirmations keep flowing while a reply topic is still being assigned") {
+    withContainers { kafka =>
+      val bootstrap    = kafka.bootstrapServers
+      val requestTopic = "flow-request"
+      val replyTopic   = "flow-reply"
+      val otherTopic   = "flow-other"
+      createTopics(bootstrap, requestTopic, replyTopic, otherTopic)
+
+      withPoolAndSender(bootstrap) { (pool, sender, _) =>
+        val acquisition = sendAndAcquireInCallback(sender, pool, requestTopic, replyTopic, 60.seconds)
+
+        // Wait until the delivery callback has actually started — from here on the producer's I/O
+        // thread is inside the acquisition — then push unrelated traffic through the same producer.
+        acquisition.awaitCallbackEntered()
+        assert(acquisition.settled.getCount > 0, "assignment completed too quickly to prove anything")
+
+        val sends      = 5
+        val confirmed  = new CountDownLatch(sends)
+        val sendErrors = new ConcurrentLinkedQueue[Throwable]()
+
+        // Timed from before the first send: a frozen producer I/O thread delays metadata and
+        // delivery confirmations alike, and both count against unrelated traffic.
+        val startedAt    = System.currentTimeMillis()
+        (0 until sends).foreach { i =>
+          sender.send(message(otherTopic, s"k-$i", s"v-$i"))(
+            _ => confirmed.countDown(),
+            e => { sendErrors.add(e); confirmed.countDown() },
+          )
+        }
+        val allConfirmed = confirmed.await(1, TimeUnit.MINUTES)
+        val elapsed      = System.currentTimeMillis() - startedAt
+
+        assert(sendErrors.isEmpty, s"unrelated sends failed: ${sendErrors.asScala.map(_.getMessage).mkString(", ")}")
+        assert(allConfirmed, "unrelated deliveries were never confirmed")
+        assert(
+          elapsed < CallbackBudget.toMillis * 2,
+          s"unrelated traffic took $elapsed ms to get through while one reply topic was being assigned",
+        )
+
+        acquisition.awaitSettled()
+        assert(acquisition.failure.get() == null, s"acquisition failed: ${acquisition.failure.get()}")
+      }
+    }
+  }
+
+  test("concurrent first use of one reply topic yields a single tracker without holding the callback thread") {
+    withContainers { kafka =>
+      val bootstrap    = kafka.bootstrapServers
+      val requestTopic = "concurrent-request"
+      val replyTopic   = "concurrent-reply"
+      createTopics(bootstrap, requestTopic, replyTopic)
+
+      withPoolAndSender(bootstrap) { (pool, sender, _) =>
+        val acquisitions =
+          (1 to 8).map(_ => sendAndAcquireInCallback(sender, pool, requestTopic, replyTopic, 60.seconds))
+
+        acquisitions.foreach(_.awaitSettled())
+
+        acquisitions.foreach { acquisition =>
+          assert(acquisition.failure.get() == null, s"acquisition failed: ${acquisition.failure.get()}")
+          assert(
+            acquisition.callbackDuration < CallbackBudget.toMillis,
+            s"delivery callback was held for ${acquisition.callbackDuration} ms",
+          )
+        }
+
+        val trackers = acquisitions.map(_.tracker.get()).distinct
+        assertEquals(trackers.size, 1, "concurrent acquisitions of one topic must converge on a single tracker")
+      }
+    }
+  }
+
+  test("an acquisition timeout fails only the requesting operation and names the topic") {
+    withContainers { kafka =>
+      val bootstrap    = kafka.bootstrapServers
+      val requestTopic = "timeout-request"
+      val replyTopic   = "timeout-reply"
+      createTopics(bootstrap, requestTopic, replyTopic)
+
+      withPoolAndSender(bootstrap) { (pool, sender, _) =>
+        // Far shorter than the broker's initial rebalance delay, so the assignment cannot arrive in time.
+        val acquisition = sendAndAcquireInCallback(sender, pool, requestTopic, replyTopic, 1.second)
+        acquisition.awaitSettled()
+
+        val failure = acquisition.failure.get()
+        assert(failure != null, "expected the acquisition to time out")
+        assert(
+          failure.getMessage.contains(replyTopic) && failure.getMessage.contains("Timed out waiting for consumer assignment"),
+          s"unexpected failure message: ${failure.getMessage}",
+        )
+        assert(
+          acquisition.callbackDuration < CallbackBudget.toMillis,
+          s"delivery callback was held for ${acquisition.callbackDuration} ms waiting to fail",
+        )
+
+        val failedAfter = acquisition.failedAt.get() - acquisition.ackAt.get()
+        assert(
+          failedAfter < AssignmentStall.toMillis,
+          s"failure was reported after $failedAfter ms, later than the requested 1s timeout",
+        )
+      }
+    }
+  }
+
+  test("the pool stays usable after an acquisition timeout and the topic can be acquired again") {
+    withContainers { kafka =>
+      val bootstrap    = kafka.bootstrapServers
+      val requestTopic = "retry-request"
+      val replyTopic   = "retry-reply"
+      createTopics(bootstrap, requestTopic, replyTopic)
+
+      withPoolAndSender(bootstrap) { (pool, sender, _) =>
+        val timedOut = sendAndAcquireInCallback(sender, pool, requestTopic, replyTopic, 1.second)
+        timedOut.awaitSettled()
+        assert(timedOut.failure.get() != null, "expected the first acquisition to time out")
+
+        // Nothing was poisoned: a later request for the same topic is attempted afresh and succeeds
+        // once the broker finishes forming the group.
+        val retried = sendAndAcquireInCallback(sender, pool, requestTopic, replyTopic, 60.seconds)
+        retried.awaitSettled()
+
+        assert(retried.failure.get() == null, s"retry failed: ${retried.failure.get()}")
+        assert(retried.tracker.get() != null, "retry produced no tracker")
+        assert(
+          retried.callbackDuration < CallbackBudget.toMillis,
+          s"delivery callback was held for ${retried.callbackDuration} ms on retry",
+        )
+      }
+    }
+  }
+
+  test("the response time a tracker reports excludes subscription setup") {
+    withContainers { kafka =>
+      val bootstrap    = kafka.bootstrapServers
+      val requestTopic = "timing-request"
+      val replyTopic   = "timing-reply"
+      createTopics(bootstrap, requestTopic, replyTopic)
+
+      withPoolAndSender(bootstrap) { (pool, sender, statsEngine) =>
+        val key        = "timing-key"
+        val ackAt      = new AtomicLong(0L)
+        val sentAt     = new AtomicLong(0L)
+        val registered = new CountDownLatch(1)
+        val matched    = new CountDownLatch(1)
+        val failure    = new AtomicReference[Throwable](null)
+        val next       = new RecordingAction
+
+        sender.send(message(requestTopic, key, "request"))(
+          _ => {
+            ackAt.set(System.currentTimeMillis())
+            pool.acquireTracker(requestTopic, replyTopic, KafkaKeyMatcher, None, 60.seconds)(
+              tracker => {
+                // Recorded exactly where KafkaRequestReplyAction records it: inside onReady, once
+                // tracking is ready — never at ack time.
+                val sentTimestamp = System.currentTimeMillis()
+                sentAt.set(sentTimestamp)
+                tracker ! KafkaMessageTracker.MessagePublished(
+                  matchId = key.getBytes,
+                  sentTimestamp = sentTimestamp,
+                  replyTimeout = 60.seconds.toMillis,
+                  checks = Nil,
+                  session = Session("scenario", 1L, null),
+                  next = next,
+                  requestName = "timing-request-reply",
+                  onComplete = () => matched.countDown(),
+                )
+                registered.countDown()
+              },
+              error => { failure.set(error); registered.countDown() },
+            )
+          },
+          error => { failure.set(error); registered.countDown() },
+        )
+
+        assert(registered.await(2, TimeUnit.MINUTES), "tracker never became ready")
+        assert(failure.get() == null, s"acquisition failed: ${failure.get()}")
+
+        val setupDuration = sentAt.get() - ackAt.get()
+        assert(
+          setupDuration > AssignmentStall.toMillis / 2,
+          s"subscription setup was not actually slow ($setupDuration ms): the guard proves nothing",
+        )
+
+        val replySent = new CountDownLatch(1)
+        sender.send(message(replyTopic, key, "reply"))(
+          _ => replySent.countDown(),
+          error => { failure.set(error); replySent.countDown() },
+        )
+        assert(replySent.await(30, TimeUnit.SECONDS), "reply was never produced")
+        assert(failure.get() == null, s"producing the reply failed: ${failure.get()}")
+        assert(matched.await(1, TimeUnit.MINUTES), "the tracker never matched the reply")
+
+        val responses = statsEngine.responses.get()
+        assertEquals(responses.size, 1, s"expected exactly one logged response, got $responses")
+        val reported  = responses.head.endTimestamp - responses.head.startTimestamp
+        assertEquals(responses.head.status, OK: Status, s"reply was not reported as OK: ${responses.head}")
+        // Fails if the sent timestamp is ever moved back to the ack: the reported duration would
+        // then carry the whole subscription setup with it.
+        assert(
+          reported < AssignmentStall.toMillis / 2,
+          s"reported response time of $reported ms includes the $setupDuration ms of subscription setup",
+        )
+      }
+    }
+  }
+
+  test("a second subscription request does not strand the first one's readiness") {
+    withContainers { kafka =>
+      val bootstrap  = kafka.bootstrapServers
+      val firstTopic = "listener-first"
+      val lateTopic  = "listener-second"
+      createTopics(bootstrap, firstTopic, lateTopic)
+
+      val consumer = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+        consumerSettings(bootstrap) + (ConsumerConfig.GROUP_ID_CONFIG -> "listener-replacement"),
+        Set.empty,
+        _ => (),
+        _ => (),
+      )
+      val thread   = new Thread(consumer, "listener-replacement-consumer")
+      thread.setDaemon(true)
+      thread.start()
+
+      try {
+        val firstReadiness = consumer.requestTopicSubscription(firstTopic)
+
+        // Long enough to land in a later poll cycle, short enough that the broker is still holding
+        // back the first assignment: the resulting second subscribe() replaces the rebalance
+        // listener, which is what used to drop whatever readiness the previous one was holding.
+        Thread.sleep(AssignmentStall.toMillis / 3)
+
+        // Without these the test could pass vacuously: if the consumer thread had not run yet, both
+        // requests would be drained by a single updateSubscription, one subscribe would cover both
+        // topics, and no listener would ever be replaced. An emptied queue means the first request
+        // has already been applied — read reflectively because the wrapped KafkaConsumer is not
+        // safe to touch from this thread.
+        val queueField = classOf[DynamicKafkaConsumer[_, _]].getDeclaredField("topicsQueue")
+        queueField.setAccessible(true)
+        assert(
+          queueField.get(consumer).asInstanceOf[java.util.Queue[_]].isEmpty,
+          "the first subscription was not applied yet, so no second subscribe can replace its listener",
+        )
+        assert(!firstReadiness.isDone, "the first assignment already landed: nothing is left to strand")
+
+        val lateReadiness = consumer.requestTopicSubscription(lateTopic)
+
+        // Either .get throwing a TimeoutException fails the test — that is the assertion.
+        firstReadiness.get(2, TimeUnit.MINUTES)
+        lateReadiness.get(2, TimeUnit.MINUTES)
+      } finally {
+        consumer.close()
+        thread.join(5000)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #163.

Two commits: the spec-kit artifacts (`docs(speckit)`) and the fix (`fix(client)`), in that order per the spec-first convention.

## Problem

`KafkaRequestReplyAction` acquired the reply tracker inside the producer's delivery callback, which runs on the producer's single I/O thread. On first use of a reply topic that reached `CountDownLatch.await` and parked the thread for up to the protocol reply timeout (60s default) — stalling acks and callbacks for **every** other in-flight send in the simulation.

## Fix

Acquisition became asynchronous; the send-then-track order is unchanged, so measured-latency semantics and the reply-matching window stay as they were.

- **`DynamicKafkaConsumer`** — `requestTopicSubscription` returns a `CompletableFuture` instead of blocking on a latch. Readiness lives on the consumer in `awaitingAssignment` and resolves from `consumer.assignment()`; it is deliberately **not** captured by the `ConsumerRebalanceListener` (see below). Pending readiness is failed on consumer failure, on close, and when its topic leaves the subscription — nothing waits forever.
- **`KafkaMessageTrackerPool`** — `acquireTracker(...)(onReady, onFailure)` replaces the blocking `tracker(...)`. Fast path stays inline; slow path attaches a continuation plus a cancellable timeout on a pool-owned single-thread daemon scheduler that drains on shutdown.
- **`KafkaRequestReplyAction`** — the callback only wires `onReady`/`onFailure`, so an acquisition timeout fails just that request while the shared producer keeps flowing.

## Two things the plan did not predict

**1. Readiness could not stay in the rebalance listener.** Kafka keeps only the most recent `ConsumerRebalanceListener`, so a second `subscribe()` issued before the first rebalance completed discarded the first listener *and the readiness it held*. The caller then waited out its full timeout for a topic that was subscribed and healthy. Blocking acquisition hid this by serialising subscriptions; concurrency exposed it at once (`Timed out waiting for consumer assignment to topic 'test.t1' after 60 seconds`). Readiness now resolves from the actual assignment.

**2. The test broker needed `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0`.** It was inheriting Kafka's 3s default, so the first assignment of every new consumer group took ~3s. `KafkaGatlingTest` has no echo service — its "replies" come from sibling scenarios publishing at +1s and +2s — so with `auto.offset.reset` at its `latest` default those replies landed before the reply consumer was assigned and were skipped. **The simulation passed before only because the blocked producer also delayed those sibling publishes**: it was green *because of* the defect being fixed here.

## Restored after a review pass

Removing the blocking wait also removed the serialisation the old failure handling relied on. Re-established explicitly:

- The action's deleted `try`/`catch` — `acquireTracker` can still throw synchronously (`RejectedExecutionException` once the setup executor is down); it now reports through `onFailure`, and both paths hand the tracker over via `deliverReady` so a throwing `onReady` neither escapes into the delivery callback nor double-advances a request already in the mailbox.
- `registerTracker` created the tracker actor **before** the deduplicating `compute`; with callbacks no longer serialised, N concurrent first uses orphaned N-1 started actors, each still running its own periodic timeout scan. Created inside the insert branch now.
- `updateSubscription`'s queue poll is null-guarded — `close()` drains the same queue from another thread, and a `MatchError` there took the whole pool down via `markConsumerFailed`.
- The readiness continuation re-checks consumer failure before registering, and `setupExecutor` drains queued continuations instead of discarding them (a `ScheduledThreadPoolExecutor` cancels even zero-delay queued tasks on shutdown unless told otherwise).

## Verification

| Gate | Result |
|------|--------|
| `sbt scalafmtCheckAll scalafmtSbtCheck compile test` | 42 passed (was 33) |
| `KafkaGatlingTest` (Compose stack) | successful — 1 KO of 9, exactly the baseline; the KO is `scnRRwo`, failing by design |
| `KafkaJavaapiMethodsGatlingTest` | successful — 0 KO of 5 |
| `KafkaConcurrencyLoadTest` (30 users, 2 min) | successful — 14 KO of 6,529 = 0.21%, budget 1% |
| `ExampleSmokeValidation` | all 9 example simulations still construct |

`TrackerAcquisitionIsolationSpec` (7 tests) drives a real broker with a genuinely slow first assignment. Since it cannot fail against the pre-fix *API*, the pre-fix *behaviour* was restored to check it bites: 4 of 6 went red with the intended diagnostics — `delivery callback was held for 5252 ms waiting for the assignment` and `unrelated traffic took 5039 ms to get through while one reply topic was being assigned`. The two tests added after review were falsified the same way: reporting from the ack fails with `reported response time of 5056 ms includes the 5024 ms of subscription setup`, and restoring the listener-closure capture fails the new listener-replacement test with `TimeoutException`.

`KafkaConcurrencyLoadTest` is a manual load harness for this path, not wired into CI. Its failure budget is 1% rather than 0 — see `KnownReplyLossBudgetPercent`, which documents the residual reply-loss race (#191), the tracker churn that re-arms it (#165), and the measured rates that make 1% still fail a regression to pre-#163 behaviour.

## Reviewer notes

- No public Scala DSL, `javaapi`, default, or wire-format change. Both replaced methods were internal `client` collaborators, absent from the DSL, `javaapi`, README, and examples.
- No new dependencies — JDK `java.util.concurrent` only.
- **CI broker synced, not consolidated.** CI declares its own `wurstmeister/kafka:2.13-2.8.1` service rather than using `docker-compose.kafka.yml`, so `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"` is applied in both files with a cross-reference comment (verified against the image's `start-kafka.sh`, which maps `KAFKA_*` env to `group.initial.rebalance.delay.ms` and does not exclude it); `test.t` was added to CI's topic list for parity. Consolidating the two definitions — which also closes a Kafka 2.8-vs-3.9 broker gap against the `7.9.5-ccs` clients this plugin ships — is #192, deliberately its own PR because it needs a real CI run to validate.
- Two review findings deliberately left open: readiness now requires the topic in this member's own `assignment()`, which changes behaviour for a user-supplied shared `group.id`; and `awaitingAssignment` still retains entries for readiness resolved purely by the pool's timeout.
- Out of scope and untouched: #164, #165, #166, #143, #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
