### PR TITLE
fix(client): do not poll a consumer with nothing to receive on (#143)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
@@ -11,7 +11,7 @@ import java.util.Properties
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, ConcurrentLinkedQueue, CountDownLatch}
 import scala.collection.mutable
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.jdk.CollectionConverters._
 
 object DynamicKafkaConsumer {
@@ -21,12 +21,38 @@ object DynamicKafkaConsumer {
       topics: Set[String],
       onRecord: ConsumerRecord[K, V] => Unit,
       onFailure: Exception => Unit,
-  ): DynamicKafkaConsumer[K, V]     = {
+  ): DynamicKafkaConsumer[K, V] =
+    withInitializationTimeout(settingsMap, topics, onRecord, onFailure, defaultInitializationTimeout)
+
+  /** Same as `apply`, with the initialization wait supplied so a test can drive its expiry without waiting the production
+    * duration (issue #143).
+    *
+    * Deliberately not an overload of `apply`: a second `apply` makes overload resolution run before the expected type reaches
+    * the callback arguments, so existing call sites that let the lambdas infer — `_ => ()` — stop compiling. A distinct name
+    * keeps inference intact and leaves the published four-argument entry point byte-identical. A default parameter would have
+    * been source-compatible but binary-incompatible, which is worse for a published artifact.
+    */
+  private[kafka] def withInitializationTimeout[K, V](
+      settingsMap: Map[String, AnyRef],
+      topics: Set[String],
+      onRecord: ConsumerRecord[K, V] => Unit,
+      onFailure: Exception => Unit,
+      initializationTimeout: FiniteDuration,
+  ): DynamicKafkaConsumer[K, V] = {
     val settings = new Properties()
     settings.putAll(settingsMap.asJava)
-    new DynamicKafkaConsumer[K, V](settings, topics, onRecord, onFailure)
+    new DynamicKafkaConsumer[K, V](settings, topics, onRecord, onFailure, initializationTimeout)
   }
-  private val initializationTimeout = 90.seconds
+
+  private[client] val defaultInitializationTimeout: FiniteDuration = 90.seconds
+
+  /** How long a turn waits when the consumer has nothing to receive on.
+    *
+    * Short rather than the poll interval: `close()` cannot interrupt this the way `wakeup()` interrupts a poll, so it is also
+    * the worst-case shutdown delay and the worst-case delay before a newly requested topic is subscribed. Costing a wakeup
+    * every 50 ms on one thread, only while there is literally nothing to fetch, buys both.
+    */
+  private val idleBackoffMillis: Long = 50L
 
   private[client] val consumerFailedMessage = "Kafka consumer failed; dynamic consumer can no longer be used"
   private[client] val consumerClosedMessage = "Kafka consumer is closed; topic subscription will not complete"
@@ -37,6 +63,7 @@ final class DynamicKafkaConsumer[K, V] private (
     topics: Set[String],
     onRecord: ConsumerRecord[K, V] => Unit,
     onFailure: Exception => Unit,
+    initializationTimeout: FiniteDuration,
 ) extends Runnable with AutoCloseable with StrictLogging {
 
   private val topicsQueue: java.util.Queue[(String, CompletableFuture[Void])] =
@@ -200,20 +227,46 @@ final class DynamicKafkaConsumer[K, V] private (
     completeAssignedReadiness()
   }
 
+  /** True exactly when `poll` would throw "Consumer is not subscribed to any topics or assigned any partitions".
+    *
+    * Reads the consumer's own state, so it is valid only on the consumer thread.
+    */
+  private def hasNothingToReceiveOn: Boolean =
+    consumer.subscription().isEmpty && consumer.assignment().isEmpty
+
   override def run(): Unit = {
     try {
-      val timeout = DynamicKafkaConsumer.initializationTimeout
-      this.initLatch.await(timeout.length, timeout.unit)
+      val topicRequested = this.initLatch.await(initializationTimeout.length, initializationTimeout.unit)
+      if (!topicRequested) {
+        // Neither an error nor a failure. The wait starts when the pool is built — before any virtual user
+        // runs — so any simulation that ramps, warms up, or simply reaches request-reply late arrives here
+        // with nothing requested yet. Logged because the expiry was previously silent and the crash it used
+        // to cause named nothing about it (issue #143).
+        logger.debug(
+          "Initialization wait of {} expired with no reply topic requested; staying idle until one is",
+          initializationTimeout,
+        )
+      }
       updateSubscription()
       while (running.get) {
-        val records = this.consumer.poll(Duration.ofMillis(1000))
-        records.forEach(record =>
-          try this.onRecord(record)
-          catch {
-            case e: Exception =>
-              this.onFailure(e)
-          },
-        )
+        // A consumer holding neither a subscription nor an assignment throws on poll, and that exception
+        // reaches markConsumerFailed, which poisons every tracker in the pool for the rest of the run
+        // (issue #143). Nothing can arrive for a consumer in that state anyway, so the turn is spent
+        // waiting for a subscription request rather than fetching. The complementary guard is in
+        // updateSubscription, which refuses to shrink a subscription to nothing; this one covers the
+        // subscription that was never established, which that guard cannot.
+        if (hasNothingToReceiveOn) {
+          Thread.sleep(DynamicKafkaConsumer.idleBackoffMillis)
+        } else {
+          val records = this.consumer.poll(Duration.ofMillis(1000))
+          records.forEach(record =>
+            try this.onRecord(record)
+            catch {
+              case e: Exception =>
+                this.onFailure(e)
+            },
+          )
+        }
         updateSubscription()
       }
     } catch {

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -56,7 +56,22 @@ final class KafkaMessageTrackerPool(
     actorSystem: ActorSystem,
     statsEngine: StatsEngine,
     clock: Clock,
+    initializationTimeout: FiniteDuration,
 ) extends KafkaLogging with NameGen with KafkaSerdesImplicits {
+
+  /** The published four-argument constructor, preserved exactly.
+    *
+    * The five-argument form has to be the primary one, because `consumer` below is built in the constructor body and needs the
+    * wait; a secondary constructor cannot introduce a field the primary lacks. Declaring the four-argument form here keeps its
+    * JVM `<init>` signature, so anything compiled against the current release still links — which is what matters, since this
+    * is a bug fix and must not force a major version. Only tests pass a wait; production takes the 90 s default (issue #143).
+    */
+  def this(
+      consumerSettings: Map[String, AnyRef],
+      actorSystem: ActorSystem,
+      statsEngine: StatsEngine,
+      clock: Clock,
+  ) = this(consumerSettings, actorSystem, statsEngine, clock, DynamicKafkaConsumer.defaultInitializationTimeout)
 
   /** How long a reply channel may sit with nothing in flight before it is released.
     *
@@ -119,7 +134,7 @@ final class KafkaMessageTrackerPool(
   }
 
   private val consumer: DynamicKafkaConsumer[Array[Byte], Array[Byte]] =
-    DynamicKafkaConsumer(
+    DynamicKafkaConsumer.withInitializationTimeout(
       if (consumerSettings.contains(ConsumerConfig.GROUP_ID_CONFIG))
         consumerSettings
       else
@@ -152,6 +167,7 @@ final class KafkaMessageTrackerPool(
           trackers.clear()
         }
       },
+      initializationTimeout,
     )
 
   // One sweep per pool, not a timer per tracker. Off both the producer callback and the consumer poll

--- a/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
@@ -1,7 +1,9 @@
 package org.galaxio.gatling.kafka.client
 
 import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.{CompletableFuture, ExecutionException, TimeUnit, TimeoutException}
+import java.util.concurrent.{CompletableFuture, CopyOnWriteArrayList, ExecutionException, TimeUnit, TimeoutException}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.jdk.CollectionConverters._
 
 class DynamicKafkaConsumerSpec extends munit.FunSuite {
 
@@ -104,6 +106,74 @@ class DynamicKafkaConsumerSpec extends munit.FunSuite {
       assertEquals(causeOf(readiness).getCause.getMessage, "boom")
     } finally {
       consumer.close()
+    }
+  }
+
+  // Issue #143. The initialization wait starts when the pool is built, before any virtual user runs, so
+  // a simulation that ramps or warms up before its first request-reply reaches its expiry with nothing
+  // requested. The expiry used to fall through into a poll on a consumer that had never subscribed,
+  // which threw and latched a failure that poisoned every tracker for the rest of the run.
+  private def newConsumerWithInitWait(
+      onFailure: Exception => Unit,
+      initializationTimeout: FiniteDuration,
+  ): DynamicKafkaConsumer[Array[Byte], Array[Byte]] =
+    DynamicKafkaConsumer.withInitializationTimeout[Array[Byte], Array[Byte]](
+      Map(
+        "bootstrap.servers"  -> "localhost:0",
+        "key.deserializer"   -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+        "value.deserializer" -> "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+      ),
+      Set.empty,
+      _ => (),
+      onFailure,
+      initializationTimeout,
+    )
+
+  private def runningConsumer(
+      consumer: DynamicKafkaConsumer[Array[Byte], Array[Byte]],
+  )(body: => Unit): Unit = {
+    val thread = new Thread(consumer, "init-wait-expiry")
+    thread.setDaemon(true)
+    thread.start()
+    try body
+    finally {
+      consumer.close()
+      thread.join(10_000)
+      assert(!thread.isAlive, "the consumer thread must exit after close")
+    }
+  }
+
+  test("the initialization wait expiring with no topic requested neither throws nor fails the consumer") {
+    val failures = new CopyOnWriteArrayList[Exception]()
+    val consumer = newConsumerWithInitWait(failures.add(_), 100.millis)
+
+    runningConsumer(consumer) {
+      // An order of magnitude past the wait, so the loop has taken many turns with nothing subscribed.
+      Thread.sleep(1_000)
+
+      assertEquals(
+        failures.asScala.map(_.getMessage).toList,
+        Nil,
+        "expiry of the initialization wait must not report a failure",
+      )
+      assertEquals(failureRef(consumer).get(), null, "expiry must not latch a consumer failure")
+    }
+  }
+
+  test("a topic requested after the initialization wait expired is still accepted") {
+    val failures = new CopyOnWriteArrayList[Exception]()
+    val consumer = newConsumerWithInitWait(failures.add(_), 100.millis)
+
+    runningConsumer(consumer) {
+      Thread.sleep(1_000)
+
+      val readiness = consumer.requestTopicSubscription("late-topic")
+
+      assert(
+        !readiness.isCompletedExceptionally,
+        "a topic requested long after the wait expired must not be refused",
+      )
+      assertEquals(failures.size(), 0, "accepting a late topic must not report a failure")
     }
   }
 

--- a/src/test/scala/org/galaxio/gatling/kafka/integration/ConsumerStartupSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/ConsumerStartupSpec.scala
@@ -1,0 +1,132 @@
+package org.galaxio.gatling.kafka.integration
+
+import com.dimafeng.testcontainers.ConfluentKafkaContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import io.gatling.commons.util.Clock
+import io.gatling.core.actor.ActorSystem
+import io.gatling.core.stats.RecordingStatsEngine
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.galaxio.gatling.kafka.client.KafkaMessageTrackerPool
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher
+
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.jdk.CollectionConverters._
+
+/** Startup coverage for issue #143 — the shared reply-receiving machinery must not fail merely because no reply topic was
+  * requested while its initialization wait ran.
+  *
+  * The wait starts when `KafkaMessageTrackerPool` is built, and the pool is built by `ProtocolKey.newComponents` for any
+  * protocol carrying `bootstrap.servers` in its consume settings — before a single virtual user runs. So the clock runs against
+  * wall time from simulation start, not against first use, and any ramp, warm-up or `nothingFor` longer than the wait used to
+  * reach `poll()` on a consumer that had never subscribed. That threw, `markConsumerFailed` latched it, and every later
+  * `acquireTracker` failed with "Kafka consumer failed; tracker pool can no longer be used" for the rest of the run.
+  *
+  * The wait is shortened here through the pool's five-argument constructor rather than by mutating a shared constant, so these
+  * tests cannot leak a value into any other suite.
+  */
+class ConsumerStartupSpec extends munit.FunSuite with TestContainerForAll {
+
+  override val containerDef: ConfluentKafkaContainer.Def = ConfluentKafkaContainer.Def()
+
+  /** Long enough that the expiry is unambiguous, short enough that the suite stays quick. */
+  private val InitWait: FiniteDuration = 500.millis
+
+  /** How far past the expiry the tests wait before asserting. Many idle loop turns, all of which used to be one throw. */
+  private val WellPastExpiry: FiniteDuration = 3.seconds
+
+  private def consumerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG        -> bootstrap,
+    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
+  )
+
+  private def createTopic(bootstrap: String, name: String): Unit = {
+    val admin = AdminClient.create(
+      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrap).asJava,
+    )
+    try admin.createTopics(List(new NewTopic(name, 1, 1.toShort)).asJava).all().get(30, TimeUnit.SECONDS)
+    finally admin.close()
+  }
+
+  private final class SystemClock extends Clock {
+    override def nowMillis: Long = System.currentTimeMillis()
+  }
+
+  private def withPool(bootstrap: String)(body: KafkaMessageTrackerPool => Unit): Unit = {
+    val actorSystem = new ActorSystem()
+    try {
+      val pool = new KafkaMessageTrackerPool(
+        consumerSettings(bootstrap),
+        actorSystem,
+        new RecordingStatsEngine,
+        new SystemClock,
+        InitWait,
+      )
+      body(pool)
+    } finally actorSystem.close()
+  }
+
+  test("a reply topic requested long after the initialization wait expired is still served") {
+    withContainers { kafka =>
+      val bootstrap  = kafka.bootstrapServers
+      val replyTopic = "startup-late-reply"
+      createTopic(bootstrap, replyTopic)
+
+      withPool(bootstrap) { pool =>
+        // Nothing is requested while the wait runs — the shape of a ramp, a warm-up, or a produce-only
+        // phase ahead of the request-reply one.
+        Thread.sleep(WellPastExpiry.toMillis)
+
+        val ready   = new CountDownLatch(1)
+        val failure = new AtomicReference[Throwable]()
+
+        pool.acquireTracker(
+          producerTopic = "startup-late-request",
+          consumerTopic = replyTopic,
+          messageMatcher = KafkaKeyMatcher,
+          responseTransformer = None,
+          timeout = 60.seconds,
+        )(
+          _ => ready.countDown(),
+          error => { failure.set(error); ready.countDown() },
+        )
+
+        assert(
+          ready.await(90, TimeUnit.SECONDS),
+          "acquisition after the initialization wait expired never reported an outcome",
+        )
+        assertEquals(
+          Option(failure.get()).map(_.getMessage),
+          None,
+          "the first reply topic requested after the wait expired must be served, not refused",
+        )
+      }
+    }
+  }
+
+  test("a pool that is built and never used reports no consumer failure") {
+    withContainers { kafka =>
+      // A protocol declaring consumeSettings for scenarios that never perform request-reply builds a
+      // pool anyway. Before the fix it failed at the wait's expiry and logged a consumer failure on a
+      // pool nobody had touched.
+      withPool(kafka.bootstrapServers) { pool =>
+        Thread.sleep(WellPastExpiry.toMillis)
+
+        val failureField    = classOf[KafkaMessageTrackerPool].getDeclaredField("consumerFailure")
+        failureField.setAccessible(true)
+        val consumerFailure = failureField.get(pool).asInstanceOf[AtomicReference[Exception]].get()
+
+        assertEquals(
+          Option(consumerFailure).map(_.getMessage),
+          None,
+          "an unused pool must not latch a consumer failure when its initialization wait expires",
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #143

Stacked on #198 (spec artifacts).

## The defect

The initialization wait starts when `KafkaMessageTrackerPool` is built — which `ProtocolKey.newComponents` does for any protocol carrying `bootstrap.servers` in its consume settings, **before a single virtual user runs**. Any simulation whose first request-reply lands more than 90 s into the run therefore reached the wait's expiry with nothing requested, fell through into `poll()` on a consumer that had never subscribed, and threw:

```
IllegalStateException: Consumer is not subscribed to any topics or assigned any partitions
```

`markConsumerFailed` latched that, and every later `acquireTracker` failed with `Kafka consumer failed; tracker pool can no longer be used` for the rest of the run. Ramps, warm-ups and `nothingFor` are ordinary load-profile shapes, and a protocol that merely *declares* reply settings for scenarios that never do request-reply failed too — on a pool nobody used.

## The fix

Guard the poll: a turn on which the consumer holds neither a subscription nor an assignment waits briefly instead of fetching, and still applies pending subscription changes so a topic requested at any later point is picked up.

This is the complement of the guard #165 added to `updateSubscription`, which refuses to shrink a subscription to nothing but cannot protect one that was **never established**. Both are needed; together they make the crash unreachable from either end.

The boolean `initLatch.await` returns is now honoured and logged, so the expiry is distinguishable from a topic arriving — previously it was silent, and the eventual error named nothing about it.

## Test-configurability

The initialization wait becomes injectable so the regression tests can drive its expiry without waiting 90 s.

`DynamicKafkaConsumer` gets a distinctly-named `private[kafka] withInitializationTimeout` rather than an `apply` overload. **An overload does not work**: a second `apply` makes overload resolution run before the expected type reaches the callback arguments, so existing call sites that let the lambdas infer — `_ => ()` — stop compiling. `KafkaIntegrationSpec` caught it immediately, and it would have been a source break for any downstream user. A default parameter was rejected too: source-compatible but binary-incompatible.

`KafkaMessageTrackerPool`'s five-argument constructor has to be the primary one, because `consumer` is built in the constructor body and needs the wait. The four-argument form is declared as a secondary constructor, which preserves its JVM `<init>` signature — what binary compatibility actually depends on.

## Verification

Red-then-green at both levels:

- `DynamicKafkaConsumerSpec` — 2 new tests, both red with the exact `Consumer is not subscribed…` message, plus refusal of a late topic.
- `ConsumerStartupSpec` (new, Testcontainers) — 2 tests, both red; covers a late first request-reply and a pool built but never used.

`sbt scalafmtCheckAll scalafmtSbtCheck compile test` green — 46 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)