### PR TITLE
docs(speckit): add 003 spec/plan/tasks for request-reply hardening

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/002-hold-reply-subscriptions"
+  "feature_directory": "specs/003-request-reply-hardening"
 }

--- a/specs/003-request-reply-hardening/checklists/requirements.md
+++ b/specs/003-request-reply-hardening/checklists/requirements.md
@@ -1,0 +1,65 @@
+# Specification Quality Checklist: Request-Reply Reliability Hardening
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Notes
+
+Two review iterations were run against the draft. Findings and resolutions:
+
+**Iteration 1 — implementation leakage.** The draft named source-level constructs (the consumer's
+poll call, the tracker actor's mailbox, the discarded cancellation handle, the concurrent map
+proposed in #191). Replaced throughout with the domain vocabulary already established in spec `002`:
+*reply channel*, *reply-tracking registration*, *shared reply-receiving machinery*, plus two terms
+this feature needs — *pending-request record* (#191) and *background timeout watch* (#166). The
+mechanism for #191 is deliberately left unstated; the issue does not prescribe one and it is a
+planning decision.
+
+**Iteration 2 — testability of the negative requirements.** FR-002 ("unmatched replies are still
+discarded") and FR-010 ("bounded by channels held, not created") read as prohibitions with no
+observable signal. Each is now paired with a measurable outcome: SC-005/SC-006 bound background
+activity and retained state against a 20-channel churn run, and FR-002 is stated explicitly as a
+constraint on FR-001's solution rather than as standalone prose. SC-007 was added to make "not by
+coincidence" (#196) directly checkable: delete the produce-only scenarios and the request-reply
+scenarios must still pass.
+
+**Deliberate non-clarifications.** Three points were resolved by informed guess rather than a
+[NEEDS CLARIFICATION] marker, and are recorded in the spec's Assumptions section:
+
+1. *Scope* — the milestone URL was read as "the work still open in it" (#143, #166, #191, #196),
+   since its other three issues have already landed under specs `001` and `002`. (The milestone's
+   `closed_issues: 7` counts four merged PRs alongside those three issues.)
+2. *Fix mechanism for #191 and #143* — both issues explicitly decline to prescribe one. The spec
+   states required behaviour and leaves mechanism to `/speckit-plan`.
+3. *Sequencing of #196 against #192* — both touch the same CI broker definition and topic list. The
+   spec requires only that they be sequenced and that the two topic lists stay identical, not which
+   lands first.
+
+Both quantitative baselines cited in SC-001 (0–2 of ~6,760 on current code; 14–17 of ~6,500 before
+idle release) are carried from measurements already recorded in the repository, not estimated.

--- a/specs/003-request-reply-hardening/contracts/internal-api.md
+++ b/specs/003-request-reply-hardening/contracts/internal-api.md
@@ -1,0 +1,175 @@
+# Internal API & Ordering Contract
+
+**Feature**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md) | **Research**: [../research.md](../research.md)
+
+The plugin's *published* contract — the Scala DSL, `javaapi`, protocol defaults, wire formats — is
+unchanged (spec FR-016). This document covers the internal signatures this feature touches and the
+guarantees each fix must hold, with the red/green condition for every one.
+
+It carries forward [001's contract](../../001-nonblocking-tracker-acquisition/contracts/internal-api.md)
+(non-blocking acquisition) and [002's](../../002-hold-reply-subscriptions/contracts/internal-api.md)
+(idle-released channels). Where this document adds a clause to a guarantee those established, it says
+so; nothing here retracts either.
+
+---
+
+## 1. `DynamicKafkaConsumer` — #143
+
+```scala
+// unchanged
+def requestTopicSubscription(topic: String): CompletableFuture[Void]
+def removeTopicSubscription(topic: String): Unit
+def close(): Unit
+def run(): Unit
+
+// additive overload — production callers keep using the existing one
+def apply[K, V](
+    settingsMap: Map[String, AnyRef],
+    topics: Set[String],
+    onRecord: ConsumerRecord[K, V] => Unit,
+    onFailure: Exception => Unit,
+    initializationTimeout: FiniteDuration,   // new; defaults to 90.seconds via the existing apply
+): DynamicKafkaConsumer[K, V]
+```
+
+| | Guarantee | Red before | Green after |
+|---|---|---|---|
+| **C1** | `poll` is never called while the consumer holds neither a subscription nor an assignment. | With no topic requested, the run loop throws `IllegalStateException: Consumer is not subscribed to any topics or assigned any partitions` once the initialization wait expires. | The loop sleeps the poll interval instead and reports no failure. |
+| **C2** | A loop turn that skips the poll still applies pending subscription changes. | n/a — the loop has already died. | A topic requested after the wait expired is subscribed on the next turn and its readiness future completes. |
+| **C3** | Expiry of the initialization wait sets no failure state. | `onFailure` fires and `markConsumerFailed` latches `consumerFailure`. | No `onFailure`, no `consumerFailure`; `subscriptionUnavailable` stays `None`. |
+| **C4** | The wait's outcome is distinguishable in the logs. | The 90 s expiry is silent; the eventual error names nothing about it. | A debug line records that the wait expired with no reply topic requested. |
+| **C5** | The "never unsubscribe to nothing" guard from 002 is preserved unchanged. | — | `KafkaIntegrationSpec`'s unsubscribe test still passes untouched. |
+
+---
+
+## 2. `KafkaMessageTrackerPool` — #143, #166
+
+```scala
+// unchanged — primary constructor, and both acquisition entry points
+class KafkaMessageTrackerPool(
+    consumerSettings: Map[String, AnyRef],
+    actorSystem: ActorSystem,
+    statsEngine: StatsEngine,
+    clock: Clock,
+)
+def acquireTracker(...)(onReady, onFailure): Unit
+def releaseTracker(consumerTopic: String, messageMatcher: KafkaMatcher): Unit
+private[client] def sweepIdleTrackers(): Unit
+@volatile private[kafka] var idleGraceMillis: Long
+
+// additive secondary constructor — tests only; production uses the primary
+def this(
+    consumerSettings: Map[String, AnyRef],
+    actorSystem: ActorSystem,
+    statsEngine: StatsEngine,
+    clock: Clock,
+    initializationTimeout: FiniteDuration,
+)
+```
+
+| | Guarantee | Red before | Green after |
+|---|---|---|---|
+| **P1** | A pool whose initialization wait expires with no topic requested still serves the first topic requested afterwards. | `acquireTracker` fails with `Kafka consumer failed; tracker pool can no longer be used`. | The topic is subscribed, assigned, and the tracker handed over. |
+| **P2** | A protocol declaring reply settings for a run that performs no request-reply logs no consumer failure. | The failure is logged around the 90 s mark, on a pool nobody uses. | Nothing is logged; shutdown is clean. |
+| **P3** | Every path that drops a `TrackerEntry` stops its tracker: the idle sweep, the consumer-failure broadcast, and pool shutdown. | Only the map entry is dropped; the tracker keeps firing `TimeoutScan` once per second for the rest of the run. | The tracker is stopped and its scan cancelled on all three paths. |
+| **P4** | `Stop` is sent after the entry is removed, and outside any `ConcurrentHashMap` compute lambda. | — | Follows the precedent `sweepIdleTrackers` already sets for `removeTopicSubscription`. |
+| **P5** | Background scan tasks alive at any moment equal the channels currently held. | Equals the number of channels *ever* created. | Equals the number held; zero when none are held. |
+| **P6** | Acquisition/release semantics from 002 are unchanged — reaching zero starts an idle clock, it does not release. | — | `TrackerLifetimeSpec` passes unchanged apart from the workaround removal in §4. |
+
+---
+
+## 3. `KafkaMessageTracker` — #166, #191
+
+```scala
+sealed trait TrackerMessage
+final case class MessagePublished(                      // field list UNCHANGED
+    matchId: Array[Byte],
+    sentTimestamp: Long,                                // now the handoff time; MessageAcked supersedes it
+    replyTimeout: Long,
+    checks: List[KafkaCheck],
+    session: Session,
+    next: Action,
+    requestName: String,
+    onComplete: () => Unit = () => (),
+) extends TrackerMessage
+final case class MessageConsumed(received: Long, message: KafkaProtocolMessage) extends TrackerMessage
+final case class ConsumerFailure(errorMessage: String) extends TrackerMessage
+
+final case class MessageAcked(matchId: Array[Byte], sentTimestamp: Long) extends TrackerMessage  // new, #191
+final case class SendFailed(matchId: Array[Byte], errorMessage: String) extends TrackerMessage   // new, #191
+case object Stop extends TrackerMessage                                                          // new, #166
+```
+
+| | Guarantee | Red before | Green after |
+|---|---|---|---|
+| **T1** | A `MessageConsumed` whose record has no ack yet is held on the record, not discarded. | `sentMessages.remove(key)` returns `None`; the reply is dropped and the request times out. | The reply is held and completed when `MessageAcked` arrives. |
+| **T2** | A response is logged with the ack timestamp as its start, never the registration timestamp. | — | Reported latency matches today's semantics exactly (FR-017). |
+| **T3** | `TimeoutScan` measures from registration, not from the ack. | — | A request whose ack never lands still times out at `replyTimeout`. |
+| **T4** | `SendFailed` removes the record, logs KO, and invokes `onComplete` exactly once. | The action logs KO directly; nothing releases the channel, because nothing was acquired. | The channel's in-flight count returns to balance. |
+| **T5** | Exactly one terminal event per record, each invoking `onComplete` once. | — | No double-release, no leaked in-flight count. |
+| **T6** | A reply matching no record is discarded silently — no failure, no mismatch. | (already holds) | Still holds; `KafkaMessageTrackerSpec`'s existing test passes unchanged. |
+| **T7** | `Stop` cancels the periodic scan and returns `die`. | The `Cancellable` is discarded at creation; nothing can cancel it. | The scan stops; the actor drops anything that arrives later. |
+| **T8** | `Stop` is idempotent and safe on a tracker that never armed a scan. | — | A tracker that only ever saw `replyTimeout <= 0` stops cleanly. |
+
+---
+
+## 4. `KafkaRequestReplyAction` — #191
+
+```scala
+override def sendKafkaMessage(
+    requestNameString: String,
+    protocolMessage: KafkaProtocolMessage,
+    session: Session,
+): Unit   // signature unchanged; call order inverted
+```
+
+**Order after the change** — this *is* the fix:
+
+```text
+1. acquireTracker(...)                            // non-blocking, as 001 established
+2.   onFailure → report KO. The record is NOT sent.        ← behaviour change, see plan Complexity Tracking
+3.   onReady   → tracker ! MessagePublished(...)           // the record exists here
+4.               sender.send(protocolMessage)(             // …and only now can a reply exist
+5.                 ack   → tracker ! MessageAcked(id, now)
+6.                 error → tracker ! SendFailed(id, msg)
+7.               )
+```
+
+| | Guarantee | Red before | Green after |
+|---|---|---|---|
+| **A1** | `MessagePublished` is enqueued before `sender.send` is called. | It is enqueued from the ack callback, after the send. | Program order guarantees it; the MPSC mailbox preserves it against the consumer thread's later enqueue (research R3). |
+| **A2** | A reply can never be processed before the request it answers. | Reproducible with a local echo responder and a fast round trip. | Structurally impossible: the reply is causally downstream of a send that is causally downstream of the enqueue. |
+| **A3** | Acquisition failure reports KO with the topic and cause, and publishes nothing. | KO is reported, but the record was already published. | Same KO, same message, same response-time span; no publish. |
+| **A4** | Send failure reports KO **and** releases the channel. | No channel was held at send time, so nothing needed releasing. | `SendFailed` does both; the in-flight count returns to zero. |
+| **A5** | Response-time semantics are unchanged in both directions. | — | Success spans ack → reply received; failure spans request start → failure detection. |
+| **A6** | The produce-only action is untouched. | — | `KafkaRequestAction` never acquires a tracker; no diff. |
+
+**Known risk, to be stated in the PR**: on the slow path the send now runs on the pool's
+single-threaded setup executor. `KafkaProducer.send` can block up to `max.block.ms` on metadata
+resolution or a full accumulator, which would stall concurrent acquisitions. Bounded in practice —
+the slow path runs once per reply topic — but it is a real change in which thread does the send.
+
+---
+
+## 5. `KafkaGatlingTest` and the broker definitions — #196
+
+Test-only; no published surface.
+
+| | Guarantee | Red before | Green after |
+|---|---|---|---|
+| **G1** | Every request-reply scenario is answered by a responder that received its request. | Replies come from sibling produce-only scenarios at fixed `nothingFor` delays. | Deleting every produce-only scenario leaves all request-reply scenarios passing (SC-007). |
+| **G2** | Key and value are byte-identical end to end. | — | `jsonPath("$.m").is("dkf")` and `bodyBytes.is("tstBytes")` pass unchanged. |
+| **G3** | A response timestamp is available through a header. | No round-trip metadata exists. | The reply carries it; key and value are untouched. |
+| **G4** | `scnRRwo` times out on `myTopic4`, which the responder does not consume. | It shares `myTopic2` with `scnRR2`; an echo there would answer it and destroy the only timeout coverage. | It has its own request topic and still times out. |
+| **G5** | The assertion fails in both directions. | `global.failedRequests.count.lte(1)` passes when the by-design timeout silently stops failing. | `count.is(1)` plus `details("Request Reply Bytes wo").failedRequests.count.is(1)`. |
+| **G6** | `myTopic4` exists in both broker definitions. | — | Present in `docker-compose.kafka.yml` and in `KAFKA_CREATE_TOPICS` in `.github/workflows/ci.yml`. |
+| **G7** | Whether `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0` is still needed is answered by running. | Assumed necessary; never retested since PR #190. | Run both ways; the result is stated in the PR either way (SC-009). |
+
+---
+
+## 6. Test-side contract change
+
+`TrackerLifetimeSpec.send` currently re-publishes the reply in a loop, with a comment naming #191 as
+the reason. Once #191 lands that loop covers for nothing and must be simplified — a re-published reply
+masks a dropped one, so leaving it in place would hide exactly the regression this feature exists to
+prevent. This is part of the #191 commit, not a follow-up.

--- a/specs/003-request-reply-hardening/data-model.md
+++ b/specs/003-request-reply-hardening/data-model.md
@@ -1,0 +1,191 @@
+# Phase 1 Data Model: Request-Reply Reliability Hardening
+
+**Feature**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md) | **Research**: [research.md](research.md)
+
+All state here is in-process and run-scoped; nothing is persisted or serialized. This document
+records the state each fix owns, what changes about it, and the transitions that must hold. Spec
+entity names are used throughout, with the implementing type named once in parentheses.
+
+---
+
+## 1. Pending-request record (`KafkaMessageTracker.sentMessages` value) — #191
+
+The record that one request has been sent and is awaiting a reply. Today the map value **is** the
+`MessagePublished` message; after #191 it is a small wrapper so the request can be registered before
+its acknowledgement timestamp exists.
+
+| Field | Source | Notes |
+|---|---|---|
+| `published` | `MessagePublished`, unchanged field list | `matchId`, `replyTimeout`, `checks`, `session`, `next`, `requestName`, `onComplete`, and `sentTimestamp` carrying the handoff time |
+| `registeredAt` | the tracker, on `MessagePublished` | The clock `TimeoutScan` measures against. Never absent — a request whose ack never lands must still time out |
+| `ackedAt` | `MessageAcked` | Absent until the producer acknowledges. **This is the timestamp reported to the stats engine**, which is what preserves FR-017 |
+| `heldReply` | `MessageConsumed` arriving before `MessageAcked` | At most one. Present only in the reply-before-ack window |
+
+**Keyed by** the Base64 encoding of the match identifier, exactly as today
+(`makeKeyForSentMessages`). Two in-flight requests producing the same identifier remain
+indistinguishable — existing behaviour, explicitly preserved by the spec's edge cases.
+
+**Ownership**: the actor's private single-threaded state. It stays a `mutable.HashMap`; research R3
+establishes that ordering, not concurrency, was the defect.
+
+### State transitions
+
+```text
+                    MessagePublished
+                   (before the send)
+                          │
+                          ▼
+                   ┌─────────────┐
+                   │ REGISTERED  │  registeredAt set, ackedAt empty
+                   └──────┬──────┘
+              MessageAcked│        │MessageConsumed
+                          ▼        ▼
+                 ┌────────────┐  ┌──────────────┐
+                 │   ACKED    │  │  REPLY HELD  │  heldReply set
+                 └─────┬──────┘  └──────┬───────┘
+          MessageConsumed│               │MessageAcked
+                          ╲             ╱
+                           ▼           ▼
+                      ┌──────────────────┐
+                      │    COMPLETED     │  removed; checks run; response logged
+                      └──────────────────┘
+                              ▲
+                              │  SendFailed / TimeoutScan / ConsumerFailure
+                              │  (removed; KO logged)
+```
+
+**Invariants**
+
+- **P1.** The record exists before `sender.send` is called for its request. This is FR-001; every
+  other guarantee about reply delivery rests on it.
+- **P2.** Exactly one terminal event fires per record — completion, send failure, timeout, or
+  consumer failure — and each invokes `onComplete` exactly once, so the channel's in-flight count is
+  balanced against acquisition.
+- **P3.** A response is logged with `ackedAt` as its start, never with `registeredAt`. A record in
+  `REPLY HELD` logs nothing until the ack lands.
+- **P4.** `TimeoutScan` measures `now - registeredAt`, so a record stuck in `REGISTERED` or
+  `REPLY HELD` because its ack never arrived still times out on schedule.
+- **P5.** A reply matching no record is discarded silently — unchanged, and FR-002 forbids buying
+  FR-001 by weakening it.
+
+---
+
+## 2. Reply-tracking registration (`KafkaMessageTrackerPool.TrackerEntry`) — #166
+
+The per-(reply topic, matching rule) bookkeeping. Gains nothing structurally; what changes is that
+its removal now stops what hangs off it.
+
+| Field | State | Notes |
+|---|---|---|
+| `actor` | unchanged | The tracker |
+| `refCount` | unchanged | Requests in flight. Incremented at acquisition, decremented by `onComplete` |
+| `idleSince` | unchanged | `clock.nowMillis` when `refCount` last reached zero |
+
+**What changes**: on removal — by the idle sweep, by the consumer-failure broadcast, or at pool
+shutdown — the entry's actor is sent `Stop`. The `Cancellable` itself stays inside the tracker, which
+created it; research R2 records why hoisting it into the entry was rejected.
+
+### Lifecycle
+
+```text
+  acquire (first)          acquire/release            idle grace elapses
+        │                        │                            │
+        ▼                        ▼                            ▼
+   ┌─────────┐   refCount>0 ┌─────────┐  refCount→0  ┌──────────────┐    ┌─────────┐
+   │ CREATED │─────────────►│ IN USE  │─────────────►│    IDLE      │───►│ STOPPED │
+   └─────────┘              └────▲────┘              └──────┬───────┘    └─────────┘
+                                 │   acquire before grace   │            entry removed,
+                                 └──────────────────────────┘            Stop sent, scan
+                                                                         cancelled, die
+```
+
+**Invariants**
+
+- **E1.** `Stop` is sent only after the entry has been removed from `trackers`, and only from outside
+  a `ConcurrentHashMap` compute lambda — following the precedent `sweepIdleTrackers` already sets for
+  `removeTopicSubscription`.
+- **E2.** `Stop` is sent only when `refCount <= 0` has held for a full idle grace, so a stopped
+  tracker never holds outstanding pending-request records. This is what makes it safe to stop the
+  very actor that would otherwise time those requests out.
+- **E3.** Every path that drops an entry stops it: the idle sweep, the consumer-failure broadcast
+  (which clears the whole map), and pool shutdown. A path that drops without stopping is the leak.
+- **E4.** After `Stop`, the tracker's `Cancellable` is cancelled and its behaviour is `die`. Nothing
+  it held — stats engine, clock, matcher closures — is reachable from the actor system's scheduler
+  any more.
+- **E5.** A stale `MessageConsumed` reaching a stopped tracker is dropped by Gatling with one INFO
+  line. Bounded to the sweep-versus-poll window, because the topic is unsubscribed immediately after.
+
+---
+
+## 3. Shared reply-receiving machinery (`DynamicKafkaConsumer`) — #143
+
+No new state. One field becomes injectable and one loop gains a precondition.
+
+| Aspect | Today | After |
+|---|---|---|
+| Initialization wait | `private val initializationTimeout = 90.seconds` on the companion | Same default, supplied through an additive `apply` overload so tests can shorten it |
+| `initLatch.await` result | discarded | Honoured and logged, so "a topic arrived" and "the wait expired" are distinguishable |
+| Poll precondition | none | Skipped whenever `subscription()` and `assignment()` are both empty; the interval is slept instead |
+
+### Loop states
+
+```text
+   ┌────────────────┐  first topic requested   ┌──────────┐
+   │  WAITING       │─────────────────────────►│ POLLING  │
+   │  (no topic)    │                          └────┬─────┘
+   └───────▲────────┘                               │
+           │  wait expires with nothing requested   │  subscription kept non-empty
+           │  → keep looping, do not poll           │  by updateSubscription (#165)
+           └───────────────────────────────────────-┘
+```
+
+**Invariants**
+
+- **C1.** `consumer.poll` is never called while the consumer holds neither a subscription nor an
+  assignment. This is the only call that throws
+  `IllegalStateException: Consumer is not subscribed to any topics or assigned any partitions`.
+- **C2.** A loop turn that skips the poll still runs `updateSubscription()`, so a topic requested
+  during the wait — or long after it expired — is picked up on the next turn.
+- **C3.** The existing "never unsubscribe down to nothing" guard is untouched. C1 and that guard are
+  complementary: one covers a subscription that was never established, the other one that shrank.
+- **C4.** Expiry of the initialization wait produces no `onFailure` call and no
+  `markConsumerFailed`, so the pool's `consumerFailure` latch is never set by it.
+
+---
+
+## 4. Echo responder (`KafkaGatlingTest`, test-only) — #196
+
+Not part of the published plugin. A stand-in for the system under test, modelled on
+`KafkaConcurrencyLoadTest`.
+
+| Aspect | Value |
+|---|---|
+| Consumes | `myTopic1`, `myTopic2` — **not** `myTopic4` |
+| Produces | `myTopic1 → test.t1`, `myTopic2 → test.t2` |
+| Key | echoed byte-for-byte — `scnRR` matches by key |
+| Value | echoed byte-for-byte — `scnRR2` matches by value and checks `bodyBytes`; `scnRR` checks `jsonPath` |
+| Headers | a response timestamp, added — the only thing the responder writes |
+| Lifecycle | started in `before` behind a readiness probe; closed in `after`, and on a `before` failure |
+
+**Invariants**
+
+- **R1.** The responder replies only to a request it received. No scenario's reply comes from another
+  scenario's publish — which is what makes SC-007 (delete the produce-only scenarios; request-reply
+  still passes) a meaningful check.
+- **R2.** Key and value are byte-identical between request and reply. Any rewrite breaks matching,
+  the checks, or both.
+- **R3.** `myTopic4` has no consumer, so `scnRRwo` times out by construction rather than by timing.
+- **R4.** A responder send failure is logged loudly. A silently-stopped responder is
+  indistinguishable from the plugin losing replies, and would fail the run with nothing pointing at
+  the cause.
+
+---
+
+## Cross-cutting: what does *not* change
+
+- `KafkaProtocolMessage` — still the single wire representation; #196's timestamp uses its existing
+  `headers` field.
+- `KafkaMatcher` — still the single matching contract.
+- `MessagePublished`'s field list, `acquireTracker`, `releaseTracker`, and both primary constructors.
+- The published Scala DSL, the `javaapi` facade, protocol defaults, and reported response-time
+  semantics (FR-016, FR-017).

--- a/specs/003-request-reply-hardening/plan.md
+++ b/specs/003-request-reply-hardening/plan.md
@@ -1,0 +1,217 @@
+# Implementation Plan: Request-Reply Reliability Hardening
+
+**Branch**: `003-request-reply-hardening` | **Date**: 2026-08-04 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/003-request-reply-hardening/spec.md`
+
+## Summary
+
+Close the four issues still open in milestone **v1.1.0 Request-reply reliability** — #143, #196,
+#166, #191 — in that order, as four independent commits.
+
+The technical core is #191, and the research reached a conclusion that makes it far smaller than the
+issue implies. The reply is dropped not because the actor mailbox is unordered, but because the
+pending-request record is created **after** the record is handed to the producer: the request is on
+the wire, and answerable, before anything is watching for its answer. Gatling's mailbox is an MPSC
+queue that preserves enqueue order across producer threads, so moving registration *before* the send
+establishes a genuine happens-before chain — registration → produce → broker → responder → consume →
+delivery — and the race disappears without a concurrent correlation table, without touching
+`acquireTracker`'s signature, and without the pool-owned correlation map that #193 sketches for
+v1.2.0.
+
+The one real cost is measurement. Today the response-time clock starts in the producer ack callback,
+and the spec's FR-017 keeps it there. Registering before the send means the ack timestamp is not
+known at registration, so the tracker gains a two-phase completion: a reply that arrives before its
+own ack is held until the ack lands, rather than being reported against the wrong clock. That, plus
+two additive messages on an internal sealed trait, is the whole of #191's surface.
+
+The other three are small and self-contained: guard the poll when there is nothing to receive on
+(#143), cancel the timeout scan and stop the tracker when its channel is released (#166), and give
+the CI simulation a real echo responder plus a dedicated topic for the scenario that must time out
+(#196).
+
+## Technical Context
+
+**Language/Version**: Scala 2.13 on sbt; Java 17+ (Temurin in CI)
+
+**Primary Dependencies**: Gatling 3.13.5 (`gatling-core` actor system, `StatsEngine`, `Clock`);
+Confluent Kafka clients 7.9.2-ccs. Avro4s 4.1.2 + Schema Registry stay `provided` and untouched.
+**No new dependency is introduced.**
+
+**Storage**: N/A — all state is in-process and run-scoped.
+
+**Testing**: munit + ScalaTest under `sbt test`, with Testcontainers
+(`ConfluentKafkaContainer`, `confluentinc/cp-kafka:7.9.5`) for anything touching broker behaviour;
+Gatling simulations (`KafkaGatlingTest`, `KafkaJavaapiMethodsGatlingTest`) against the
+`docker-compose.kafka.yml` stack in CI; `ExampleSmokeValidation` for API construction.
+
+**Target Platform**: JVM library published to Sonatype, consumed by Gatling simulations.
+
+**Project Type**: Library / Gatling protocol plugin.
+
+**Performance Goals**: zero reply loss across ≥5,000 sustained concurrent request-reply requests
+against an echo responder (SC-001); per-channel background timer count equal to channels currently
+held, not channels ever created (SC-005).
+
+**Constraints**:
+
+- No change to the published Scala DSL, the `javaapi` facade, protocol defaults, or wire formats.
+- Response-time semantics preserved exactly (FR-017) — the ack-based clock start stays, because
+  moving it belongs to #170/#193 and must ship with a Migration Guide entry.
+- `KafkaMessageTrackerPool`'s primary constructor signature stays as it is; spec `002` already
+  established that changing it is a binary break that would force a major version for a bug fix.
+- No MiMa in the build, so binary compatibility is a review obligation rather than a gate.
+
+**Scale/Scope**: 4 issues → 4 commits. 5 main-source files, 5 test files, 2 broker definitions.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*Source: `.specify/memory/constitution.md` v1.0.0.*
+
+- [x] **I. Published API Compatibility** — **No** change to any public Scala DSL signature, `javaapi`
+      signature, default protocol setting, or serialized format. Internal changes are additive:
+      two case classes on the sealed `TrackerMessage` trait, an overloaded
+      `DynamicKafkaConsumer.apply`, and a secondary `KafkaMessageTrackerPool` constructor. Every
+      existing signature — including `acquireTracker`, `releaseTracker`, and both primary
+      constructors — is untouched, and `MessagePublished`'s field list is deliberately preserved.
+      `ExampleSmokeValidation` is unaffected because nothing it constructs changes.
+      **One deviation requires approval before #191 merges** — see Complexity Tracking.
+- [x] **II. Real Broker Over Mocks** — every behaviour claim is asserted against a real broker.
+      #143 and #166 get Testcontainers integration tests; #191 gets both a Testcontainers test that
+      forces the race deterministically and the CI simulation as its oracle; #196 *is* a broker test.
+      Mocks stay confined to `StubClock` / `RecordingAction` — units with no Kafka interaction —
+      exactly as the existing client specs already use them.
+- [x] **III. Layer Separation & Single Wire Contract** — `KafkaSender` still only sends,
+      `DynamicKafkaConsumer` still only consumes, `KafkaMessageTracker` and its pool still only
+      track. #191 changes the *order* in which `KafkaRequestReplyAction` calls its injected
+      collaborators, not who owns what; the action still constructs none of them.
+      `KafkaProtocolMessage` and `KafkaMatcher` are unchanged — #196's response timestamp rides in
+      the existing `headers` field rather than in a new message type. No new abstraction is
+      introduced: the correlation table stays where it is, because the ordering fix removes the
+      reason to move it.
+- [x] **IV. Test-First for Behavior Change** — all four are bug fixes, so each ships a test that
+      reproduces the defect against pre-change code. #143 and #191 in particular must *force* their
+      condition (a parameterised initialization wait; a responder faster than the ack path) rather
+      than wait for it to occur by chance, which is what the issues ask for.
+- [x] **V. One Concern per Change, Always Green** — spec, plan and tasks land first as one
+      `docs(speckit):` commit. Then one semantic commit per issue, each green on its own under
+      `sbt scalafmtCheckAll scalafmtSbtCheck compile test`, each PR carrying the
+      `v1.1.0 Request-reply reliability` milestone and `Closes #NNN`.
+- [x] **Constraints** — no new dependency and no upgrade; Avro/Schema Registry stay `provided` and
+      optional (nothing here touches them); no supported Gatling version changes, so the README
+      compatibility table is untouched.
+
+### Post-Design Re-check
+
+Re-evaluated after Phase 1. No gate changed verdict. Two design decisions were made *because* of the
+gates rather than despite them:
+
+- Principle III steered #191 away from #193's pool-owned correlation map. Once the ordering argument
+  in [research.md](research.md) R3 held, moving the table would have been an abstraction with no
+  second caller — introduced in anticipation of v1.2.0's deadline consolidation, which Principle III
+  forbids.
+- Principle I steered #166 away from hoisting the timeout scan into the pool sweep (#193 point 4).
+  The tracker already owns its `Cancellable`; having it cancel its own scan on a terminal message is
+  additive, whereas hoisting would change what the pool hands back from `acquireTracker`.
+
+The single deviation in Complexity Tracking survived the re-check and still needs sign-off.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-request-reply-hardening/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — R1..R7, decisions with alternatives
+├── data-model.md        # Phase 1 output — state each fix owns and its transitions
+├── quickstart.md        # Phase 1 output — how to run each fix's verification
+├── contracts/
+│   └── internal-api.md  # Phase 1 output — internal signatures and guarantees, red/green per issue
+├── checklists/
+│   └── requirements.md  # From /speckit-specify
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/org/galaxio/gatling/kafka/
+├── actions/
+│   └── KafkaRequestReplyAction.scala      # #191 — acquire and register before send; ack and
+│                                          #        send-failure callbacks feed the tracker
+├── client/
+│   ├── DynamicKafkaConsumer.scala         # #143 — honour the init-wait result; never poll with
+│   │                                      #        nothing subscribed and nothing assigned;
+│   │                                      #        additive apply overload for the wait duration
+│   ├── KafkaMessageTracker.scala          # #166 — terminal Stop cancels the scan and dies
+│   │                                      # #191 — two-phase completion (ack / reply join)
+│   └── KafkaMessageTrackerPool.scala      # #166 — TrackerEntry carries the scan handle; sweep,
+│                                          #        failure broadcast and shutdown all stop it
+└── protocol/, checks/, request/           # unchanged
+
+src/test/scala/org/galaxio/gatling/kafka/
+├── client/
+│   ├── DynamicKafkaConsumerSpec.scala     # #143 — no-subscription poll guard
+│   └── KafkaMessageTrackerSpec.scala      # #191 — reply-before-ack join; #166 — Stop behaviour
+├── integration/
+│   ├── ConsumerStartupSpec.scala          # #143 — NEW: late first request-reply, real broker
+│   ├── TrackerLifetimeSpec.scala          # #166 — timer released with the channel;
+│   │                                      # #191 — the reply re-publish workaround comes out
+│   └── ReplyRegistrationRaceSpec.scala    # #191 — NEW: echo faster than the ack path
+└── examples/
+    └── KafkaGatlingTest.scala             # #196 — echo responder, own topic for the timeout
+                                           #        scenario, pinned assertion
+
+docker-compose.kafka.yml                   # #196 — new topic in the init list
+.github/workflows/ci.yml                   # #196 — same topic in KAFKA_CREATE_TOPICS
+```
+
+**Structure Decision**: The existing single-module sbt layout is unchanged. Every source edit lands
+in `actions/` or `client/`, which is where the constitution already locates send/track/consume
+responsibilities. Two new integration specs are added rather than extending `KafkaIntegrationSpec`,
+because each needs its own broker configuration — a shortened initialization wait for #143, an
+in-process echo responder for #191 — and folding either into the shared spec would impose that
+configuration on unrelated tests.
+
+## Implementation Sequence
+
+Four commits, in this order. The ordering is not arbitrary — #193's own sequencing note asks for
+#196 before #191 so the hardest fix has a deterministic CI oracle rather than a coincidence.
+
+| # | Issue | Scope | Why here |
+|---|-------|-------|----------|
+| 1 | **#143** | `DynamicKafkaConsumer` + one integration spec | Fully self-contained; removes a terminal, run-ending failure; touches nothing the other three touch. |
+| 2 | **#196** | `KafkaGatlingTest` + both broker definitions | Test-only. Lands the echo responder that makes #191's fix verifiable in CI instead of by inference. |
+| 3 | **#166** | `KafkaMessageTrackerPool` + `KafkaMessageTracker` | Small and independent. Lands before #191 so #191 rebases onto a tracker whose lifecycle is already correct. |
+| 4 | **#191** | `KafkaRequestReplyAction` + `KafkaMessageTracker` | Largest, and the only one with an approval gate. Benefits from all three above. |
+
+Each PR carries the `v1.1.0 Request-reply reliability` milestone and `Closes #NNN`. Once all four
+merge the milestone is tag-ready; note that its title already starts with `v1.1.0`, so
+`scripts/check-linkage.sh --for-tag v1.1.0` resolves it.
+
+## Complexity Tracking
+
+> One deviation. It is not extra complexity — it is a deliberate behaviour change that Principle I
+> requires be proposed and approved rather than arriving as a side effect.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| **#191 changes what the system under test receives when tracker acquisition fails.** Today the request is published and *then* acquisition is attempted, so a failed acquisition still delivers the message to the broker before reporting KO. After the change, acquisition and registration precede the send, so a failed acquisition reports the same KO without publishing anything. The Gatling-visible result is identical — same KO, same message text, same response-time span — but the broker and the system under test see one fewer record. | FR-001 requires a defined order between registering a request and its reply becoming possible. A reply becomes possible the moment the record is handed to the producer, so registration must precede the send. Once registration precedes the send, acquisition must too, since registration needs the channel. There is no ordering that both registers first and still publishes on acquisition failure without publishing a request whose reply can never be received — which is the state #143 exists to prevent from the other direction. | *Keep send-then-acquire and buffer unmatched replies briefly*: narrows the window instead of closing it, gives no defined order (FR-001), and is the "retain unmatched replies" shape FR-002 forbids. *Keep send-then-acquire and accept the loss*: that is the defect. *Publish on acquisition failure anyway, before reporting KO*: publishes a request nothing can ever receive the answer to, and makes the failure path deliver load the success path would not — a worse measurement artefact than the one being fixed. |
+
+**Approval needed from the maintainer before the #191 PR merges**, per Principle I. It is a
+behaviour change inside a bug fix, so it carries no `!:` marker and does not force a major version,
+but the PR description must state it explicitly and the README Migration Guide should note it under
+the v1.1.0 entry.
+
+## Phase Outputs
+
+- **Phase 0** → [research.md](research.md) — R1 (#143 guard placement), R2 (#166 stopping a Gatling
+  actor that has no stop), R3 (#191 why mailbox ordering suffices), R4 (#191 keeping the ack clock),
+  R5 (#191 rejected alternatives incl. #193's correlation map), R6 (#196 responder shape and topic
+  layout), R7 (making the initialization wait testable without a signature break).
+- **Phase 1** → [data-model.md](data-model.md), [contracts/internal-api.md](contracts/internal-api.md),
+  [quickstart.md](quickstart.md).
+- **Phase 2** → `tasks.md`, generated by `/speckit-tasks`. Not created by this command.

--- a/specs/003-request-reply-hardening/quickstart.md
+++ b/specs/003-request-reply-hardening/quickstart.md
@@ -1,0 +1,178 @@
+# Quickstart: Verifying Request-Reply Reliability Hardening
+
+**Feature**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md) | **Contracts**: [contracts/internal-api.md](contracts/internal-api.md)
+
+How to run the verification for each of the four issues, and what each run should show. Every check
+below has a **red** condition — what it must do against pre-change code — because all four are bug
+fixes and Principle IV requires the test to fail first.
+
+## Prerequisites
+
+- JDK 17+ and sbt.
+- Docker running. Testcontainers pulls `confluentinc/cp-kafka:7.9.5`; the Gatling simulations need
+  the Compose stack.
+- Git hooks enabled once per clone:
+
+```bash
+bash scripts/install-hooks.sh
+```
+
+## Default gate (run before every push)
+
+```bash
+sbt scalafmtCheckAll scalafmtSbtCheck compile test
+```
+
+## Compose stack, for anything Gatling
+
+```bash
+docker compose -f docker-compose.kafka.yml up -d
+```
+
+---
+
+## #143 — request-reply after a late start
+
+**Unit level** — the poll guard, no broker needed (`poll` raises before any network I/O):
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.client.DynamicKafkaConsumerSpec"
+```
+
+**Integration level** — the whole path, against a real broker:
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.integration.ConsumerStartupSpec"
+```
+
+Build a pool with a short initialization wait (the additive constructor from research R7), request no
+topic, let the wait expire, then request one.
+
+- **Red**: `acquireTracker` fails with `Kafka consumer failed; tracker pool can no longer be used`,
+  and the consumer logged `Consumer is not subscribed to any topics or assigned any partitions`.
+- **Green**: the topic is subscribed and assigned, the tracker is handed over, and no consumer
+  failure appears anywhere in the log. Covers **C1–C4**, **P1–P2**, and SC-003/SC-004.
+
+Do not shorten the wait by mutating the companion constant — it is JVM-wide and would leak into other
+tests. Use the overload.
+
+---
+
+## #196 — the CI simulation proves a round trip
+
+```bash
+sbt "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest"
+```
+
+- **Green**: exactly one failure, and it is `Request Reply Bytes wo`. Both assertions hold —
+  `global.failedRequests.count.is(1)` and the `details(...)` one.
+- **Red for G5**: with the old `lte(1)`, deliberately breaking the timeout scenario (point it at a
+  topic the responder *does* serve) still passes. With the new assertion it fails.
+
+**The check that proves replies are no longer coincidental (SC-007)** — comment out every
+produce-only scenario (`scn`, `scn2`, `scnAvro4s`, `scnwokey`) from `setUp` and run again:
+
+- **Red**: `scnRR` and `scnRR2` fail — their "replies" were the sibling scenarios' publishes.
+- **Green**: both still pass. Restore `setUp` afterwards; this is a manual check, not a committed
+  variant.
+
+**The rebalance-delay question (SC-009)** — run once with
+`KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0` as today, then once with it removed from
+`docker-compose.kafka.yml`. State the outcome in the PR either way. Expect it to still be needed:
+readiness resolves on assignment, position resolution comes later, and `auto.offset.reset` defaults
+to `latest` — that gap is #193 point 3 and is not fixed here.
+
+---
+
+## #166 — nothing outlives its channel
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.integration.TrackerLifetimeSpec"
+sbt "testOnly org.galaxio.gatling.kafka.client.KafkaMessageTrackerSpec"
+```
+
+Drive a channel through acquire → release → idle grace, then assert the tracker's periodic scan has
+stopped and the entry is gone. Then repeat across at least 20 sequential reply topics.
+
+- **Red**: scan tasks accumulate — one per channel ever created — and each keeps firing once per
+  second on the actor system's single shared scheduler thread.
+- **Green**: live scan tasks equal channels currently held; zero held means zero firing. Covers
+  **P3–P5**, **T7–T8**, and SC-005/SC-006.
+
+A useful manual cross-check: run the CI simulation with the tracker logger at DEBUG and confirm
+`Releasing idle tracker` is followed by no further `TimeoutScan` activity for that topic.
+
+---
+
+## #191 — no reply is ever dropped
+
+**Unit level** — the two-phase join, deterministic and broker-free:
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.client.KafkaMessageTrackerSpec"
+```
+
+Send `MessagePublished`, then `MessageConsumed`, then `MessageAcked` — in that order.
+
+- **Red**: the reply is discarded (`sentMessages.remove` returns `None`) and the request later times
+  out.
+- **Green**: the reply is held and completed when the ack lands, logged with the **ack** timestamp as
+  its start. Covers **T1–T3**.
+
+**Integration level** — the real race, forced rather than waited for:
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.integration.ReplyRegistrationRaceSpec"
+```
+
+An in-process echo responder answering far faster than the reply timeout, driving the real
+`KafkaRequestReplyAction`, with enough requests to exercise the window repeatedly.
+
+- **Red**: some requests fail with `Reply timeout after Xms` even though the responder answered every
+  one — the signature of the defect.
+- **Green**: zero reply-timeout failures. Covers **A1–A2** and SC-001/SC-002.
+
+**Load level** — the measured oracle:
+
+```bash
+sbt "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaConcurrencyLoadTest"
+```
+
+This is the harness whose `KnownReplyLossBudget` documents the baseline: 0–2 KO of ~6,760 across five
+runs on current code, 14–17 of ~6,500 before #165. Its own comment says **"Tighten to 0 once #191
+lands"** — do that in the #191 commit and confirm five consecutive green runs before claiming SC-001.
+
+**Also part of the #191 commit**: simplify `TrackerLifetimeSpec.send`, which re-publishes the reply in
+a loop specifically to work around #191. Leaving it would mask a regression.
+
+---
+
+## Full CI gate
+
+What `.github/workflows/ci.yml` runs, against the Compose stack:
+
+```bash
+sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport
+```
+
+And the API-construction check, which must keep passing untouched (SC-010):
+
+```bash
+sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"
+```
+
+---
+
+## Per-commit checklist
+
+Each of the four commits is green on its own and carries the milestone plus `Closes #NNN`.
+
+| Order | Commit | Must be green |
+|---|---|---|
+| 1 | `fix(client): do not poll a consumer with nothing to receive on (#143)` | default gate + `ConsumerStartupSpec` |
+| 2 | `test(examples): answer request-reply with a real echo responder (#196)` | default gate + `KafkaGatlingTest` on Compose |
+| 3 | `fix(client): stop the tracker and its timeout scan on release (#166)` | default gate + `TrackerLifetimeSpec` |
+| 4 | `fix(request-reply): register the pending request before sending (#191)` | default gate + `ReplyRegistrationRaceSpec` + `KafkaConcurrencyLoadTest` at budget 0 |
+
+The #191 PR additionally needs maintainer approval for the behaviour change recorded in the plan's
+Complexity Tracking table, and a README Migration Guide note under v1.1.0.

--- a/specs/003-request-reply-hardening/research.md
+++ b/specs/003-request-reply-hardening/research.md
@@ -1,0 +1,333 @@
+# Phase 0 Research: Request-Reply Reliability Hardening
+
+**Feature**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+The specification deliberately left the mechanism for #191 and #143 unstated, because both issues
+decline to prescribe one. This document resolves them, plus the smaller open questions in #166 and
+#196. Every finding below was read out of the code or the Gatling 3.13.5 sources, not assumed.
+
+---
+
+## R1 — #143: where to put the guard, and what to do with the wait's result
+
+**Decision**: Keep the poll loop as it is, and guard the poll itself. In `DynamicKafkaConsumer.run()`,
+capture what `initLatch.await(...)` returns and log the distinction; then, inside the loop, skip
+`consumer.poll(...)` on any iteration where the consumer holds neither a subscription nor an
+assignment, sleeping the poll interval instead and still calling `updateSubscription()` so a topic
+requested later is picked up on the next turn.
+
+**Rationale**:
+
+- The exception is thrown by exactly one call. `consumer.poll()` raises
+  `IllegalStateException: Consumer is not subscribed to any topics or assigned any partitions` when
+  both `subscription()` and `assignment()` are empty. Guarding that call covers every route into the
+  state, not just the startup one the issue currently describes.
+- The other route is already guarded, from the other end. `updateSubscription()` at
+  [`DynamicKafkaConsumer.scala:176-181`](../../src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala)
+  refuses to shrink the subscription to nothing, a guard #165 added when idle release made emptying
+  the set routine. That protects a subscription that *shrank* to nothing; it cannot protect one that
+  was never established, because there is nothing to keep. The two guards are complementary and both
+  are needed — which is why the fix belongs at the poll rather than as a second guard in
+  `updateSubscription`.
+- Discarding the `await` result is what makes the failure unattributable. The issue asks for it to be
+  honoured. It does not need to change control flow — the poll guard already handles both outcomes —
+  but logging "initialization wait expired with no reply topic requested" at debug turns a silent
+  90-second gap into something a reader can find.
+
+**Alternatives considered**:
+
+- *Do not start the poll loop until the first `requestTopicSubscription` lands.* Rejected: it turns
+  the bounded `initLatch.await` into an unbounded one, and the loop's `finally` is what closes the
+  consumer, so a consumer that never enters the loop needs a second close path. `close()` already has
+  to work on a consumer that was never run; adding a second way to not-run it doubles the paths
+  through shutdown for no gain.
+- *Subscribe to a sentinel topic at construction so the consumer is never empty.* Rejected: it
+  creates a topic-shaped side effect on the broker (or an `UNKNOWN_TOPIC_OR_PARTITION` warning loop
+  if it does not exist) purely to dodge a client-side precondition, and it would put a topic nobody
+  asked for into the consumer group's assignment.
+- *Catch the `IllegalStateException` around the poll and continue.* Rejected: control flow by
+  exception, which Principle III forbids outright, and it would also swallow a genuine
+  `IllegalStateException` from a different cause.
+
+**When it fires, restated from the code**: the wait starts when `KafkaMessageTrackerPool` is
+constructed, and the pool is constructed by `ProtocolKey.newComponents` for any protocol whose
+`consumeSettings` carry `bootstrap.servers` — before any virtual user runs. So the clock is against
+wall time from simulation start, not against first use.
+
+---
+
+## R2 — #166: how to stop a Gatling actor, given that Gatling has no way to stop one
+
+**Decision**: Add a terminal `Stop` message to `KafkaMessageTracker` whose handler cancels the
+periodic scan and returns `die`. Store the `TrackerEntry`'s actor ref as today; the tracker keeps
+ownership of its own `Cancellable`. `sweepIdleTrackers`, the consumer-failure broadcast, and pool
+shutdown each send `Stop` to every entry they drop — *after* removing it from the map, and outside
+the `ConcurrentHashMap` compute lambda.
+
+**Findings from the Gatling 3.13.5 sources** (`io/gatling/core/actor/`), all of which shaped this:
+
+- **`ActorSystem` has no `stop`.** `actorOf` returns an `ActorRef` with exactly `!`, `name` and
+  `replyPromise`. The only termination path is `Actor.die`, an `Effect` reachable only from inside
+  the actor's own behaviour — so stopping a tracker *requires* sending it a message. There is no
+  external kill.
+- **`die` swaps the behaviour, it does not deallocate.** A dead actor logs
+  `Dropping msg '...' as actor is dead` at INFO for anything that arrives afterwards. Reachability is
+  what actually frees the tracker, and reachability is held by the scheduled task, not by the actor
+  system: `ActorSystem` keeps no registry of spawned actors.
+- **The `Cancellable` is the leak.** `Scheduler.scheduleAtFixedRate` returns
+  `() => future.cancel(true)` over a `ScheduledFuture` on the actor system's scheduler, and that
+  scheduler is a **single** `newSingleThreadScheduledExecutor` shared by the whole simulation. So
+  every leaked tracker is not just retained memory — it is one more wakeup per second on one shared
+  thread, and the task's closure captures `self`, which transitively retains the tracker's
+  `statsEngine`, `clock` and matcher closures. Cancelling is therefore both the memory fix and the
+  CPU fix.
+- **The `Cancellable` is created inside the actor**, in `triggerPeriodicTimeoutScan`, on the first
+  `MessagePublished` carrying a positive reply timeout. The pool never sees it. Having the actor
+  cancel its own on `Stop` needs no plumbing at all; having the pool own it would mean hoisting the
+  scheduling out of the actor.
+
+**Ordering constraints the fix must respect**:
+
+1. Send `Stop` only after the entry is removed from `trackers`, so no acquisition can hand out a
+   tracker that is about to die. `sweepIdleTrackers` already re-checks the entry's state inside
+   `computeIfPresent`, and already performs its one side effect (`removeTopicSubscription`) outside
+   the lambda — follow that precedent rather than stopping inside the lambda.
+2. Release only happens at `refCount <= 0` sustained for a full idle grace, and `refCount` is
+   decremented by `onComplete` *after* the request has been reported. So a stopped tracker never has
+   outstanding work. That is what makes it safe to stop the very thing that would otherwise time
+   those requests out.
+3. The consumer-failure path already clears `trackers` wholesale; it must stop what it clears, or the
+   timers outlive a pool that can no longer be used at all.
+
+**Residual, accepted**: a `MessageConsumed` broadcast reading a stale snapshot can reach a just-dead
+tracker and log one INFO line. The window is the gap between the sweep's removal and the poll thread's
+iteration, and the topic is unsubscribed immediately after, so this is bounded to a sweep-versus-poll
+race rather than to ongoing third-party traffic.
+
+**Alternatives considered**:
+
+- *Fold deadlines into the pool's existing idle sweep* (#193 point 4). Rejected **for v1.1.0**: it is
+  the better end state and #193 should keep it, but it moves timeout detection out of the tracker,
+  changes what `acquireTracker` must hand back, and turns a contained bug fix into the v1.2.0
+  redesign. Principle III's "no abstraction without a second real caller" applies — there is one
+  caller today.
+- *Cancel without stopping.* Rejected: it fixes reachability and the shared-thread cost, but leaves a
+  live actor that would still process a stale `MessageConsumed` against bookkeeping the pool has
+  abandoned. `Stop` costs one case in the behaviour.
+- *Stop without cancelling.* Rejected: `die` swaps the behaviour but the scheduled task keeps firing
+  and keeps `self` reachable, so the leak survives almost intact.
+
+---
+
+## R3 — #191: why register-before-send is sufficient, and a concurrent correlation table is not needed
+
+**Decision**: Move tracker acquisition and pending-request registration ahead of
+`sender.send(...)` in `KafkaRequestReplyAction.sendKafkaMessage`. Leave `sentMessages` as the actor's
+private `mutable.HashMap`.
+
+**The finding that makes this work**: Gatling's mailbox preserves enqueue order across producer
+threads. `AtomicRunnableActorRef` backs its mailbox with
+`PlatformDependent.newMpscQueue[Message]()` — a JCTools multi-producer/single-consumer queue. Producers
+claim slots by atomic increment and the single consumer drains in slot order, stopping at any slot
+whose element is not yet published rather than skipping ahead. `!` is `mbox.offer(msg)` followed by
+`async()`, so the message is in the queue before `!` returns. The 20-message drain limit re-schedules
+rather than reorders.
+
+So enqueue order *is* processing order. What is missing today is not ordering — it is that the
+enqueue happens too late:
+
+```text
+today:   sender.send ──► broker ──► responder ──► broker ──► poll ──► offer(MessageConsumed)
+                └─► ack ──► acquireTracker ──► offer(MessagePublished)          ← may lose the race
+```
+
+The two offers come from unrelated threads with no happens-before between them, and the ack callback
+can be delayed by exactly the producer-I/O-thread pressure the load creates. That is precisely what
+#191's log correlation shows: `Record received` and `Received with MatchId` are logged before
+`Published with MatchId` for the same key.
+
+Registering first replaces the race with a causal chain:
+
+```text
+after:   offer(MessagePublished) ──► sender.send ──► broker ──► responder ──► broker ──► poll
+                                                                          └─► offer(MessageConsumed)
+```
+
+`offer(MessagePublished)` completes (program order) before `send` is called, and every step to the
+reply is causally downstream of that send. A reply cannot exist before the request is sent, so
+`MessageConsumed` can never be offered before `MessagePublished`. FR-001's "defined order" is
+satisfied structurally, not statistically.
+
+**What this buys**: #193's point 3 — a pool-owned correlation table keyed by correlation id, written
+by the sending side and read by the consumer thread — is **not required** to close #191. It remains
+valuable for point 4 (folding deadlines into the pool sweep), which is a v1.2.0 concern. Recording
+this explicitly because #193's map still lists point 3 as part of #191's fix, and it is not.
+
+**Second-order consequences, all checked**:
+
+- **Acquisition moves off the producer I/O thread onto the virtual user's thread.** This does not
+  undo #163: acquisition has been non-blocking since PR #190, so the VU thread is not blocked either.
+  The slow path's continuation now performs the `send` on the pool's setup executor rather than on the
+  VU thread. `KafkaProducer.send` can block up to `max.block.ms` on metadata or a full buffer; on the
+  single-threaded setup executor that would stall other acquisitions. Bounded in practice because the
+  slow path runs once per reply topic, but it is a real risk and belongs in the PR description.
+- **The refcount is now held across the send.** Acquisition increments it before the record is
+  handed over, so a send failure must remove the pending record and release the refcount, or the
+  channel never goes idle. This is the leak PR #144 anticipated ("release the already-acquired
+  tracker to avoid a ref-count leak") and it is handled by a `SendFailed` message rather than by the
+  action reaching into the tracker.
+- **A failed acquisition no longer publishes the request.** Deliberate, and the one item in the
+  plan's Complexity Tracking table.
+- **`KafkaRequestAction` (produce-only) is untouched** — it never acquires a tracker.
+- **Throttling is untouched** — `KafkaAction.sendRequest` still wraps the whole of
+  `sendKafkaMessage`, whatever order it does things in.
+
+**Historical note**: PR #144 (open, unmilestoned) already proposed "move tracker acquisition before
+send". It was written against the blocking `tracker()` API and aimed at #143; #163/PR #190 solved the
+blocking problem differently, by making acquisition asynchronous. The ordering idea in #144 turns out
+to be the right shape for #191 rather than for #143, now that it no longer implies blocking the
+virtual user. Worth saying so on #144 when this lands.
+
+---
+
+## R4 — #191: keeping the ack-based response-time clock
+
+**Decision**: Two-phase completion inside the tracker. `MessagePublished` (enqueued before the send)
+creates the pending record. A new `MessageAcked(matchId, sentTimestamp)` (enqueued from the producer
+ack callback) supplies the timestamp the report is measured from. `MessageConsumed` completes the
+request if the ack has landed, and otherwise holds the reply on the record until it does.
+
+**Why it is needed**: FR-017 keeps the reported clock starting at the producer ack, and after R3 the
+ack timestamp is not known at registration. Both events can therefore arrive in either order — and the
+order that used to lose the reply (reply before ack) is exactly the one this feature exists to fix, so
+it cannot be treated as too rare to handle.
+
+**Why not simply move the clock**: registering before the send makes "when the record was handed to
+the producer" the natural start, which is also what #170 asks for and what Gatling's HTTP support
+measures. #193 records both as one decision: they move reported percentiles for the same reason and
+must ship together with a Migration Guide entry. Making that change here would smuggle a
+percentile-moving change into a bug fix — precisely what Principle I forbids.
+
+**Timeout clock**: `TimeoutScan` measures from the record's registration time, not from the ack. A
+request whose ack never arrives is stuck and must still time out; measuring from the ack would leave
+it pending forever.
+
+**Alternatives considered**:
+
+- *Complete immediately using the registration timestamp when the ack has not landed.* Rejected: the
+  requests it affects — the ones whose reply beat the ack — would be reported with a latency that
+  includes the produce round trip while every other request excludes it. An invisible inconsistency in
+  a measurement tool is worse than one extra message type, and it lands on exactly the population
+  under study.
+- *Write the ack timestamp into the record from the producer thread via an `AtomicLong`.* Rejected:
+  it makes the record concurrent state again for no benefit — the completion still has to run on the
+  actor to execute checks and log stats, so a message is needed regardless. Keeping the record
+  single-threaded is what makes the join trivially correct.
+
+---
+
+## R5 — #191: the surface this touches, and what is deliberately left alone
+
+**`MessagePublished` keeps its exact field list.** `(matchId, sentTimestamp, replyTimeout, checks,
+session, next, requestName, onComplete)` is unchanged; at registration `sentTimestamp` carries the
+handoff time and `MessageAcked` supersedes it for reporting. The pending record gains its extra state
+inside the actor's private map value, not on the public message.
+
+**Two additive cases on `sealed trait TrackerMessage`**: `MessageAcked` and `SendFailed`. The trait is
+sealed, so no external code extends it, and an external exhaustive match on it is not meaningful.
+
+**Untouched**: `KafkaMessageTrackerPool.acquireTracker` and `releaseTracker` signatures; both primary
+constructors; `KafkaProtocolMessage`; `KafkaMatcher`; every DSL and `javaapi` entry point.
+
+**A test workaround comes out.** `TrackerLifetimeSpec.send` currently re-publishes the reply in a
+loop, with a comment naming #191 as the reason: "a reply which arrives before its own request finishes
+registering is dropped silently (issue #191, out of scope here)". Once #191 lands, that loop is no
+longer covering for a defect and should be simplified — leaving it would hide a regression, since a
+re-published reply masks a dropped one.
+
+---
+
+## R6 — #196: responder shape, topic layout, and the assertion
+
+**Decision**: Follow `KafkaConcurrencyLoadTest`'s shape exactly — a plain `KafkaSender` driven from a
+`DynamicKafkaConsumer`, started in `before`, closed in `after`, with a readiness probe before the
+simulation begins. One responder consuming both request topics, mapping `myTopic1 → test.t1` and
+`myTopic2 → test.t2`.
+
+**Constraints read out of `KafkaGatlingTest`**:
+
+| Scenario | Protocol | Matcher | Check | What the echo must not break |
+|---|---|---|---|---|
+| `scnRR` | `kafkaProtocolRRString`, 60 s | key (default) | `jsonPath("$.m").is("dkf")` | key and the JSON body |
+| `scnRR2` | `kafkaProtocolRRBytes`, 5 s | `matchByValue` | `bodyBytes.is("tstBytes")` | the value byte-for-byte |
+| `scnRRwo` | `kafkaProtocolRRBytes2`, 1 s | `matchByValue` | none | must receive nothing at all |
+
+A byte-level echo satisfies all three: the responder consumes and produces `Array[Byte]`, so a
+`String`-serialised request round-trips unchanged. Any rewrite of key or value breaks one of the three
+columns above, which is why the response timestamp goes in a header.
+
+**Response timestamp**: `KafkaProtocolMessage` already carries `headers: Option[Headers]`, and
+`KafkaGatlingTest` already imports `Headers`/`RecordHeaders`. So the responder attaches a
+`RecordHeaders` carrying the response time and nothing else changes.
+
+**Topic for `scnRRwo`**: give it a new request topic — `myTopic4` — that the responder does not
+consume. Its reply topic stays `test.t2`, per #196's text, which asks only for a dedicated request
+topic. That keeps a useful side effect: `scnRR2`'s echoes land on `test.t2` while `scnRRwo` also holds
+a registration there under a *different* matcher instance, so the simulation exercises the
+"two registrations on one reply topic, one discards" edge case from the spec for free.
+
+**Assertion**: `global.failedRequests.count.is(1)` plus
+`details("Request Reply Bytes wo").failedRequests.count.is(1)`. Today's `lte(1)` passes when the
+by-design timeout silently stops failing; pinning both directions is what makes the gate meaningful.
+
+**Broker definitions**: `myTopic4` goes into `docker-compose.kafka.yml`'s init command and into
+`KAFKA_CREATE_TOPICS` in `.github/workflows/ci.yml`. Note the two lists already differ — compose
+creates `test.t`, CI does not. That divergence is #192's subject; this change adds the same topic to
+both and does not attempt to reconcile the rest.
+
+**The rebalance-delay question is to be answered by running, not by reasoning.** SC-009 requires the
+simulation be run with and without `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0` and the result stated in
+the PR. The expected answer is that it is *still* required, because #193 point 5 is unfixed —
+readiness resolves on assignment, which precedes position resolution, and the protocol leaves
+`auto.offset.reset` at `latest`, so a reply produced in that gap is still skipped. But the issue asks
+for an observation and an observation is what it should get.
+
+---
+
+## R7 — making the initialization wait testable without a signature break
+
+**Decision**: Add an overloaded `DynamicKafkaConsumer.apply` taking the initialization wait, and a
+secondary `KafkaMessageTrackerPool` constructor that passes one through. Both default to today's
+values; production code calls neither.
+
+**Why not the alternatives**:
+
+- *Mutate the companion's `private val initializationTimeout`.* It is object-level state shared by
+  every consumer in the JVM, so one test's value would leak into another's. The pool's
+  `idleGraceMillis` precedent is not comparable — that is a per-instance field.
+- *Make it a per-instance `private[client] var` on the consumer.* The pool constructs its consumer in
+  its own constructor, so a test holding only the pool has no moment at which to write the field
+  before it is read.
+- *Change the primary constructor.* This is the binary break spec `002` explicitly refused, for the
+  same reason: it would force a major version for a bug fix.
+
+A secondary constructor and an overload are both purely additive, so nothing compiled against the
+current release is affected.
+
+**Test reach**: the consumer-level overload covers the unit assertion (a consumer whose wait expires
+with no topic requested does not fail). The pool-level constructor covers FR-005 and FR-007 — build a
+pool, request nothing, let the wait expire, then request a topic and see it served.
+
+---
+
+## Summary of decisions
+
+| # | Question | Decision |
+|---|---|---|
+| R1 | #143 — where to guard | Guard the poll when nothing is subscribed and nothing assigned; honour and log the init-wait result |
+| R2 | #166 — how to stop an actor | Terminal `Stop` message: the tracker cancels its own `Cancellable` and returns `die`; the pool sends it after removing the entry |
+| R3 | #191 — mechanism | Register before send; mailbox MPSC ordering then gives the happens-before. No pool-owned correlation map |
+| R4 | #191 — measurement | Two-phase completion via `MessageAcked`; a reply that beats its ack is held, not misreported |
+| R5 | #191 — surface | Two additive `TrackerMessage` cases; every existing signature unchanged; `TrackerLifetimeSpec`'s re-publish workaround removed |
+| R6 | #196 — shape | `KafkaConcurrencyLoadTest`-style responder, byte-level echo, timestamp in a header, `myTopic4` for the timeout scenario, two-sided assertion |
+| R7 | #143 — testability | Additive `apply` overload and secondary pool constructor; production defaults unchanged |

--- a/specs/003-request-reply-hardening/spec.md
+++ b/specs/003-request-reply-hardening/spec.md
@@ -1,0 +1,370 @@
+# Feature Specification: Request-Reply Reliability Hardening
+
+**Feature Branch**: `003-request-reply-hardening`
+
+**Created**: 2026-08-04
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/gatling-kafka-plugin/milestone/2"
+
+Milestone **v1.1.0 Request-reply reliability** exists to make request-reply usable outside a
+single-user, start-at-t0 profile. Three of its issues have landed — non-blocking tracker acquisition
+and the coalesced no-op subscribe (#163, #164, spec `001`), and per-request reply-channel churn
+(#165, spec `002`). Four remain open, and together they are what still stands between the plugin and
+a trustworthy request-reply run:
+
+- **A reply the plugin received can be thrown away** (#191). Bookkeeping for a sent request and
+  delivery of its reply travel two independent paths with no ordering between them. When the round
+  trip is fast enough, the reply arrives first, finds no record of the request, and is discarded.
+  The request then fails on its reply timeout, indistinguishable from a system under test that never
+  answered.
+- **A run that does not start request-reply immediately loses it entirely** (#143). The shared
+  reply-receiving machinery starts a fixed initialization wait when the protocol is built, before
+  any virtual user runs. If nothing has asked for a reply topic when that wait expires, the
+  machinery tries to receive replies for nothing, fails, and refuses every reply topic for the rest
+  of the run. Any ramp, warm-up, or delayed start longer than the wait is enough.
+- **Retired reply channels keep working forever** (#166). Bookkeeping released when a channel goes
+  idle leaves its periodic timeout watch running and its state reachable for the remainder of the
+  run. Growth tracks every channel the run has *ever* used, which is precisely what releasing on
+  idleness was introduced to avoid.
+- **The gate that is supposed to catch all of this proves nothing** (#196). The CI simulation has no
+  responder: its request-reply scenarios are "answered" by sibling fire-and-forget scenarios that
+  happen to publish a matching key or value at a fixed delay. It exercises the matching code without
+  ever exercising the round trip, and it is green because of timing rather than correlation.
+
+The first three are defects a performance engineer experiences as unexplained failures, unexplained
+memory growth, or a request-reply run that never worked. The fourth is why the project cannot
+currently tell the difference.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A reported timeout always means the system under test did not answer (Priority: P1)
+
+A performance engineer runs a request-reply scenario against a service that answers every request.
+Every reply that service sent is matched to its request and reported as a success, with the round-trip
+time it actually took. When the report shows a reply timeout, it means the service did not answer
+within the configured timeout — never that the tool received the answer and dropped it.
+
+**Why this priority**: The report is the deliverable. A received-then-discarded reply is reported
+identically to a genuinely unanswered request, so the engineer cannot separate a defect in the system
+under test from a defect in the tool — the one distinction a load test exists to preserve. It is
+silent loss, not delay: nothing in the output hints that a reply was seen. It is also live today
+under ordinary conditions (a sub-few-millisecond round trip and concurrent users), and it predates
+this milestone rather than being introduced by it.
+
+**Independent Test**: Run sustained concurrent request-reply load against a responder that answers
+every request, with a round-trip time far shorter than the configured reply timeout so registration
+and reply delivery genuinely race. Every request the responder answered must be reported as a
+success.
+
+**Acceptance Scenarios**:
+
+1. **Given** a request whose reply arrives before the request has finished being recorded as
+   awaiting one, **When** the reply is received, **Then** it is matched to that request and reported
+   as a success with its true round-trip time — not discarded.
+2. **Given** sustained concurrent request-reply traffic against a responder answering every request,
+   **When** the run completes, **Then** no request is reported as a reply timeout.
+3. **Given** a request that is genuinely never answered, **When** its reply timeout elapses, **Then**
+   it is reported as a timeout exactly as it is today.
+4. **Given** a reply topic whose channel has just been established, so the gap between sending a
+   request and recording it is at its widest, **When** replies arrive during that gap, **Then** they
+   are still matched — establishing a channel does not open a loss window.
+
+---
+
+### User Story 2 - Request-reply works no matter how far into the run it starts (Priority: P1)
+
+A performance engineer's simulation ramps for several minutes, or runs a produce-only warm-up phase,
+before its first request-reply request. That request is served, and so is every request after it. The
+shared reply-receiving machinery does not fail merely because nothing needed a reply topic during the
+opening minutes of the run.
+
+**Why this priority**: The failure is total and delayed. The machinery fails around the initialization
+wait, long before any virtual user asks it for anything, and every request-reply request afterwards
+fails with an error that names nothing about the cause. Ramps, warm-ups, pacing and delayed starts are
+ordinary load-profile shapes, not corner cases — and a protocol that merely *declares* reply settings
+for scenarios that never do request-reply fails too, on machinery nobody uses.
+
+**Independent Test**: Build the reply machinery, request no reply topic, let the initialization wait
+elapse (parameterised so a test need not wait the production duration), then request a reply topic.
+It must be served normally, and the machinery must have reported no failure at any point.
+
+**Acceptance Scenarios**:
+
+1. **Given** a simulation whose first request-reply request happens well after the initialization
+   wait has elapsed, **When** that request is sent, **Then** it is served normally and matched to its
+   reply.
+2. **Given** reply machinery for which no reply topic has ever been requested, **When** the
+   initialization wait elapses, **Then** no failure is reported and every later reply-topic request
+   is still served.
+3. **Given** a protocol that declares reply settings for a simulation that performs no request-reply
+   at all, **When** the simulation runs to completion, **Then** no failure of the reply machinery is
+   reported.
+4. **Given** a reply topic requested while the initialization wait is still running, **When** it
+   arrives, **Then** behaviour is unchanged from today, including a request landing exactly as the
+   wait expires.
+
+---
+
+### User Story 3 - A long run holds only the reply channels it is still using (Priority: P2)
+
+A performance engineer runs a long simulation whose reply topics or matching rules vary over time —
+a reply topic derived per virtual user, or several matching rules across scenarios. Background
+activity and retained state track the reply channels in use at that moment, not every channel the run
+has ever opened.
+
+**Why this priority**: Growth is proportional to the **total** number of reply channels created over
+the run rather than the number concurrently active, so topic or matcher churn accumulates without
+bound until the simulation ends. Each retired channel keeps a once-per-second timeout watch firing and
+keeps its reporting, timing and matching state reachable. This directly undermines idle release, whose
+entire purpose is to free resources when a topic goes quiet — the channel is let go while everything
+hanging off it is kept.
+
+**Independent Test**: Run a scenario that creates and retires many reply channels in sequence, with
+reply timeouts configured so each one arms a timeout watch. After the idle grace has elapsed for all of
+them, verify that background timeout activity and retained per-channel state correspond to the channels
+currently held, not to the number created.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reply channel released after going idle, **When** the release completes, **Then** its
+   periodic timeout watch stops firing and its per-channel state is no longer retained.
+2. **Given** a scenario that uses many distinct reply topics one after another, **When** the run
+   proceeds, **Then** background timeout activity is bounded by the channels concurrently held rather
+   than growing with the number of channels created.
+3. **Given** requests still in flight on a channel, **When** other requests on that channel complete,
+   **Then** the channel is not released, its timeout watch keeps running, and outstanding requests are
+   still timed out and reported correctly.
+4. **Given** a simulation ending with channels still held, **When** it shuts down, **Then** every
+   channel and everything scoped to it is released, as today.
+
+---
+
+### User Story 4 - The CI simulation proves a real round trip (Priority: P3)
+
+The project's request-reply gate answers each request with a responder that received it, so a green
+run means the plugin correlated a reply with the request that caused it. The one scenario designed to
+time out does so on a topic the responder does not serve, and the assertion names that request rather
+than tolerating any single failure.
+
+**Why this priority**: No user-facing behaviour changes here, so it ranks below the three defects. But
+it is what makes the other three verifiable: today a request-reply scenario passes because a sibling
+produce-only scenario publishes a matching key or value at a fixed delay, so the gate demonstrates
+matching without ever demonstrating a round trip, and it cannot be tightened past "at most one failure"
+because it cannot distinguish the expected failure from a new one.
+
+**Independent Test**: Delete the sibling produce-only scenarios from the simulation and run it. Every
+request-reply scenario must still pass — proof that its replies came from the responder rather than
+from coincidence.
+
+**Acceptance Scenarios**:
+
+1. **Given** the request-reply scenarios in the CI simulation, **When** the simulation runs, **Then**
+   each reply is produced by a responder answering the request it received, and no scenario depends on
+   another scenario's publish for its reply.
+2. **Given** scenarios that match by key and by value respectively, **When** replies come back, **Then**
+   key and value are preserved end to end and the existing payload checks pass unchanged.
+3. **Given** a responder reply, **When** the simulation inspects it, **Then** a response timestamp is
+   available through a message header, leaving key and value untouched.
+4. **Given** the scenario that is designed to receive no answer, **When** it runs on a request topic the
+   responder does not serve, **Then** it times out, and the assertion fails the run both if that request
+   succeeds and if any other request fails.
+5. **Given** the topics the simulation uses, **When** it runs on the local stack and in CI, **Then** both
+   topic lists contain all of them and the simulation is green in both.
+6. **Given** a responder that answers only after receiving a request, **When** the simulation is run
+   without the broker's zero rebalance-delay setting, **Then** whether that setting is still required is
+   established by observation and recorded either way.
+
+---
+
+### Edge Cases
+
+- **A reply for a request that already finished** — matched earlier, already timed out, or answered
+  twice: discarded silently. Not reported as a failure, not attributed to an unrelated later request,
+  not counted twice.
+- **A reply arriving after its channel was released as idle**: discarded without producing a failure
+  and without reviving the channel.
+- **Two reply-tracking registrations on the same reply topic with different matching rules**: a reply
+  is offered to both; only the one holding a matching pending request claims it and the other discards
+  it silently. Neither registration's lifecycle affects the other's.
+- **Two in-flight requests sharing one match key**: existing behaviour is preserved — the tracking key
+  is derived from the match identifier, so requests that produce the same identifier are not
+  distinguishable from one another and a reply resolves one of them. Making them distinguishable is not
+  part of this feature.
+- **Reply machinery fails while requests are pending**: each pending request is reported as failed with
+  the underlying cause, and every background timeout watch stops rather than continuing to scan
+  bookkeeping that has been abandoned.
+- **Initialization wait expires, then the simulation ends without ever requesting a reply topic**:
+  shutdown completes cleanly and no failure is reported for machinery that was never used.
+- **A reply topic requested exactly as the initialization wait expires**: served, not lost to the race
+  between the two.
+- **A channel released as idle and later re-established for the same topic**: the new channel gets its
+  own timeout watch and bookkeeping; nothing from the previous one is still running or still retained.
+- **The last reply channel is released**: the receiving machinery must not be left with nothing to
+  receive on, or its next attempt fails and takes the whole run's request-reply capability with it —
+  the same failure mode as the initialization-wait path, reached from the other end.
+- **A request in flight when the idle grace expires for its channel**: the channel is not released;
+  release waits until nothing is in flight for a full grace period.
+- **The CI responder cannot answer a request** (its send fails): the failure is visible in the run's
+  output, because a responder that silently stops echoing is indistinguishable from the plugin losing
+  replies.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Reply delivery (#191)**
+
+- **FR-001**: A reply that arrives before the request it answers has finished being recorded as
+  awaiting one MUST still be matched to that request and reported with its true round-trip time.
+  Recording a sent request and delivering its reply MUST have a defined order relative to one another;
+  a reply MUST NOT become discardable because bookkeeping performed on a different path has not yet
+  been applied.
+- **FR-002**: A reply that matches no pending request MUST continue to be discarded silently — not
+  reported as a failure and not matched to an unrelated request. FR-001 MUST NOT be satisfied by
+  retaining unmatched replies indefinitely in the hope that a request appears for them.
+- **FR-003**: A reported reply timeout MUST mean that no reply for that request was received within
+  its timeout. It MUST NOT be produced by the plugin discarding a reply it did receive.
+- **FR-004**: FR-001 MUST hold on every path by which a request is recorded, including the first
+  request on a newly established reply channel, where the gap between sending and recording is widest.
+
+**Availability of the reply machinery (#143)**
+
+- **FR-005**: The shared reply-receiving machinery MUST NOT fail because no reply topic was requested
+  within its initialization wait, and MUST remain able to serve a reply topic requested at any later
+  point in the run.
+- **FR-006**: The machinery MUST distinguish "a reply topic was requested" from "the initialization
+  wait expired with none requested", and MUST NOT attempt to receive replies while it has nothing to
+  receive them for.
+- **FR-007**: A protocol that declares reply settings for scenarios that never perform request-reply
+  MUST run to completion without reporting a failure of the reply machinery.
+- **FR-008**: The initialization wait MUST be configurable for testing, so a regression test can drive
+  its expiry without waiting the production duration.
+
+**Lifetime of per-channel work (#166)**
+
+- **FR-009**: Releasing a reply channel MUST release everything scoped to it: its periodic timeout
+  watch MUST stop firing, and its per-channel bookkeeping MUST stop being retained.
+- **FR-010**: Background timeout activity and retained per-channel state MUST be bounded by the number
+  of reply channels currently held, not by the total number created over the run.
+- **FR-011**: A channel MUST NOT be released while requests are in flight on it, and releasing one
+  channel MUST NOT disturb requests in flight on any other. Requests outstanding on a held channel MUST
+  continue to be timed out and reported as they are today.
+
+**Verification of the round trip (#196)**
+
+- **FR-012**: Every request-reply scenario in the CI simulation MUST be answered by a responder
+  replying to the request it received. No scenario's replies may be supplied by another scenario's
+  publish.
+- **FR-013**: The responder MUST preserve the request's key and value end to end, so key-based
+  matching, value-based matching, and the existing payload checks all pass unchanged. Round-trip
+  metadata — specifically a response timestamp — MUST be carried in a message header rather than in the
+  key or value.
+- **FR-014**: The scenario designed to receive no answer MUST use a request topic the responder does
+  not serve, and the simulation's assertion MUST pin the expected failure to that request, failing the
+  run both when that request unexpectedly succeeds and when any other request fails.
+- **FR-015**: Every topic the simulation uses MUST be present in both the local stack's topic list and
+  CI's, and the simulation MUST be green against both.
+
+**Compatibility (all four)**
+
+- **FR-016**: The published Scala and Java DSLs, protocol configuration options, defaults, and
+  observable result semantics MUST remain unchanged. No new user-facing configuration option is
+  introduced by this feature.
+- **FR-017**: Reported response-time semantics MUST remain unchanged: a successful request-reply
+  measures from message sent to reply received; a failed one spans request start to failure detection.
+
+### Key Entities
+
+- **Reply channel**: the plugin's ability to receive replies for one reply topic. Established on first
+  use, held while in use and for an idle grace period after, released when that grace elapses or when
+  the simulation ends.
+- **Reply-tracking registration**: the per-(reply topic, matching rule) bookkeeping that correlates a
+  sent request with its reply. Shares the reply channel's lifetime. Owns the pending-request records
+  and the background timeout watch below — the subject of #166 is that today it does not let go of
+  either when it is itself let go.
+- **Pending-request record**: the record that one request has been sent and is awaiting a reply,
+  carrying its match identifier, send time, reply timeout, checks and continuation. Written when the
+  request is sent, read and removed when its reply arrives or its timeout elapses. The subject of #191
+  is that a reply can be looked up before this record exists.
+- **Background timeout watch**: the periodic activity, one per reply-tracking registration, that finds
+  pending-request records past their reply timeout and reports them as failures.
+- **Shared reply-receiving machinery**: the single receiving path serving every reply channel of a
+  protocol. Started when the protocol is built, before any virtual user runs. Its failure ends
+  request-reply for the whole run — the subject of #143.
+- **Echo responder** (verification only): a stand-in for the system under test that replies to the
+  request it received, preserving key and value. Belongs to the test simulations, not to the published
+  plugin.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Under sustained concurrent request-reply load against a responder answering every request
+  — at least 5,000 requests, with a round-trip time far below the configured reply timeout — zero
+  requests are reported as reply timeouts. *Baseline*: 0–2 lost replies per ~6,760 requests across five
+  runs on current code, and 14–17 per ~6,500 before idle release removed the amplifier that made each
+  re-registration re-arm the next loss.
+- **SC-002**: A regression test that reliably forces a reply to arrive before its request is recorded
+  fails against the pre-change behaviour and passes after it — rather than depending on incidental
+  timing to reproduce.
+- **SC-003**: A simulation whose first request-reply request occurs after the initialization wait has
+  elapsed completes with 100% of its request-reply requests served. *Today*: every one of them fails.
+- **SC-004**: A simulation whose protocol declares reply settings but performs no request-reply
+  completes with no failure of the reply machinery reported anywhere in its output.
+- **SC-005**: In a run that creates and retires at least 20 reply channels in sequence, background
+  timeout activity once all of them are idle past their grace corresponds to the channels still held —
+  zero held, zero activity — rather than to the 20 created.
+- **SC-006**: No per-channel bookkeeping for a channel released more than one idle grace period ago is
+  still retained at any point in such a run.
+- **SC-007**: Removing every produce-only scenario from the CI simulation leaves all of its
+  request-reply scenarios passing — demonstrating that replies come from a responder rather than from a
+  sibling scenario's coincidental publish.
+- **SC-008**: The CI simulation's assertion fails the run in both directions around the one expected
+  failure: it fails if that request succeeds, and it fails if any additional request fails.
+- **SC-009**: Whether the CI simulation still requires the broker's zero rebalance-delay setting is
+  determined by running it both ways and is stated explicitly in the change that lands the responder.
+- **SC-010**: The complete existing verification suite — unit and integration tests, both CI Gatling
+  simulations, and construction of every README and example simulation — passes unchanged.
+
+## Assumptions
+
+- **Scope is the four issues still open in milestone v1.1.0**: the dropped reply (#191), the poisoned
+  reply machinery after the initialization wait (#143), the leaked per-channel timeout watch and
+  bookkeeping (#166), and the CI simulation's coincidental matching (#196). The milestone's other three
+  issues have landed under specs `001` (#163, #164) and `002` (#165) and are treated here as
+  established behaviour to preserve, not to revisit.
+- **Out of scope, and separately tracked**: consolidating the CI broker definition with the local Compose
+  stack (#192); readiness meaning "positioned" rather than merely "subscribed", optional up-front
+  declaration of reply topics, and moving the reported response-time clock to when the message is handed
+  to the sending machinery (#193). The last of these would move reported percentiles and needs its own
+  migration entry.
+- **How the four fixes are structured is a planning decision, not a scope decision.** Each issue remains
+  one issue, one commit, one PR under the project's rules; this specification states the behaviour each
+  must produce and deliberately does not prescribe the mechanism. #191 in particular is left open on
+  mechanism because it touches the core registration path rather than only the pool around it.
+- **#191's fix must not be bought with unbounded retention.** Holding every unmatched reply until a
+  request appears for it would trade a dropped reply for unbounded memory growth and for replies being
+  matched to requests they do not answer. FR-002 stands as a constraint on FR-001's solution.
+- **The duration of the initialization wait is not in scope.** #143 concerns what happens when the wait
+  expires with nothing requested, not how long it lasts. Its production value is unchanged; only its
+  configurability for tests is required (FR-008).
+- **Idle release (#165) is in place and preserved.** #166's fix attaches to the same release point:
+  idle release already bounds the number of channels; this feature makes what hangs off a channel share
+  its fate. The two together are what issue #78 requires of a per-user reply topic.
+- **The reply machinery must never be left with nothing to receive on.** The last subscription is kept
+  deliberately, for the same reason #143 exists: a receiver with nothing to receive on fails and takes
+  the run's request-reply capability with it. This feature must not reintroduce that state from either
+  the startup end or the release end.
+- **The echo responder is verification-only** and follows the shape the existing concurrency load
+  simulation already uses. It does not become part of the published plugin and adds no dependency to it.
+- **#196 and #192 touch the same files.** Both change the CI broker definition and the topic list it
+  shares with the local Compose stack, so they are sequenced rather than developed in parallel. Either
+  order works provided both topic lists stay identical.
+- **Everything is validated against a real broker** — Testcontainers for the integration tests, the
+  Compose stack for the Gatling simulations. Reply correlation, consumer lifetime and timeout handling
+  are exactly the behaviours a stub reproduces incorrectly.
+- **Each fix ships with a test that fails before it and passes after it**, per the project's
+  test-first rule for behaviour change. For #191 and #143 that test must force the condition
+  deterministically rather than waiting for it to occur by chance.

--- a/specs/003-request-reply-hardening/tasks.md
+++ b/specs/003-request-reply-hardening/tasks.md
@@ -1,0 +1,292 @@
+---
+
+description: "Task list for Request-Reply Reliability Hardening"
+---
+
+# Tasks: Request-Reply Reliability Hardening
+
+**Input**: Design documents from `/specs/003-request-reply-hardening/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/internal-api.md](contracts/internal-api.md)
+
+**Tests**: Per Constitution Principle IV, test tasks are MANDATORY here — all four issues are bug
+fixes, so each ships a test that reproduces the defect against pre-change code. Per Principle II,
+every Kafka behaviour claim is asserted against Testcontainers or the `docker-compose.kafka.yml`
+stack, never a mock.
+
+**Organization**: Tasks are grouped by user story. Story labels map to [spec.md](spec.md):
+
+| Story | Priority | Issue | Phase |
+|---|---|---|---|
+| **US1** | P1 | #191 — a reported timeout always means the SUT did not answer | Phase 6 |
+| **US2** | P1 | #143 — request-reply works no matter how far into the run it starts | Phase 3 |
+| **US3** | P2 | #166 — a long run holds only the channels it is still using | Phase 5 |
+| **US4** | P3 | #196 — the CI simulation proves a real round trip | Phase 4 |
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+- Exact file paths are included in every description
+
+## Path Conventions
+
+Single-module Scala/sbt project (`gatling-kafka-plugin`):
+
+- **Plugin sources**: `src/main/scala/org/galaxio/gatling/kafka/{protocol,actions,client,checks,request}/`
+- **Tests**: `src/test/scala/org/galaxio/gatling/kafka/{client,integration,examples}/`
+- **Broker definitions**: `docker-compose.kafka.yml`, `.github/workflows/ci.yml`
+
+## ⚠️ Phase order is NOT priority order — this is deliberate
+
+Phases run in the plan's implementation sequence — **US2 → US4 → US3 → US1** — not in P1→P3 order.
+Issue #193's own sequencing note asks for #196 (US4) before #191 (US1) so the hardest fix has a
+deterministic CI oracle rather than a coincidence to verify against. #143 (US2) leads because it is
+fully self-contained and removes a terminal, run-ending failure.
+
+The four stories are genuinely independent: **any one of them can be implemented and shipped alone.**
+US1 remains the highest-value single slice (see Implementation Strategy).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish a known-green starting point. Nothing is created — this is an established repo.
+
+- [ ] T001 Enable the shared git hooks by running `bash scripts/install-hooks.sh` (once per clone; see `.githooks/pre-commit`)
+- [ ] T002 Bring up the broker stack with `docker compose -f docker-compose.kafka.yml up -d` and confirm topics `myTopic1, test.t1, myTopic2, test.t2, myTopic3, test.t3, test.t` exist
+- [ ] T003 Confirm the baseline is green: `sbt scalafmtCheckAll scalafmtSbtCheck compile test`, so every later red is attributable to the change under test
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Anchor the measured baselines that US1 and US3 prove movement against.
+
+**There are no blocking code prerequisites.** The four fixes touch disjoint concerns and none needs
+scaffolding from another. This phase exists only to pin the numbers.
+
+- [ ] T004 Reproduce the documented reply-loss baseline with one run of `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaConcurrencyLoadTest.scala` (`sbt "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaConcurrencyLoadTest"`) and record the KO count; its `KnownReplyLossBudget` comment documents 0–2 KO of ~6,760, and T043 tightens it to 0
+
+**Checkpoint**: Baseline pinned — all four stories may start, in any order or in parallel.
+
+---
+
+## Phase 3: User Story 2 - Request-reply works no matter how far into the run it starts (Priority: P1) — issue #143
+
+**Goal**: A simulation whose first request-reply request happens minutes into the run is served
+normally. The shared reply-receiving machinery never fails because nothing needed it yet.
+
+**Independent Test**: Build a pool with a shortened initialization wait, request no reply topic, let
+the wait expire, then request one — it must be served, with no consumer failure logged at any point.
+
+### Tests for User Story 2 (MANDATORY — Principle IV) ⚠️
+
+> Write these first and confirm they FAIL against pre-change code.
+
+- [ ] T005 [P] [US2] Add a test to `src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala` asserting a consumer whose initialization wait expires with no topic requested neither throws nor invokes `onFailure` (contract C1, C3; red: `IllegalStateException: Consumer is not subscribed to any topics or assigned any partitions`)
+- [ ] T006 [P] [US2] Create `src/test/scala/org/galaxio/gatling/kafka/integration/ConsumerStartupSpec.scala` — Testcontainers spec that builds a `KafkaMessageTrackerPool` with a short initialization wait, requests no topic, lets the wait expire, then acquires a tracker for a real topic and drives one request-reply through (contracts C2, P1, P2; SC-003)
+- [ ] T007 [P] [US2] Add a test to `src/test/scala/org/galaxio/gatling/kafka/integration/ConsumerStartupSpec.scala` asserting a pool built but never used logs no consumer failure through to shutdown (contract P2; SC-004)
+
+### Implementation for User Story 2
+
+- [ ] T008 [P] [US2] Add an overloaded `apply` taking `initializationTimeout: FiniteDuration` to the `DynamicKafkaConsumer` companion in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala`, keeping the existing `apply` delegating with the 90 s default (research R7 — additive, no signature break)
+- [ ] T009 [US2] Add a secondary constructor taking `initializationTimeout` to `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala`, passing it to the consumer; the primary constructor stays byte-identical (research R7)
+- [ ] T010 [US2] In `DynamicKafkaConsumer.run()` (`src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala`), capture the boolean `initLatch.await(...)` returns and log at debug that the wait expired with no reply topic requested (contract C4)
+- [ ] T011 [US2] Guard the poll in `run()` in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala`: skip `consumer.poll(...)` whenever `consumer.subscription()` and `consumer.assignment()` are both empty, sleeping the poll interval instead, and still call `updateSubscription()` on that turn so a later topic is picked up (contracts C1, C2 — research R1)
+- [ ] T012 [US2] Confirm the 002-era "never unsubscribe down to nothing" guard at `DynamicKafkaConsumer.scala:176-181` is untouched and `src/test/scala/org/galaxio/gatling/kafka/integration/KafkaIntegrationSpec.scala`'s unsubscribe test passes unchanged (contract C5)
+- [ ] T013 [US2] Run `sbt scalafmtAll scalafmtSbt` then `sbt scalafmtCheckAll scalafmtSbtCheck compile test`; commit as `fix(client): do not poll a consumer with nothing to receive on (#143)` with the `v1.1.0 Request-reply reliability` milestone and `Closes #143`
+
+**Checkpoint**: US2 complete and independently verifiable.
+
+---
+
+## Phase 4: User Story 4 - The CI simulation proves a real round trip (Priority: P3) — issue #196
+
+**Goal**: Every request-reply scenario in the CI gate is answered by a responder that received its
+request, and the one scenario designed to time out does so on a topic nobody serves.
+
+**Independent Test**: Delete every produce-only scenario from `setUp` and run the simulation — all
+request-reply scenarios must still pass (SC-007).
+
+### Tests for User Story 4 (the simulation *is* the test) ⚠️
+
+- [ ] T014 [P] [US4] Add `myTopic4` to the topic-creation command in `docker-compose.kafka.yml` (contract G6)
+- [ ] T015 [P] [US4] Add `myTopic4` to `KAFKA_CREATE_TOPICS` in `.github/workflows/ci.yml`, leaving the pre-existing `test.t` divergence between the two lists alone — that is issue #192's subject (contract G6)
+
+### Implementation for User Story 4
+
+- [ ] T016 [US4] Add an echo responder to `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala` in `KafkaConcurrencyLoadTest`'s shape — a `KafkaSender` driven from a `DynamicKafkaConsumer`, started in `before` behind a readiness probe, closed in `after` and on a `before` failure — consuming `myTopic1` and `myTopic2` and replying on `test.t1` and `test.t2` respectively (contract G1; data-model §4)
+- [ ] T017 [US4] Make the echo preserve key and value byte-for-byte in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`, so `scnRR`'s `jsonPath("$.m").is("dkf")` and `scnRR2`'s `matchByValue` + `bodyBytes.is("tstBytes")` all pass unchanged (contract G2)
+- [ ] T018 [US4] Attach a response-timestamp header to the reply in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala` using `KafkaProtocolMessage`'s existing `headers: Option[Headers]` field and a `RecordHeaders` — never the key or value (contract G3)
+- [ ] T019 [US4] Point `scnRRwo`'s `requestTopic` at `myTopic4` in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`, leaving its reply topic `test.t2`, so the responder never answers it (contract G4)
+- [ ] T020 [US4] Replace the assertion in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala` with `global.failedRequests.count.is(1)` plus `details("Request Reply Bytes wo").failedRequests.count.is(1)`, and update the explanatory comment (contract G5; SC-008)
+- [ ] T021 [US4] Log responder send failures loudly in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala` — a silently-stopped responder is indistinguishable from the plugin losing replies (contract R4)
+- [ ] T022 [US4] Verify SC-007 by hand: comment out `scn`, `scn2`, `scnAvro4s` and `scnwokey` from `setUp` in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`, run the simulation, confirm the request-reply scenarios still pass, then restore `setUp` — do not commit the variant
+- [ ] T023 [US4] Answer SC-009 by observation: run `KafkaGatlingTest` with and without `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0` in `docker-compose.kafka.yml`, and record the outcome in the PR description either way (research R6 expects it to still be required, because #193 point 5 is unfixed — but the issue asks for a measurement, not a prediction)
+- [ ] T024 [US4] Run `sbt scalafmtAll scalafmtSbt`, the default gate, and `sbt "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest"`; commit as `test(examples): answer request-reply with a real echo responder (#196)` with the milestone and `Closes #196`
+
+**Checkpoint**: US4 complete. The CI gate now has a real oracle for US1.
+
+---
+
+## Phase 5: User Story 3 - A long run holds only the channels it is still using (Priority: P2) — issue #166
+
+**Goal**: Releasing a reply channel releases everything scoped to it — the periodic timeout scan
+stops and the tracker is no longer retained.
+
+**Independent Test**: Create and retire at least 20 reply channels in sequence; once all are idle past
+their grace, live scan tasks must equal the channels currently held (zero), not the 20 created.
+
+### Tests for User Story 3 (MANDATORY — Principle IV) ⚠️
+
+- [ ] T025 [P] [US3] Add tests to `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala`: `Stop` cancels the periodic scan and the actor drops later messages (contract T7), and `Stop` is safe on a tracker that never armed a scan because every request had `replyTimeout <= 0` (contract T8)
+- [ ] T026 [P] [US3] Add a test to `src/test/scala/org/galaxio/gatling/kafka/integration/TrackerLifetimeSpec.scala` asserting that after a channel is released as idle, no further `TimeoutScan` activity occurs for that topic and the entry is gone (contracts P3, E4; red: the scan keeps firing once per second for the rest of the run)
+- [ ] T027 [P] [US3] Add a test to `src/test/scala/org/galaxio/gatling/kafka/integration/TrackerLifetimeSpec.scala` driving at least 20 sequential reply topics through acquire → release → idle grace, asserting live scan tasks track channels currently held rather than channels ever created (contract P5; SC-005, SC-006)
+
+### Implementation for User Story 3
+
+- [ ] T028 [US3] Add `case object Stop` to the sealed `TrackerMessage` trait in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` (additive — the trait is sealed, so nothing external extends or exhaustively matches it)
+- [ ] T029 [US3] Retain the `Cancellable` returned by `scheduler.scheduleAtFixedRate` in `triggerPeriodicTimeoutScan` in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` instead of discarding it, and have the `Stop` handler cancel it and return `die` (contracts T7, T8 — research R2: Gatling's `ActorSystem` has no `stop`, so a message is the only way)
+- [ ] T030 [US3] Send `Stop` from `sweepIdleTrackers` in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala` after the entry is removed and outside the `computeIfPresent` lambda, following the precedent the existing `doUnsubscribe` handling already sets (contracts P3, P4, E1)
+- [ ] T031 [US3] Send `Stop` to every entry the consumer-failure broadcast clears in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala`, so timers do not outlive a pool that can no longer be used (contracts P3, E3)
+- [ ] T032 [US3] Send `Stop` to any entry still held at pool shutdown in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala`'s `registerOnTermination` block (contracts P3, E3)
+- [ ] T033 [US3] Run `sbt scalafmtAll scalafmtSbt` then the default gate plus `TrackerLifetimeSpec`; commit as `fix(client): stop the tracker and its timeout scan on release (#166)` with the milestone and `Closes #166`
+
+**Checkpoint**: US3 complete. The tracker lifecycle is correct before US1 builds on it.
+
+---
+
+## Phase 6: User Story 1 - A reported timeout always means the SUT did not answer (Priority: P1) 🎯 — issue #191
+
+**Goal**: Every reply the plugin receives is matched to its request. A reported reply timeout means
+the system under test did not answer — never that the tool dropped an answer it had.
+
+**Independent Test**: Sustained request-reply load against an echo responder answering far faster than
+the reply timeout — zero requests reported as reply timeouts.
+
+- [ ] T034 [US1] **BLOCKING** — obtain maintainer approval for the behaviour change recorded in the Complexity Tracking table of `specs/003-request-reply-hardening/plan.md`: after this change a failed tracker acquisition reports the same KO **without publishing the request**. Principle I requires this be proposed and approved, not arrive as a side effect
+
+### Tests for User Story 1 (MANDATORY — Principle IV) ⚠️
+
+- [ ] T035 [P] [US1] Add a test to `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala` sending `MessagePublished` → `MessageConsumed` → `MessageAcked` in that order, asserting the reply is held and then completed, and that the logged response starts at the **ack** timestamp (contracts T1, T2; red: `sentMessages.remove` returns `None` and the reply is discarded)
+- [ ] T036 [P] [US1] Add a test to `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala` asserting `TimeoutScan` measures from registration, so a record whose `MessageAcked` never arrives still times out at `replyTimeout` (contract T3)
+- [ ] T037 [P] [US1] Add a test to `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala` asserting `SendFailed` removes the record, logs a KO, and invokes `onComplete` exactly once so the channel's in-flight count returns to balance (contracts T4, T5)
+- [ ] T038 [P] [US1] Create `src/test/scala/org/galaxio/gatling/kafka/integration/ReplyRegistrationRaceSpec.scala` — Testcontainers spec with an in-process echo responder answering far faster than the reply timeout, driving the real `KafkaRequestReplyAction` over enough requests to hit the window repeatedly, asserting zero reply-timeout failures (contracts A1, A2; SC-001, SC-002; red: some requests fail with `Reply timeout after Xms` despite every one being answered)
+
+### Implementation for User Story 1
+
+- [ ] T039 [US1] Add `MessageAcked(matchId, sentTimestamp)` and `SendFailed(matchId, errorMessage)` to the sealed `TrackerMessage` trait in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala`, leaving `MessagePublished`'s field list byte-identical (research R5)
+- [ ] T040 [US1] Change `sentMessages`' value in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` to a private wrapper carrying `published`, `registeredAt`, `ackedAt` and `heldReply`; keep it a single-threaded `mutable.HashMap` — ordering, not concurrency, was the defect (data-model §1; research R3)
+- [ ] T041 [US1] Implement the two-phase completion in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala`: `MessageConsumed` holds the reply when `ackedAt` is absent, `MessageAcked` completes a held reply, and a response is always logged with `ackedAt` as its start (contracts T1, T2; invariants P2, P3)
+- [ ] T042 [US1] Change `TimeoutScan` in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` to measure `now - registeredAt` rather than from the ack (contract T3; invariant P4)
+- [ ] T043 [US1] Invert the call order in `sendKafkaMessage` in `src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala`: `acquireTracker` → `tracker ! MessagePublished` → `sender.send`, with the ack callback sending `MessageAcked` and the error callback sending `SendFailed` (contracts A1, A4; this is the fix)
+- [ ] T044 [US1] In the same `acquireTracker` `onFailure` branch of `src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala`, report the KO without publishing the record — same message text, same response-time span (contract A3; the change T034 approves)
+- [ ] T045 [US1] Confirm `src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestAction.scala` (produce-only) is untouched by the diff (contract A6)
+- [ ] T046 [US1] Simplify `send` in `src/test/scala/org/galaxio/gatling/kafka/integration/TrackerLifetimeSpec.scala` by removing the reply re-publish loop and its `#191, out of scope here` comment — a re-published reply masks a dropped one, so leaving it would hide the regression this story prevents (contracts §6)
+- [ ] T047 [US1] Tighten `KnownReplyLossBudget` to `0` in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaConcurrencyLoadTest.scala` and rewrite its scaladoc, which currently says "Tighten to 0 once #191 lands"
+- [ ] T048 [US1] Add a Migration Guide note under v1.1.0 in `README.md` recording that a failed tracker acquisition no longer publishes the request — this belongs in the #191 commit rather than a separate docs PR, because it documents that commit's own behaviour change (Principle I)
+- [ ] T049 [US1] Confirm five consecutive green runs of `sbt "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaConcurrencyLoadTest"` at budget 0 before claiming SC-001, comparing against the T004 baseline
+- [ ] T050 [US1] Run `sbt scalafmtAll scalafmtSbt` then the default gate plus `ReplyRegistrationRaceSpec`; commit as `fix(request-reply): register the pending request before sending (#191)` with the milestone and `Closes #191`. State the slow-path send-thread risk from contracts §4 in the PR description
+
+**Checkpoint**: All four stories complete.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Whole-feature verification and milestone closure. No production code changes here.
+
+- [ ] T051 [P] Run the API-compatibility gate: `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` (Principle I; SC-010)
+- [ ] T052 Run the full CI gate against the Compose stack: `sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport`
+- [ ] T053 Walk `specs/003-request-reply-hardening/quickstart.md` end to end and correct anything that has drifted from the delivered code
+- [ ] T054 [P] Gate each PR with `scripts/check-linkage.sh --pr <N>` — milestone assigned, `Closes #NNN` present, issue in the same milestone (Principle V)
+- [ ] T055 Confirm milestone readiness with `scripts/check-linkage.sh --for-tag v1.1.0`; the milestone title `v1.1.0 Request-reply reliability` resolves for `--for-tag`
+- [ ] T056 [P] Comment on `https://github.com/galax-io/gatling-kafka-plugin/pull/144` noting that its register-before-send idea landed via #191 rather than #143, and close it if superseded (research R3 historical note)
+- [ ] T057 [P] Update `https://github.com/galax-io/gatling-kafka-plugin/issues/193`'s map: #143 and #166 are done, and point 3 (pool-owned correlation table) was **not** required for #191 — the ordering fix removed the need (research R3)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies
+- **Foundational (Phase 2)**: depends on Setup. Pins baselines only — it blocks nothing structurally
+- **User stories (Phases 3–6)**: each depends only on Phase 2. They are mutually independent
+- **Polish (Phase 7)**: depends on every story intended for the release
+
+### User Story Dependencies
+
+None are hard. The phase order is a sequencing preference, and the two reasons for it are:
+
+- **US4 before US1** — recommended by #193 so US1 is verified by a real echo responder in CI rather
+  than by inference. US1 has its own `ReplyRegistrationRaceSpec`, so this is *soft*: US1 can ship
+  first if needed, with weaker CI coverage until US4 lands.
+- **US3 before US1** — both touch `KafkaMessageTracker.scala`. Landing US3 first means US1 rebases
+  onto a correct tracker lifecycle instead of merging two changes to one file. A convenience, not a
+  dependency.
+
+### Within Each User Story
+
+- Tests are written first and must FAIL before implementation (Principle IV)
+- Contract/type additions before the logic that uses them
+- Client-layer changes before action-layer changes
+- Format, then full gate, then commit — one issue, one semantic commit, green on its own
+
+### Parallel Opportunities
+
+- T005–T007 (US2 tests) — three different assertions across two files
+- T014–T015 (US4 broker definitions) — two different files
+- T025–T027 (US3 tests) — two different files
+- T035–T038 (US1 tests) — four independent assertions, one new file
+- T051, T054, T056, T057 (Polish) — independent
+- **Whole stories in parallel**: with more than one developer, US2/US4/US3/US1 can be taken
+  concurrently. The only file collision is `KafkaMessageTracker.scala` between US3 and US1, and
+  `KafkaMessageTrackerPool.scala` between US2 and US3
+
+## Parallel Example: User Story 1
+
+```bash
+# All four US1 tests are independent — write them together, confirm all four go red:
+Task: "Reply-before-ack join in src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala"
+Task: "TimeoutScan measures from registration in src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala"
+Task: "SendFailed releases the channel in src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala"
+Task: "Forced race in src/test/scala/org/galaxio/gatling/kafka/integration/ReplyRegistrationRaceSpec.scala"
+```
+
+## Implementation Strategy
+
+### MVP: User Story 1 alone (#191)
+
+US1 is the highest-value single slice: it is the only remaining source of *silent* data loss, and it
+corrupts the report a load test exists to produce. It is independently shippable — Phase 6 needs
+nothing from Phases 3–5, and `ReplyRegistrationRaceSpec` proves it without the echo responder.
+
+If only one thing ships from this feature, ship US1. The recommended order still puts US4 first,
+because a stronger CI oracle costs one test-only commit and makes US1's proof cheaper to trust.
+
+### Recommended: all four, in phase order
+
+1. Phase 1–2 → baselines pinned
+2. Phase 3 (US2 / #143) → the terminal startup failure is gone
+3. Phase 4 (US4 / #196) → the CI gate becomes an oracle instead of a coincidence
+4. Phase 5 (US3 / #166) → the tracker lifecycle is correct
+5. Phase 6 (US1 / #191) → no reply is ever dropped
+6. Phase 7 → milestone `v1.1.0 Request-reply reliability` is tag-ready
+
+### Parallel Team Strategy
+
+Setup and Foundational are shared. After that, one developer per story works, with two coordination
+points: `KafkaMessageTracker.scala` (US3 and US1) and `KafkaMessageTrackerPool.scala` (US2 and US3).
+Sequence those two pairs or rebase; nothing else overlaps.
+
+## Notes
+
+- `[P]` = different files, no dependencies on incomplete tasks
+- One issue = one semantic commit, green on its own under
+  `sbt scalafmtCheckAll scalafmtSbtCheck compile test` (Principle V). Do not commit per task
+- Every PR carries the `v1.1.0 Request-reply reliability` milestone and `Closes #NNN`
+- Verify every test goes red before implementing it — for US1 and US2 the red condition must be
+  *forced* (a parameterised initialization wait; a responder faster than the ack path), not waited for
+- T034 is a genuine blocker on Phase 6, not a formality: it is a Principle I approval gate


### PR DESCRIPTION
Spec-first artifacts for the four issues still open in milestone **v1.1.0 Request-reply reliability**: #143, #166, #191, #196. No production code — the four fixes follow as stacked PRs on top of this one.

## What the research established

The headline finding is that **#191 is far smaller than the issue implies**. The reply is not lost because Gatling's actor mailbox is unordered — it is a JCTools MPSC queue that *does* preserve enqueue order across producer threads. It is lost because the pending record is created from the producer's acknowledgement callback, i.e. **after** the request is already on the wire and answerable.

So registering before the send is sufficient: it establishes a real happens-before chain (register → produce → broker → responder → consume → deliver), and a reply cannot exist before the send. No concurrent correlation table, no change to `acquireTracker`'s signature.

Worth flagging against #193, which still lists its point 3 (pool-owned correlation table) as part of #191's fix: it is **not required**. It stays relevant for point 4.

## Artifacts

| File | What it holds |
|---|---|
| `spec.md` | 4 user stories, 17 functional requirements, 10 measurable outcomes, 11 edge cases |
| `research.md` | R1–R7 — the decisions above, each with the alternatives rejected and why |
| `data-model.md` | State each fix owns and its transitions |
| `contracts/internal-api.md` | Internal signatures and a red/green condition per guarantee |
| `quickstart.md` | How to run each fix's verification |
| `tasks.md` | 57 tasks, ordered |
| `checklists/requirements.md` | Spec quality checklist, 16/16 |

## Note on ordering

`tasks.md` sequences #196 before #191, following #193's own note. **That turned out to be impossible** — see the correcting docs PR at the top of this stack. The order actually shipped is `#143 → #166 → #191 → #196`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)