### PR TITLE
fix(client): stop the tracker and its timeout scan on release (#166)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -4,7 +4,7 @@ import io.gatling.commons.stats.{KO, OK, Status}
 import io.gatling.commons.util.Clock
 import io.gatling.commons.validation.Failure
 import io.gatling.core.action.Action
-import io.gatling.core.actor.{Actor, Behavior}
+import io.gatling.core.actor.{Actor, Behavior, Cancellable}
 import io.gatling.core.check.Check
 import io.gatling.core.session.Session
 import io.gatling.core.stats.StatsEngine
@@ -47,6 +47,14 @@ object KafkaMessageTracker {
 
   final case class ConsumerFailure(errorMessage: String) extends TrackerMessage
 
+  /** Asks the tracker to cancel its periodic timeout scan and stop.
+    *
+    * Sent by [[KafkaMessageTrackerPool]] once the reply channel this tracker belongs to has been released. It exists because
+    * Gatling's `ActorSystem` offers no way to stop an actor from outside — `die` is an `Effect` reachable only from the actor's
+    * own behaviour — so stopping has to be asked for (issue #166).
+    */
+  private[client] final case object Stop extends TrackerMessage
+
   private final case object TimeoutScan extends TrackerMessage
 
   private def makeKeyForSentMessages(m: Array[Byte]): String =
@@ -63,16 +71,24 @@ class KafkaMessageTracker[K, V](
     responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
 ) extends Actor[TrackerMessage](name) with KafkaLogging {
 
-  private val sentMessages                 = mutable.HashMap.empty[String, MessagePublished]
-  private val timedOutMessages             = mutable.ArrayBuffer.empty[MessagePublished]
-  private var periodicTimeoutScanTriggered = false
+  private val sentMessages     = mutable.HashMap.empty[String, MessagePublished]
+  private val timedOutMessages = mutable.ArrayBuffer.empty[MessagePublished]
+
+  /** The periodic timeout scan, once something with a reply timeout has been published.
+    *
+    * Retained rather than discarded so [[KafkaMessageTracker.Stop]] can cancel it. The handle held nothing before, which meant
+    * the scan outlived every channel that ever armed one: it captures `self`, so the tracker — and with it the stats engine,
+    * the clock and the matcher closures — stayed reachable from the actor system's scheduler, and that scheduler is a single
+    * thread shared by the whole simulation, so each leaked scan also cost one wakeup per second for the rest of the run (issue
+    * #166).
+    */
+  private var periodicTimeoutScan: Option[Cancellable] = None
 
   private def triggerPeriodicTimeoutScan(): Unit =
-    if (!periodicTimeoutScanTriggered) {
-      periodicTimeoutScanTriggered = true
-      scheduler.scheduleAtFixedRate(1000.millis) {
+    if (periodicTimeoutScan.isEmpty) {
+      periodicTimeoutScan = Some(scheduler.scheduleAtFixedRate(1000.millis) {
         self ! TimeoutScan
-      }
+      })
     }
 
   override def init(): Behavior[TrackerMessage] = {
@@ -165,6 +181,15 @@ class KafkaMessageTracker[K, V](
       }
       timedOutMessages.clear()
       stay
+
+    case Stop =>
+      // Cancelling matters as much as dying: `die` only swaps the behaviour, so a scan left running would
+      // keep firing TimeoutScan at a dead actor and keep it reachable — the leak would survive almost
+      // intact. The pool only sends this once the channel has had nothing in flight for a full idle grace,
+      // so there is no pending request left for the scan to time out.
+      periodicTimeoutScan.foreach(_.cancel())
+      periodicTimeoutScan = None
+      die
   }
 
   private def executeNext(

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -163,7 +163,16 @@ final class KafkaMessageTrackerPool(
         logger.debug("Consumer failure stacktrace", exception)
         if (consumerFailure.compareAndSet(null, exception)) {
           val failure = KafkaMessageTracker.ConsumerFailure(exception.getMessage)
-          trackers.values().forEach(_.values().forEach(entry => entry.actor ! failure))
+          trackers
+            .values()
+            .forEach(_.values().forEach { entry =>
+              entry.actor ! failure
+              // Then stop it. Nothing will ever release these entries — the pool is finished — so their
+              // timeout scans would otherwise keep firing for the rest of the run against bookkeeping the
+              // failure broadcast has just cleared. The mailbox is FIFO, so the failure above is processed
+              // first and every pending request still gets its KO.
+              entry.actor ! KafkaMessageTracker.Stop
+            })
           trackers.clear()
         }
       },
@@ -183,6 +192,11 @@ final class KafkaMessageTrackerPool(
 
   private val consumerFuture = consumerExecutor.submit(consumer)
   actorSystem.registerOnTermination {
+    // Anything still held at the end of the run is released here rather than left to the actor system's
+    // scheduler shutting down underneath it. Runs before ActorSystem.close() shuts its executor, so the
+    // messages are still dispatched.
+    trackers.values().forEach(_.values().forEach(_.actor ! KafkaMessageTracker.Stop))
+    trackers.clear()
     logger.debug("Closing consumer {}", consumer)
     consumer.close()
     try {
@@ -436,14 +450,22 @@ final class KafkaMessageTrackerPool(
     trackers.forEach { (consumerTopic, innerMap) =>
       innerMap.forEach { (mRef, entry) =>
         if (entry.refCount.get() <= 0 && now - entry.idleSince.get() >= idleGraceMillis) {
+          var released: ActorRef[KafkaMessageTracker.TrackerMessage] = null
           innerMap.computeIfPresent(
             mRef,
             (_, current) =>
               if (current.refCount.get() <= 0 && now - current.idleSince.get() >= idleGraceMillis) {
                 logger.debug("Releasing idle tracker for topic {} matcher {}", consumerTopic, mRef)
+                released = current.actor
                 null
               } else current,
           )
+          // Outside the compute lambda, following removeTopicSubscription below: the bin lock is held
+          // inside it, and telling an actor is a side effect on another object. Sent only once the entry
+          // is gone, so no acquisition can be handed a tracker that is about to die. Dropping the entry
+          // without this is the whole of issue #166 — the registration went, everything hanging off it
+          // stayed.
+          if (released != null) released ! KafkaMessageTracker.Stop
         }
       }
       if (innerMap.isEmpty) {

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
@@ -3,6 +3,7 @@ package org.galaxio.gatling.kafka.client
 import io.gatling.commons.stats.KO
 import io.gatling.commons.util.Clock
 import io.gatling.core.action.Action
+import io.gatling.core.actor.{Actor, ActorSystem}
 import io.gatling.core.session.Session
 import io.gatling.core.stats.RecordingStatsEngine
 import org.galaxio.gatling.kafka.client.KafkaMessageTracker.{ConsumerFailure, MessageConsumed, MessagePublished}
@@ -76,6 +77,92 @@ class KafkaMessageTrackerSpec extends munit.FunSuite {
 
     assertEquals(statsEngine.responses.get().size, 0, "an unmatched reply must not be reported")
     assert(next.lastSession.get() == null, "an unmatched reply must not advance any virtual user")
+  }
+
+  // Issue #166. These need a real ActorSystem rather than the direct `tracker.init()` style above: arming
+  // the periodic scan touches `scheduler` and `self`, which only exist once the actor was created through
+  // `actorSystem.actorOf`.
+  private def withActorSystem(body: ActorSystem => Unit): Unit = {
+    val actorSystem = new ActorSystem()
+    try body(actorSystem)
+    finally actorSystem.close()
+  }
+
+  /** Whether the tracker is still holding an armed timeout scan.
+    *
+    * Read off the actor instance rather than off Gatling's scheduler: the scheduler is an
+    * `Executors.newSingleThreadScheduledExecutor`, whose ScheduledThreadPoolExecutor sits behind a JDK-internal delegate that
+    * JDK 17 will not open to reflection, so its queue cannot be counted from a test.
+    *
+    * Behaviour alone cannot distinguish the two halves of the fix. `die` swaps the behaviour to one that drops messages, so a
+    * scan left running still produces nothing observable — it just keeps firing at a dead actor once a second, on a scheduler
+    * thread shared by the whole simulation, holding the tracker reachable. That is the leak, and this is what shows it.
+    */
+  private def scanIsArmed(tracker: Actor[KafkaMessageTracker.TrackerMessage]): Boolean = {
+    val field = tracker.getClass.getDeclaredField("periodicTimeoutScan")
+    field.setAccessible(true)
+    field.get(tracker).asInstanceOf[Option[_]].isDefined
+  }
+
+  private def publishedWithTimeout(
+      next: Action,
+      session: Session,
+      replyTimeout: Long,
+  ): MessagePublished =
+    MessagePublished(
+      matchId = "match-stop".getBytes(StandardCharsets.UTF_8),
+      sentTimestamp = 0L,
+      replyTimeout = replyTimeout,
+      checks = Nil,
+      session = session,
+      next = next,
+      requestName = "request-reply",
+    )
+
+  test("Stop cancels the periodic timeout scan and stops the tracker") {
+    withActorSystem { actorSystem =>
+      val statsEngine = new RecordingStatsEngine
+      // Far enough ahead that the pending request below is already past its 50 ms reply timeout, so any
+      // scan that still ran would have something to report.
+      val clock       = new StubClock(10_000L)
+      val next        = new RecordingAction("next")
+      val tracker     =
+        KafkaMessageTracker.actor[Array[Byte], Array[Byte]]("tracker", statsEngine, clock, KafkaKeyMatcher, None)
+      val ref         = actorSystem.actorOf(tracker)
+
+      ref ! publishedWithTimeout(next, Session("scenario", 1L, null), replyTimeout = 50L)
+      Thread.sleep(300)
+      assert(scanIsArmed(tracker), "a request with a reply timeout must arm the periodic scan")
+
+      ref ! KafkaMessageTracker.Stop
+      Thread.sleep(300)
+
+      assert(
+        !scanIsArmed(tracker),
+        "Stop must cancel the periodic scan: leaving it armed keeps firing at a dead actor once a second " +
+          "for the rest of the run and holds the tracker reachable, which is the leak in issue #166",
+      )
+      assertEquals(statsEngine.responses.get().size, 0, "a stopped tracker must report nothing")
+      assert(next.lastSession.get() == null, "a stopped tracker must not advance any virtual user")
+    }
+  }
+
+  test("Stop is safe on a tracker that never armed a timeout scan") {
+    withActorSystem { actorSystem =>
+      val statsEngine = new RecordingStatsEngine
+      val next        = new RecordingAction("next")
+      val tracker     = KafkaMessageTracker
+        .actor[Array[Byte], Array[Byte]]("tracker", statsEngine, new StubClock(1_000L), KafkaKeyMatcher, None)
+      val ref         = actorSystem.actorOf(tracker)
+
+      // replyTimeout 0 never arms a scan, so Stop has nothing to cancel.
+      ref ! publishedWithTimeout(next, Session("scenario", 1L, null), replyTimeout = 0L)
+      ref ! KafkaMessageTracker.Stop
+      Thread.sleep(500)
+
+      assert(!scanIsArmed(tracker), "an unarmed tracker must still be unarmed after Stop")
+      assertEquals(statsEngine.responses.get().size, 0, "stopping an unarmed tracker must not report anything")
+    }
   }
 
   private final class StubClock(now: Long) extends Clock {

--- a/src/test/scala/org/galaxio/gatling/kafka/integration/TrackerLifetimeSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/TrackerLifetimeSpec.scala
@@ -526,6 +526,80 @@ class TrackerLifetimeSpec extends munit.FunSuite with TestContainerForAll {
     }
   }
 
+  /** The tracker actor instance behind a pool registration.
+    *
+    * Two reflection hops, both into classpath classes: `TrackerEntry.actor` gives Gatling's `ActorRef`, whose implementation
+    * holds the `Actor` instance. Needed because the pool creates its trackers internally, so a test never sees the instance —
+    * and the instance is where the evidence for issue #166 lives.
+    */
+  private def trackerBehind(registration: AnyRef): AnyRef = {
+    val entryField = registration.getClass.getDeclaredField("actor")
+    entryField.setAccessible(true)
+    val ref        = entryField.get(registration)
+    val instField  = ref.getClass.getDeclaredField("actor")
+    instField.setAccessible(true)
+    instField.get(ref)
+  }
+
+  /** Whether a tracker is still holding an armed periodic timeout scan.
+    *
+    * The scan is the leak: it captures `self`, and Gatling's scheduler is a single thread shared by the whole simulation, so
+    * one left armed after its channel is released keeps the tracker — with its stats engine, clock and matcher closures —
+    * reachable, and costs a wakeup per second for the rest of the run. Read here rather than off the scheduler, whose
+    * ScheduledThreadPoolExecutor sits behind a JDK-internal delegate that JDK 17 will not open to reflection.
+    */
+  private def scanIsArmed(tracker: AnyRef): Boolean = {
+    val field = tracker.getClass.getDeclaredField("periodicTimeoutScan")
+    field.setAccessible(true)
+    field.get(tracker).asInstanceOf[Option[_]].isDefined
+  }
+
+  test("(7) a released channel takes its timeout scan with it, so scans track channels held not channels created") {
+    withContainers { kafka =>
+      val bootstrap = kafka.bootstrapServers
+      // Enough distinct reply topics that "one scan per channel ever created" and "one scan per channel
+      // currently held" are unmistakably different numbers. This is the shape issue #78 requires to stay
+      // bounded — a reply topic derived per virtual user — and the shape #166 made unbounded again by
+      // releasing the registration while leaving everything hanging off it running.
+      val channels  = 20
+      val grace     = 3.seconds
+      val topics    = (1 to channels).flatMap(i => List(s"lifetime-scan-request-$i", s"lifetime-scan-reply-$i"))
+      createTopics(bootstrap, topics: _*)
+
+      val run = new Run(bootstrap, KafkaKeyMatcher, idleGrace = grace)
+      try {
+        // Captured as each channel is created: after release the registration is gone and the tracker
+        // with it, so there would be nothing left to inspect.
+        val trackers = (1 to channels).map { i =>
+          val replyTopic   = s"lifetime-scan-reply-$i"
+          requestReply(run, s"scan-$i", s"lifetime-scan-request-$i", replyTopic, s"scan-key-$i")
+          val registration = registrationFor(run.pool, replyTopic, run.matcher)
+          assert(registration != null, s"channel $i was released while its request was still completing")
+          val tracker      = trackerBehind(registration)
+          assert(scanIsArmed(tracker), s"channel $i never armed a timeout scan, so this proves nothing")
+          tracker
+        }
+
+        val deadline = System.currentTimeMillis() + grace.toMillis + 30000
+        while (
+          (1 to channels).exists(i => registrationFor(run.pool, s"lifetime-scan-reply-$i", run.matcher) != null) &&
+          System.currentTimeMillis() < deadline
+        ) Thread.sleep(100)
+
+        val stillHeld = (1 to channels).count(i => registrationFor(run.pool, s"lifetime-scan-reply-$i", run.matcher) != null)
+        assertEquals(stillHeld, 0, "every channel should have gone idle and been released by now")
+
+        val stillArmed = trackers.count(scanIsArmed)
+        assertEquals(
+          stillArmed,
+          0,
+          s"$stillArmed of $channels released channels left their timeout scan running; scans must be bounded by " +
+            "the channels currently held, not by the number ever created",
+        )
+      } finally run.close()
+    }
+  }
+
   test("(4) a second scenario looping on its own topic pair does not disturb the first") {
     withContainers { kafka =>
       val bootstrap = kafka.bootstrapServers


### PR DESCRIPTION
Closes #166

Stacked on #199 (#143).

## The defect

`triggerPeriodicTimeoutScan` armed a fixed-rate `TimeoutScan` and **discarded the `Cancellable`**, and releasing a channel only ever removed the map entry. So every tracker that handled a message with `replyTimeout > 0` kept firing once a second for the rest of the run and stayed reachable, retaining its `statsEngine`, `clock` and matcher closures.

Growth tracked the **total** number of trackers created over the run rather than the number concurrently active — which is exactly what idle release (#165) exists to prevent. The registration was let go while everything hanging off it was kept.

Worth spelling out how much this costs: Gatling's `ActorSystem` scheduler is a **single** `newSingleThreadScheduledExecutor` shared by the whole simulation. Each leaked scan is not just retained memory, it is one more wakeup per second on that one thread.

## The fix

The tracker retains its `Cancellable` and gains a terminal `Stop` message that cancels it and returns `die`.

Gatling's `ActorSystem` has **no way to stop an actor from outside** — `die` is an `Effect` reachable only from the actor's own behaviour — so stopping has to be asked for. And cancelling matters as much as dying: `die` only swaps the behaviour, so a scan left running would keep firing at a dead actor and keep it reachable. The leak would survive almost intact.

The pool sends `Stop` on all three paths that drop an entry:

- the idle sweep — after removal and outside the `computeIfPresent` lambda, following the precedent the existing `removeTopicSubscription` handling already sets;
- the consumer-failure broadcast — after `ConsumerFailure`, so pending requests still get their KO (the mailbox is FIFO);
- pool shutdown.

Safe because release only happens at `refCount <= 0` sustained for a full idle grace, and `refCount` is decremented after the request has been reported — so a stopped tracker never has outstanding work.

## A note on the regression test

My first probe was **a false pass**. It asserted that a stopped tracker reports nothing — but `die` swaps the behaviour to one that drops messages, so a leaked scan produces nothing observable either. The test passed with the cancellation removed.

The assertion now reads the scan handle off the actor instance. Reading Gatling's scheduler directly is not possible: it is an `Executors.newSingleThreadScheduledExecutor`, whose `ScheduledThreadPoolExecutor` sits behind a JDK-internal delegate that JDK 17 will not open to reflection.

## Verification

- `KafkaMessageTrackerSpec` — `Stop` cancels the scan; `Stop` is safe on a tracker that never armed one. Red with the cancellation removed.
- `TrackerLifetimeSpec` — new test drives **20 sequential channels** through acquire → release → idle grace and asserts none left its scan armed. Red without the pool-side `Stop`.

`sbt scalafmtCheckAll scalafmtSbtCheck compile test` green — 49 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)