### PR TITLE
test(client): guard the coalesced remove-then-resubscribe path (#164)

### DIFF
--- a/src/test/scala/org/galaxio/gatling/kafka/integration/KafkaIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/KafkaIntegrationSpec.scala
@@ -336,6 +336,73 @@ class KafkaIntegrationSpec extends munit.FunSuite with TestContainerForAll {
     }
   }
 
+  test("a topic removed and re-requested in the same batch is still assigned and still delivers") {
+    // Regression guard for issue #164. A removal and a re-subscription that land in the same
+    // updateSubscription batch cancel out: allTopics equals the current subscription, so
+    // consumer.subscribe() is skipped and no rebalance follows. Readiness used to hang off
+    // onPartitionsAssigned, so it was never signalled and the caller waited out its whole timeout
+    // on a topic that had been subscribed and healthy throughout. Readiness is now resolved from
+    // consumer.assignment() on every pass, which does not depend on a rebalance happening.
+    //
+    // Two topics, so the "never unsubscribe down to nothing" guard is not what keeps this alive —
+    // this has to pass on the coalescing path itself.
+    //
+    // The two queue writes below coalesce as long as no poll cycle (1s) separates them; back-to-back
+    // calls make that near-certain. A rare interleaving that splits them across cycles under-tests
+    // the coalescing path but cannot fail the test, since both assertions are about liveness.
+    withContainers { kafka =>
+      val bootstrap = kafka.bootstrapServers
+      val churned   = "test-coalesced-churned"
+      val stable    = "test-coalesced-stable"
+      createTopic(bootstrap, churned)
+      createTopic(bootstrap, stable)
+
+      val consumerReady = new CountDownLatch(1)
+      val afterReceived = new CountDownLatch(1)
+
+      val consumer       = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+        consumerSettings(bootstrap, "group-coalesced"),
+        Set(churned, stable),
+        record => {
+          consumerReady.countDown()
+          if (record.topic() == churned && new String(record.value()) == "after-rechurn") {
+            afterReceived.countDown()
+          }
+        },
+        e => fail(s"Consumer error: ${e.getMessage}"),
+      )
+      val consumerThread = new Thread(consumer, "coalesced-consumer")
+      consumerThread.setDaemon(true)
+      consumerThread.start()
+
+      val sender = KafkaSender(producerSettings(bootstrap))
+
+      try {
+        awaitConsumerReady(sender, churned, consumerReady)
+
+        consumer.removeTopicSubscription(churned)
+        val readiness = consumer.requestTopicSubscription(churned)
+
+        // Pre-fix this waited forever: the subscribe was a no-op, so no assignment callback fired.
+        readiness.get(30, TimeUnit.SECONDS)
+
+        val sent = new CountDownLatch(1)
+        sender.send(KafkaProtocolMessage("k".getBytes, "after-rechurn".getBytes, churned, churned))(
+          _ => sent.countDown(),
+          e => { fail(s"Send failed: $e"); sent.countDown() },
+        )
+        assert(sent.await(10, TimeUnit.SECONDS), "Send did not complete in time")
+
+        // Readiness resolving is only meaningful if the subscription really survived the batch.
+        assert(afterReceived.await(30, TimeUnit.SECONDS), "Re-requested topic stopped delivering")
+      } finally {
+        consumer.close()
+        consumerThread.join(5000)
+        sender.close()
+      }
+    }
+  }
+
   test("concurrent sends: multiple messages sent in parallel arrive correctly") {
     withContainers { kafka =>
       val bootstrap = kafka.bootstrapServers


### PR DESCRIPTION
Closes #164

## What this is

#164 is already fixed in `main`, by two changes that were not aimed at it:

- **#163 / #190** replaced the assignment latch with a `CompletableFuture` resolved from `consumer.assignment()` on every `updateSubscription` pass ([`DynamicKafkaConsumer.scala:105`](https://github.com/galax-io/gatling-kafka-plugin/blob/main/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala#L105), [`:200`](https://github.com/galax-io/gatling-kafka-plugin/blob/main/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala#L200)). Readiness no longer depends on a rebalance happening, which is the whole of #164 — a coalesced add+remove yields an unchanged topic set, Kafka forces no rebalance, and the old latch was therefore never counted down.
- **#165 / #195** removed the per-request release that produced the coalescing window in the first place.

So the defect is gone, but nothing in the suite observes it. This PR adds the missing witness before the issue is closed.

## The test

`KafkaIntegrationSpec`: `removeTopicSubscription` immediately followed by `requestTopicSubscription` on an already-assigned topic, so both land in one `updateSubscription` batch and `subscribe()` is skipped. A second topic stays subscribed throughout, so the "never unsubscribe down to nothing" guard is not what keeps the test alive — it has to pass on the coalescing path itself.

It asserts two things, not one: readiness resolves, **and** the topic still delivers afterwards. Readiness resolving on a subscription that was actually dropped would be no better than hanging.

## Red before green

Reverting readiness to the pre-#163 shape — resolved only by `onPartitionsAssigned`, by removing both `completeAssignedReadiness()` calls from `updateSubscription` — fails this test on a 30 s timeout and leaves the other eight tests in the suite passing. It is the only guard for this path.

## Verification

`sbt scalafmtCheckAll scalafmtSbtCheck compile test` — 42/42 green (41 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)