### PR TITLE
fix(request-reply): register the pending request before sending (#191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,29 @@ Use this section as release-based upgrade notes. Start from the version you are 
 | `0.21.x` | `1.0.x` | Stay on Gatling `3.13.x`, review request-reply defaults and DSL surface. |
 | `0.20.x` or older | `1.0.x` | Treat as full doc refresh. Older consume-only or per-action matcher APIs are not present. |
 
+### Upgrading to `1.1.0`
+
+No API changes. One behavioural change worth knowing about, in request-reply only.
+
+#### A request whose reply channel cannot be established is no longer published
+
+Request-reply now registers the pending request **before** handing the record to the producer, so that a reply cannot arrive
+before the plugin is watching for it. Previously the request was sent first and the reply channel acquired afterwards, which
+meant a reply from a fast responder could be received and silently discarded, and the request then failed on its reply timeout
+as though nothing had answered.
+
+The consequence: when acquiring the reply channel fails — for example the reply topic is never assigned within the configured
+timeout — the request is now reported as a failure **without** being published. Before, it was published first and then
+reported as a failure.
+
+- Reported results are unchanged: the same KO, the same error message, and the same response-time span.
+- What changes is that your system under test no longer receives a request whose reply the plugin could never have matched.
+- If a simulation depended on that request reaching the broker despite the failure, it will now see one fewer record on that
+  path.
+
+Reported response times are unchanged in both directions: a successful request-reply is still measured from the producer's
+acknowledgement to the reply arriving, and a failed one still spans the request's start to failure detection.
+
 ### Upgrading to `1.0.0` from `0.22.x` / RC
 
 #### Protocol-level topic API removed

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -45,58 +45,79 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
       next ! session.logGroupRequestTimings(requestStartDate, requestEndDate).markAsFailed
     }
 
-    components.sender.send(protocolMessage)(
-      rm => {
-        if (logger.underlying.isDebugEnabled) {
-          logMessage(
-            s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${rm.topic()}",
-            protocolMessage,
-          )
-        }
-        val id = components.kafkaProtocol.messageMatcher.requestMatch(protocolMessage)
+    components.trackersPool match {
+      case Some(trackers) =>
+        val consumerTopic = protocolMessage.consumerTopic
+        val matcher       = components.kafkaProtocol.messageMatcher
+        val id            = matcher.requestMatch(protocolMessage)
 
-        components.trackersPool match {
-          case Some(trackers) =>
-            val consumerTopic = protocolMessage.consumerTopic
-            val matcher       = components.kafkaProtocol.messageMatcher
-            // This body runs on the producer's I/O thread: acquisition hands back a tracker without
-            // waiting here, so a reply topic that is slow to be assigned cannot stall that thread.
-            trackers.acquireTracker(
-              protocolMessage.producerTopic,
-              consumerTopic,
-              matcher,
-              None,
-              components.kafkaProtocol.timeout,
-            )(
-              tracker =>
-                tracker ! KafkaMessageTracker
-                  .MessagePublished(
-                    id,
-                    clock.nowMillis,
-                    components.kafkaProtocol.timeout.toMillis,
-                    attributes.checks,
-                    session,
-                    next,
-                    requestNameString,
-                    onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
-                  ),
+        // Acquire, register, then send — in that order, and the order is the point.
+        //
+        // Sending first meant the request was on the wire, and answerable, before anything was watching
+        // for its answer: the pending record was only created from the producer's acknowledgement
+        // callback, which under load can run after a fast responder's reply has already been polled and
+        // broadcast. The reply then matched nothing, was discarded silently, and the request failed on
+        // its reply timeout — indistinguishable from a system under test that never answered (issue
+        // #191).
+        //
+        // Registering first replaces that race with a causal chain: the record is enqueued before the
+        // send, a reply cannot exist before the send, and Gatling's mailbox preserves enqueue order
+        // across producer threads. Acquisition is asynchronous (issue #163), so this still does not
+        // block the virtual user.
+        trackers.acquireTracker(
+          protocolMessage.producerTopic,
+          consumerTopic,
+          matcher,
+          None,
+          components.kafkaProtocol.timeout,
+        )(
+          tracker => {
+            tracker ! KafkaMessageTracker
+              .MessagePublished(
+                id,
+                requestStartDate,
+                components.kafkaProtocol.timeout.toMillis,
+                attributes.checks,
+                session,
+                next,
+                requestNameString,
+                onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
+              )
+            components.sender.send(protocolMessage)(
+              rm => {
+                if (logger.underlying.isDebugEnabled) {
+                  logMessage(
+                    s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${rm.topic()}",
+                    protocolMessage,
+                  )
+                }
+                // Carries the timestamp a successful request-reply is measured from. Reporting stays on
+                // the acknowledgement, exactly as before, even though registration now happens earlier.
+                tracker ! KafkaMessageTracker.MessageAcked(id, clock.nowMillis)
+              },
               e => {
                 logger.error(e.getMessage, e)
-                reportFailure(e.getMessage, None)
+                // Through the tracker rather than reported here: the record registered above has to be
+                // removed and the channel reference released, and the tracker owns both.
+                tracker ! KafkaMessageTracker.SendFailed(id, e.getMessage)
               },
             )
-          case None           =>
-            val msg =
-              s"Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration, " +
-                s"otherwise the virtual user will hang for ${components.kafkaProtocol.timeout} with no reply"
-            logger.error(msg)
-            reportFailure(msg, None)
-        }
-      },
-      e => {
-        logger.error(e.getMessage, e)
-        reportFailure(e.getMessage, Some("500"))
-      },
-    )
+          },
+          e => {
+            logger.error(e.getMessage, e)
+            // Nothing was published. Approved deliberately rather than as a side effect: there is no
+            // ordering that both registers before the send and still publishes when acquisition fails,
+            // and publishing a request whose reply can never be received is the state issue #143 exists
+            // to prevent from the other direction. The virtual user sees the same KO as before.
+            reportFailure(e.getMessage, None)
+          },
+        )
+      case None           =>
+        val msg =
+          s"Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration, " +
+            s"otherwise the virtual user will hang for ${components.kafkaProtocol.timeout} with no reply"
+        logger.error(msg)
+        reportFailure(msg, None)
+    }
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -45,6 +45,21 @@ object KafkaMessageTracker {
       message: KafkaProtocolMessage,
   ) extends TrackerMessage
 
+  /** The broker acknowledged the request identified by `matchId`, at `sentTimestamp`.
+    *
+    * Separate from [[MessagePublished]] because the request is now registered *before* it is handed to the producer (issue
+    * #191), so the acknowledgement timestamp does not exist yet at registration. It is the timestamp a successful request-reply
+    * is measured from, and keeping it that way is what leaves reported response times unchanged.
+    */
+  final case class MessageAcked(matchId: Array[Byte], sentTimestamp: Long) extends TrackerMessage
+
+  /** The producer failed to deliver the request identified by `matchId`.
+    *
+    * The request was registered before the send, so a delivery failure has to un-register it — otherwise the record sits until
+    * its reply timeout and, worse, its channel never returns to idle because nothing releases the reference acquisition took.
+    */
+  final case class SendFailed(matchId: Array[Byte], errorMessage: String) extends TrackerMessage
+
   final case class ConsumerFailure(errorMessage: String) extends TrackerMessage
 
   /** Asks the tracker to cancel its periodic timeout scan and stop.
@@ -55,7 +70,33 @@ object KafkaMessageTracker {
     */
   private[client] final case object Stop extends TrackerMessage
 
-  private final case object TimeoutScan extends TrackerMessage
+  /** Package-visible so a spec can drive one scan deterministically, rather than waiting on the scheduler. */
+  private[client] final case object TimeoutScan extends TrackerMessage
+
+  /** One request that has been registered and is awaiting its reply.
+    *
+    * `published.sentTimestamp` is the moment the virtual user began the request, captured before the channel was even acquired.
+    * `ackedAt` is when the broker acknowledged it, and arrives separately because registration now happens before the send
+    * (issue #191).
+    *
+    * In the companion rather than in the class body: a case class nested in a class carries an outer reference that pattern
+    * matching cannot check at run time, which this build treats as an error.
+    */
+  private final case class PendingRequest(published: MessagePublished, ackedAt: Option[Long] = None) {
+
+    /** The timestamp this request is reported from, and the one its reply timeout is measured against.
+      *
+      * The acknowledgement once it has landed, which is what a successful request-reply has always been measured from and what
+      * keeps reported response times unchanged. Otherwise the value the caller registered with, which is the request's own
+      * start.
+      *
+      * A reply is deliberately never held back waiting for the acknowledgement it is nominally measured from. Holding would
+      * make a reply that already arrived depend on a later message to be reported at all — the same shape as the defect this
+      * fixes, and it would lose the reply outright if that message never came. Reporting a hair early is the cheaper error: the
+      * gap is a single produce acknowledgement, and it only opens for a reply that outran one.
+      */
+    def startedAt: Long = ackedAt.getOrElse(published.sentTimestamp)
+  }
 
   private def makeKeyForSentMessages(m: Array[Byte]): String =
     Option(m).map(java.util.Base64.getEncoder.encodeToString(_)).getOrElse("")
@@ -71,8 +112,8 @@ class KafkaMessageTracker[K, V](
     responseTransformer: Option[KafkaProtocolMessage => KafkaProtocolMessage],
 ) extends Actor[TrackerMessage](name) with KafkaLogging {
 
-  private val sentMessages     = mutable.HashMap.empty[String, MessagePublished]
-  private val timedOutMessages = mutable.ArrayBuffer.empty[MessagePublished]
+  private val sentMessages     = mutable.HashMap.empty[String, PendingRequest]
+  private val timedOutMessages = mutable.ArrayBuffer.empty[PendingRequest]
 
   /** The periodic timeout scan, once something with a reply timeout has been published.
     *
@@ -91,14 +132,68 @@ class KafkaMessageTracker[K, V](
       })
     }
 
+  /** Reports a matched reply and drops its record, whether or not the acknowledgement has landed yet. */
+  private def completeMatched(
+      key: String,
+      pending: PendingRequest,
+      receivedTimestamp: Long,
+      message: KafkaProtocolMessage,
+  ): Unit = {
+    sentMessages.remove(key)
+    val published = pending.published
+    try
+      processMessage(
+        published.session,
+        pending.startedAt,
+        receivedTimestamp,
+        published.checks,
+        message,
+        published.next,
+        published.requestName,
+      )
+    finally published.onComplete()
+  }
+
   override def init(): Behavior[TrackerMessage] = {
-    // message was sent; add the timestamps to the map
+    // The request is registered here, before it is handed to the producer, so a reply cannot be looked
+    // up before the record for it exists (issue #191). The acknowledgement timestamp is not known yet
+    // and arrives as MessageAcked.
     case messageSent: MessagePublished =>
       val key = makeKeyForSentMessages(messageSent.matchId)
       logger.debug("Published with MatchId: {} Tracking Key: {}", describeBytes(messageSent.matchId), key)
-      sentMessages += key -> messageSent
+      sentMessages += key -> PendingRequest(messageSent)
       if (messageSent.replyTimeout > 0) {
         triggerPeriodicTimeoutScan()
+      }
+      stay
+
+    case MessageAcked(matchId, sentTimestamp) =>
+      val key = makeKeyForSentMessages(matchId)
+      // Only if the request is still pending. A reply that outran its own acknowledgement has already
+      // completed and removed the record, and re-adding it here would leave a record nothing ever
+      // resolves — it would sit until its reply timeout and report a KO for a request that succeeded.
+      sentMessages.get(key).foreach(pending => sentMessages += key -> pending.copy(ackedAt = Some(sentTimestamp)))
+      stay
+
+    case SendFailed(matchId, errorMessage) =>
+      val key = makeKeyForSentMessages(matchId)
+      sentMessages.remove(key).foreach { pending =>
+        val published = pending.published
+        logger.error("Delivery failed for {}: {}", describeBytes(matchId), errorMessage)
+        try
+          executeNext(
+            published.session.markAsFailed,
+            pending.startedAt,
+            clock.nowMillis,
+            KO,
+            published.next,
+            published.requestName,
+            Some("500"),
+            Some(errorMessage),
+          )
+        // Releases the reference acquisition took. Without it the channel never returns to idle and is
+        // never reclaimed, because the request that held it was never completed by any other path.
+        finally published.onComplete()
       }
       stay
 
@@ -125,11 +220,10 @@ class KafkaMessageTracker[K, V](
           message.producerTopic,
           message.consumerTopic,
         )
-        sentMessages.remove(key).foreach {
-          case MessagePublished(_, sentTimestamp, _, checks, session, next, requestName, onComplete) =>
-            try processMessage(session, sentTimestamp, receivedTimestamp, checks, message, next, requestName)
-            finally onComplete()
-        }
+        // Reported as soon as it arrives, whether or not the acknowledgement has landed. A reply that
+        // matches nothing — one for a request already completed or timed out, a duplicate, or
+        // third-party traffic on a held channel — stays silent, as it always has.
+        sentMessages.get(key).foreach(completeMatched(key, _, receivedTimestamp, message))
       }
       stay
 
@@ -138,38 +232,39 @@ class KafkaMessageTracker[K, V](
       logger.error("Consumer failure propagated to tracker: {}", errorMessage)
       val pending = sentMessages.values.toList
       sentMessages.clear()
-      for (mp <- pending) {
+      for (p <- pending) {
         try
           executeNext(
-            mp.session.markAsFailed,
-            mp.sentTimestamp,
+            p.published.session.markAsFailed,
+            p.startedAt,
             now,
             KO,
-            mp.next,
-            mp.requestName,
+            p.published.next,
+            p.published.requestName,
             None,
             Some(s"Consumer failure: $errorMessage"),
           )
-        finally mp.onComplete()
+        finally p.published.onComplete()
       }
       stay
 
     case TimeoutScan =>
       val now = clock.nowMillis
-      sentMessages.valuesIterator.foreach { messagePublished =>
-        val replyTimeout = messagePublished.replyTimeout
-        if (replyTimeout > 0 && (now - messagePublished.sentTimestamp) > replyTimeout) {
-          timedOutMessages += messagePublished
+      sentMessages.valuesIterator.foreach { p =>
+        val replyTimeout = p.published.replyTimeout
+        if (replyTimeout > 0 && (now - p.startedAt) > replyTimeout) {
+          timedOutMessages += p
         }
       }
-      for (mp <- timedOutMessages) {
+      for (p <- timedOutMessages) {
+        val mp       = p.published
         val matchKey = makeKeyForSentMessages(mp.matchId)
         logger.warn("Did not receive match for {} - key: {} after {}ms", describeBytes(mp.matchId), matchKey, mp.replyTimeout)
         sentMessages.remove(matchKey)
         try
           executeNext(
             mp.session.markAsFailed,
-            mp.sentTimestamp,
+            p.startedAt,
             now,
             KO,
             mp.next,

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
@@ -1,17 +1,23 @@
 package org.galaxio.gatling.kafka.client
 
-import io.gatling.commons.stats.KO
+import io.gatling.commons.stats.{KO, OK, Status}
 import io.gatling.commons.util.Clock
 import io.gatling.core.action.Action
 import io.gatling.core.actor.{Actor, ActorSystem}
 import io.gatling.core.session.Session
 import io.gatling.core.stats.RecordingStatsEngine
-import org.galaxio.gatling.kafka.client.KafkaMessageTracker.{ConsumerFailure, MessageConsumed, MessagePublished}
+import org.galaxio.gatling.kafka.client.KafkaMessageTracker.{
+  ConsumerFailure,
+  MessageAcked,
+  MessageConsumed,
+  MessagePublished,
+  SendFailed,
+}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
 class KafkaMessageTrackerSpec extends munit.FunSuite {
 
@@ -163,6 +169,129 @@ class KafkaMessageTrackerSpec extends munit.FunSuite {
       assert(!scanIsArmed(tracker), "an unarmed tracker must still be unarmed after Stop")
       assertEquals(statsEngine.responses.get().size, 0, "stopping an unarmed tracker must not report anything")
     }
+  }
+
+  // Issue #191. Registration now happens before the send, so a reply and its own acknowledgement can
+  // arrive in either order. These drive the behaviour directly, which is deterministic — the broker-level
+  // race is covered by ReplyRegistrationRaceSpec.
+  private def replyFor(key: String): MessageConsumed =
+    MessageConsumed(
+      received = 5_000L,
+      message = KafkaProtocolMessage(
+        key = key.getBytes(StandardCharsets.UTF_8),
+        value = "reply".getBytes(StandardCharsets.UTF_8),
+        producerTopic = "reply-topic",
+        consumerTopic = "reply-topic",
+      ),
+    )
+
+  private def published(next: Action, replyTimeout: Long, requestStart: Long): MessagePublished =
+    MessagePublished(
+      matchId = "match-race".getBytes(StandardCharsets.UTF_8),
+      sentTimestamp = requestStart,
+      replyTimeout = replyTimeout,
+      checks = Nil,
+      session = Session("scenario", 1L, null),
+      next = next,
+      requestName = "request-reply",
+    )
+
+  test("a reply arriving before its own acknowledgement is reported at once, not held") {
+    val statsEngine = new RecordingStatsEngine
+    val next        = new RecordingAction("next")
+    val tracker     =
+      new KafkaMessageTracker[Array[Byte], Array[Byte]]("tracker", statsEngine, new StubClock(9_000L), KafkaKeyMatcher, None)
+    val behavior    = tracker.init()
+
+    // The order this feature exists for: registered, answered, and only then acknowledged. Before the
+    // fix the request was not registered until the acknowledgement, so the reply found nothing and was
+    // dropped — the request then failed on its reply timeout with no sign a reply had ever arrived.
+    behavior(published(next, replyTimeout = 0L, requestStart = 1_000L))
+    behavior(replyFor("match-race"))
+
+    val responses = statsEngine.responses.get()
+    assertEquals(responses.size, 1, "a reply that arrived must be reported, never withheld pending another message")
+    assertEquals(responses.head.status, (OK: Status))
+    assertEquals(
+      responses.head.startTimestamp,
+      1_000L,
+      "with no acknowledgement yet, the request's own start is used rather than losing the reply",
+    )
+    assertEquals(responses.head.endTimestamp, 5_000L)
+
+    // The acknowledgement arrives for a request that is already complete. It must not resurrect the
+    // record, or nothing would ever resolve it and it would report a second, spurious timeout.
+    behavior(MessageAcked("match-race".getBytes(StandardCharsets.UTF_8), sentTimestamp = 2_000L))
+    assertEquals(statsEngine.responses.get().size, 1, "a late acknowledgement must not re-register a completed request")
+  }
+
+  test("a reply arriving after its acknowledgement is reported immediately, from the acknowledgement") {
+    val statsEngine = new RecordingStatsEngine
+    val next        = new RecordingAction("next")
+    val tracker     =
+      new KafkaMessageTracker[Array[Byte], Array[Byte]]("tracker", statsEngine, new StubClock(9_000L), KafkaKeyMatcher, None)
+    val behavior    = tracker.init()
+
+    behavior(published(next, replyTimeout = 0L, requestStart = 1_000L))
+    behavior(MessageAcked("match-race".getBytes(StandardCharsets.UTF_8), sentTimestamp = 2_000L))
+    behavior(replyFor("match-race"))
+
+    val responses = statsEngine.responses.get()
+    assertEquals(responses.size, 1)
+    assertEquals(responses.head.status, (OK: Status))
+    assertEquals(responses.head.startTimestamp, 2_000L)
+    assertEquals(responses.head.endTimestamp, 5_000L)
+  }
+
+  test("a request whose acknowledgement never arrives still times out, measured from its start") {
+    // Needs an ActorSystem: a positive reply timeout arms the periodic scan, which touches `scheduler`.
+    withActorSystem { actorSystem =>
+      val statsEngine = new RecordingStatsEngine
+      val next        = new RecordingAction("next")
+      val ref         = actorSystem.actorOf(
+        KafkaMessageTracker
+          .actor[Array[Byte], Array[Byte]]("tracker", statsEngine, new StubClock(9_000L), KafkaKeyMatcher, None),
+      )
+
+      // Registered at 1_000 with a 5 s timeout and never acknowledged; the clock is at 9_000. Measuring
+      // from the acknowledgement would leave this pending forever, because there is none.
+      ref ! published(next, replyTimeout = 5_000L, requestStart = 1_000L)
+      ref ! KafkaMessageTracker.TimeoutScan
+      Thread.sleep(500)
+
+      val responses = statsEngine.responses.get()
+      assertEquals(responses.size, 1, "a request stuck without an acknowledgement must still time out")
+      assertEquals(responses.head.status, (KO: Status))
+      assertEquals(responses.head.startTimestamp, 1_000L)
+      assertEquals(responses.head.message, Some("Reply timeout after 5000 ms"))
+    }
+  }
+
+  test("a delivery failure removes the pending request, reports KO, and releases the channel once") {
+    val statsEngine = new RecordingStatsEngine
+    val next        = new RecordingAction("next")
+    val released    = new AtomicInteger(0)
+    val tracker     =
+      new KafkaMessageTracker[Array[Byte], Array[Byte]]("tracker", statsEngine, new StubClock(4_000L), KafkaKeyMatcher, None)
+    val behavior    = tracker.init()
+
+    behavior(
+      published(next, replyTimeout = 0L, requestStart = 1_000L)
+        .copy(onComplete = () => { released.incrementAndGet(); () }),
+    )
+    behavior(SendFailed("match-race".getBytes(StandardCharsets.UTF_8), "Broker unavailable"))
+
+    val responses = statsEngine.responses.get()
+    assertEquals(responses.size, 1)
+    assertEquals(responses.head.status, (KO: Status))
+    assertEquals(responses.head.startTimestamp, 1_000L, "a failed request spans its start to failure detection")
+    assertEquals(responses.head.endTimestamp, 4_000L)
+    assertEquals(responses.head.message, Some("Broker unavailable"))
+    assertEquals(released.get(), 1, "the channel reference acquisition took must be released exactly once")
+
+    // The record is gone, so a late reply for it matches nothing and stays silent.
+    behavior(replyFor("match-race"))
+    assertEquals(statsEngine.responses.get().size, 1, "a reply for a failed send must not be reported")
   }
 
   private final class StubClock(now: Long) extends Clock {

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaConcurrencyLoadTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaConcurrencyLoadTest.scala
@@ -34,28 +34,21 @@ class KafkaConcurrencyLoadTest extends Simulation {
   private val scenarioLoops = rampDuration + sustainFor + 15.seconds // outlasts the injection window
   private val probeMarker   = "_probe"
 
-  /** Known-loss budget: deliberately not zero, and now a **count** rather than a percentage.
+  /** Reply-loss budget: **zero**, now that every known source of loss is closed.
     *
-    * A reply can still be dropped while its own request is being registered: `MessagePublished` and `MessageConsumed` reach the
-    * tracker's mailbox from two different threads with no ordering between them, so a round-trip of a few milliseconds can be
-    * processed before the request it answers — see [[https://github.com/galax-io/gatling-kafka-plugin/issues/191 #191]]. That
-    * race is now the only source of loss here.
+    * The last one was [[https://github.com/galax-io/gatling-kafka-plugin/issues/191 #191]]: the pending record was created from
+    * the producer's acknowledgement callback, i.e. after the request was already answerable, so a fast responder's reply could
+    * be delivered before the request it answers had registered and be discarded silently. Registering before the send removed
+    * it structurally — a reply cannot exist before the send, and the mailbox preserves enqueue order across threads.
     *
-    * Measured against a local broker on this code, five runs: **0, 1, 1, 0 and 1 KO of ~6,760** (0–0.0148%). Before
-    * [[https://github.com/galax-io/gatling-kafka-plugin/issues/165 #165]] the same simulation lost 14–16 KO of ~6,500
-    * (0.2135–0.2470%): the tracker entry was dropped at refcount zero after every reply, and each re-registration re-armed the
-    * next loss. Holding the registration for the whole run removed that amplifier, leaving #191 on its own. Before #163 it lost
-    * ~1.4% (38 KO of 2,724, of which 7 were assignment timeouts that #163 removed outright).
-    *
-    * A count rather than a percentage because the losses are time-driven, not rate-driven — roughly one per reply-timeout
-    * cycle, so a run loses a near-fixed count whatever its throughput, and a slower machine would report a *higher* percentage
-    * for the same defect. This is the count-based ceiling the previous percentage budget recommended switching to.
-    *
-    * Headroom is one loss above the worst measured run — thin on purpose, so a regression surfaces instead of being absorbed.
-    * At the rate above that is roughly a 2% chance of a spurious red, which is the deliberate trade: this harness is run
-    * manually, not in CI, and a red run is meant to prompt a look. Tighten to 0 once #191 lands.
+    * The history this budget tracked, for context. Before [[https://github.com/galax-io/gatling-kafka-plugin/issues/163 #163]]:
+    * ~1.4% (38 KO of 2,724, of which 7 were assignment timeouts #163 removed outright). Before
+    * [[https://github.com/galax-io/gatling-kafka-plugin/issues/165 #165]]: 14–16 KO of ~6,500, because the tracker entry was
+    * dropped at refcount zero after every reply and each re-registration re-armed the next loss. After #165 and before #191:
+    * 0–2 KO of ~6,760 across five runs. After #191: zero, and anything above it is a regression rather than a known defect
+    * being absorbed.
     */
-  private val KnownReplyLossBudget: Long = 2
+  private val KnownReplyLossBudget: Long = 0
 
   // Stand-in for the external service under test: echoes every request straight back on the reply
   // topic with the same key and value, so the default key-based matcher (KafkaKeyMatcher) pairs each

--- a/src/test/scala/org/galaxio/gatling/kafka/integration/ReplyRegistrationRaceSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/ReplyRegistrationRaceSpec.scala
@@ -1,0 +1,201 @@
+package org.galaxio.gatling.kafka.integration
+
+import com.dimafeng.testcontainers.ConfluentKafkaContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import io.gatling.commons.stats.{OK, Status}
+import io.gatling.commons.util.Clock
+import io.gatling.commons.validation._
+import io.gatling.core.CoreComponents
+import io.gatling.core.action.Action
+import io.gatling.core.actor.ActorSystem
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.session.Session
+import io.gatling.core.stats.{LoggedResponse, RecordingStatsEngine}
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, Serdes}
+import org.galaxio.gatling.kafka.actions.KafkaRequestReplyAction
+import org.galaxio.gatling.kafka.client.{DynamicKafkaConsumer, KafkaMessageTrackerPool, KafkaSender}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher
+import org.galaxio.gatling.kafka.protocol.{KafkaComponents, KafkaProtocol}
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.KafkaAttributes
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.jdk.CollectionConverters._
+
+/** Regression coverage for issue #191 — a reply must never be dropped because it arrived before its own request finished
+  * registering.
+  *
+  * The defect was an ordering one, not a concurrency one. The pending record used to be created from the producer's
+  * acknowledgement callback, i.e. *after* the request was already on the wire and answerable. A responder that answers in under
+  * a millisecond can therefore have its reply polled and delivered before that callback has run, at which point the reply
+  * matches nothing, is discarded silently, and the request fails on its reply timeout — indistinguishable from a system under
+  * test that never answered.
+  *
+  * This forces the condition rather than waiting for it: the responder echoes immediately, the reply timeout is generous, and
+  * enough requests are issued that the window is hit repeatedly. Every request is answered, so any reply-timeout failure is
+  * this bug and nothing else.
+  */
+class ReplyRegistrationRaceSpec extends munit.FunSuite with TestContainerForAll {
+
+  override val containerDef: ConfluentKafkaContainer.Def = ConfluentKafkaContainer.Def()
+
+  override def munitTimeout: scala.concurrent.duration.Duration = 5.minutes
+
+  private val RequestTopic = "race-request"
+  private val ReplyTopic   = "race-reply"
+
+  /** Generous on purpose: the point is that nothing times out, so a timeout means a lost reply rather than a slow broker. */
+  private val ReplyTimeout: FiniteDuration = 30.seconds
+
+  private val Requests = 60
+
+  private def producerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ProducerConfig.ACKS_CONFIG                   -> "1",
+    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> bootstrap,
+    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> classOf[ByteArraySerializer].getName,
+    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[ByteArraySerializer].getName,
+  )
+
+  private def consumerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG        -> bootstrap,
+    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
+  )
+
+  private def createTopics(bootstrap: String, names: String*): Unit = {
+    val admin = AdminClient.create(
+      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrap).asJava,
+    )
+    try admin.createTopics(names.map(new NewTopic(_, 1, 1.toShort)).asJava).all().get(30, TimeUnit.SECONDS)
+    finally admin.close()
+  }
+
+  private final class SystemClock extends Clock {
+    override def nowMillis: Long = System.currentTimeMillis()
+  }
+
+  private final class CountingAction extends Action {
+    private val count = new AtomicInteger(0)
+
+    override def name: String                    = "counting-next"
+    override def !(session: Session): Unit       = execute(session)
+    override def execute(session: Session): Unit = { count.incrementAndGet(); () }
+
+    def completed: Int = count.get()
+  }
+
+  private def attributes: KafkaAttributes[Array[Byte], Array[Byte]] =
+    KafkaAttributes[Array[Byte], Array[Byte]](
+      requestName = _ => "request-reply".success,
+      producerTopic = None,
+      consumerTopic = None,
+      key = None,
+      value = _ => Array.emptyByteArray.success,
+      headers = None,
+      keySerde = None,
+      valueSerde = Serdes.ByteArray(),
+      checks = Nil,
+    )
+
+  test("every reply is matched, even when it arrives before its own request has finished registering") {
+    withContainers { kafka =>
+      val bootstrap = kafka.bootstrapServers
+      createTopics(bootstrap, RequestTopic, ReplyTopic)
+
+      val actorSystem = new ActorSystem()
+      val statsEngine = new RecordingStatsEngine
+      val clock       = new SystemClock
+      val sender      = KafkaSender(producerSettings(bootstrap))
+      val next        = new CountingAction
+
+      // Echoes key and value straight back, with no delay at all. That immediacy is the whole point: a
+      // responder that answered slowly would never reach the window this test exists to cover.
+      val echoSender      = KafkaSender(producerSettings(bootstrap))
+      val echoReady       = new CountDownLatch(1)
+      val responder       = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+        consumerSettings(bootstrap) + (ConsumerConfig.GROUP_ID_CONFIG -> "race-responder"),
+        Set(RequestTopic),
+        record => {
+          echoReady.countDown()
+          echoSender.send(KafkaProtocolMessage(record.key(), record.value(), ReplyTopic, ReplyTopic))(
+            _ => (),
+            error => println(s"[race responder] failed to echo: $error"),
+          )
+        },
+        error => println(s"[race responder] consumer failed: $error"),
+      )
+      val responderThread = new Thread(responder, "race-responder")
+      responderThread.setDaemon(true)
+      responderThread.start()
+
+      try {
+        val pool = new KafkaMessageTrackerPool(consumerSettings(bootstrap), actorSystem, statsEngine, clock)
+
+        val protocol = KafkaProtocol(
+          producerProperties = producerSettings(bootstrap),
+          consumerProperties = consumerSettings(bootstrap),
+          timeout = ReplyTimeout,
+          messageMatcher = KafkaKeyMatcher,
+        )
+
+        val coreComponents =
+          new CoreComponents(actorSystem, null, null, None, statsEngine, clock, null, GatlingConfiguration.loadForTest())
+
+        val action = new KafkaRequestReplyAction[Array[Byte], Array[Byte]](
+          KafkaComponents(coreComponents, protocol, Some(pool), sender),
+          attributes,
+          coreComponents,
+          next,
+          None,
+        )
+
+        // Wait for the responder to be positioned before measuring, so a skipped first echo is not
+        // mistaken for a dropped reply.
+        val warmup = KafkaProtocolMessage("warmup".getBytes, "warmup".getBytes, RequestTopic, ReplyTopic)
+        val sent   = new CountDownLatch(1)
+        sender.send(warmup)(_ => sent.countDown(), _ => sent.countDown())
+        assert(sent.await(30, TimeUnit.SECONDS), "warmup request was never delivered")
+        assert(echoReady.await(60, TimeUnit.SECONDS), "responder never received anything")
+
+        (1 to Requests).foreach { i =>
+          action.sendKafkaMessage(
+            "request-reply",
+            KafkaProtocolMessage(s"race-$i".getBytes, s"body-$i".getBytes, RequestTopic, ReplyTopic),
+            Session("scenario", i.toLong, null),
+          )
+        }
+
+        val deadline = System.currentTimeMillis() + ReplyTimeout.toMillis + 60000
+        while (statsEngine.responses.get().size < Requests && System.currentTimeMillis() < deadline)
+          Thread.sleep(100)
+
+        val responses: Vector[LoggedResponse] = statsEngine.responses.get()
+        assertEquals(responses.size, Requests, s"only ${responses.size} of $Requests requests reported an outcome")
+
+        val timedOut = responses.filter(_.message.exists(_.startsWith("Reply timeout")))
+        assertEquals(
+          timedOut.size,
+          0,
+          s"${timedOut.size} of $Requests replies were lost: the responder answered every request, so a reply " +
+            "timeout here means the reply arrived before its request had registered and was discarded",
+        )
+        assert(
+          responses.forall(_.status == (OK: Status)),
+          s"unexpected failures: ${responses.filterNot(_.status == (OK: Status)).map(_.message)}",
+        )
+        assertEquals(next.completed, Requests, "every virtual user must be advanced exactly once")
+      } finally {
+        responder.close()
+        echoSender.close()
+        sender.close()
+        actorSystem.close()
+      }
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/integration/TrackerLifetimeSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/TrackerLifetimeSpec.scala
@@ -228,13 +228,6 @@ class TrackerLifetimeSpec extends munit.FunSuite with TestContainerForAll {
     assert(latch.await(30, TimeUnit.SECONDS), s"producing onto $topic never completed")
   }
 
-  /** Sends one request and drives it to a logged response, returning the wall-clock time it took.
-    *
-    * The reply is re-published while waiting. That is not impatience: a reply which arrives before its own request finishes
-    * registering is dropped silently (issue #191, out of scope here), and on a first use the registration can be a full
-    * assignment stall away. Re-publishing keeps these tests measuring channel lifetime instead of that unrelated race, and it
-    * costs nothing — a reply that matches no pending request is discarded, which is exactly what FR-008 requires.
-    */
   private def send(run: Run, name: String, requestTopic: String, replyTopic: String, key: String): Unit =
     run.action.sendKafkaMessage(name, message(requestTopic, replyTopic, key), session)
 
@@ -257,6 +250,17 @@ class TrackerLifetimeSpec extends munit.FunSuite with TestContainerForAll {
     found
   }
 
+  /** Re-publishes the reply until the request is reported.
+    *
+    * A property of the harness, not a workaround for a product defect. There is no responder here, and `send` returns as soon
+    * as the request is handed off — the request itself is only published once the reply channel has been established, which on
+    * a first use is a full assignment stall away. A reply produced before that has nothing subscribed to receive it and is
+    * simply never delivered, however correct the plugin is.
+    *
+    * It used to cover for issue #191 as well, where a reply arriving before its own request finished registering was dropped
+    * silently. That half is gone: registration now precedes the send, so a reply produced after the channel exists is always
+    * matched.
+    */
   private def driveReply(
       run: Run,
       name: String,


### PR DESCRIPTION
Closes #191

Stacked on #200 (#166).

## ⚠️ Behaviour change — approved before implementation

**When acquiring the reply channel fails, the request is now reported as a failure without being published.** Previously it was sent first and the channel acquired afterwards, so a failed acquisition still delivered the message to the broker before reporting KO.

- Gatling-visible results are **unchanged**: same KO, same message text, same response-time span.
- What changes is that your system under test no longer receives a request whose reply the plugin could never have matched.

There is no ordering that both registers before the send and still publishes on acquisition failure — and publishing a request whose reply can never be received is the state #143 exists to prevent from the other direction. Recorded in the README Migration Guide under v1.1.0. Raised and approved before implementation per Constitution Principle I.

## The defect

The pending record was created from the producer's acknowledgement callback — **after** the request was already on the wire and answerable. Under load that callback can run after a fast responder's reply has been polled and broadcast, so the reply matched nothing, was discarded silently, and the request failed on its reply timeout: indistinguishable from a system under test that never answered.

## The finding that made this small

The defect is **ordering, not concurrency**. Gatling's mailbox is a JCTools MPSC queue that preserves enqueue order across producer threads, so registering before the send replaces the race with a causal chain:

```
register -> produce -> broker -> responder -> consume -> deliver
```

A reply cannot exist before the send, so it can never be processed before the request it answers. **No concurrent correlation table is needed and `acquireTracker` keeps its signature** — worth noting against #193, which lists its point 3 as part of this fix.

## Measured

| | Requests | Replies lost |
|---|---|---|
| Before | 60 | 59-60 |
| After | 60 | **0** |

Load harness (`KafkaConcurrencyLoadTest`), five consecutive runs after the fix: **33,889 requests, 0 KO**. Its `KnownReplyLossBudget` drops from 2 to 0, so any loss now fails the run.

## Measurement semantics preserved

`MessageAcked` carries the acknowledgement timestamp, so a successful request-reply is still measured from the acknowledgement and reported percentiles do not move. Moving the clock is #170 / #193's decision and needs its own migration entry — deliberately not done here.

`SendFailed` un-registers a request the producer could not deliver and releases the channel reference acquisition took, which would otherwise never return to idle.

## One design decision reversed mid-implementation

An earlier draft **held** a reply until its acknowledgement arrived, to guarantee the ack-based clock. `TrackerAcquisitionIsolationSpec` showed why that is wrong: it registers a request and never acknowledges it, so the reply was held forever and the request timed out despite having been answered — the exact failure class this PR removes, reintroduced by its own fix.

Replies are now reported on arrival, falling back to the request's own start. That is at most one produce acknowledgement early, and only for a reply that outran one — a bounded, conservative error, where holding risked losing the reply outright.

## Verification

- `KafkaMessageTrackerSpec` — 4 new tests: reply-before-ack, reply-after-ack, timeout without an ack, and delivery failure releasing the channel exactly once.
- `ReplyRegistrationRaceSpec` (new, Testcontainers) — forces the race with an immediate echo responder. Red 59-60/60, green 0/60.
- `TrackerLifetimeSpec`'s reply loop was planned for removal and **kept**: it had two jobs and only one was #191. The other — the harness publishes replies before the request is actually sent — still applies. Comment corrected.

`sbt scalafmtCheckAll scalafmtSbtCheck compile test` green — 54 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
