### PR TITLE
chore(ci): add Dependabot for GitHub Actions and Docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    commit-message:
+      prefix: "chore"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the two ecosystems Scala Steward doesn't reach: `github-actions` (pinned versions in `.github/workflows/`) and `docker` (Confluent image tags in `docker-compose.kafka.yml`)
- Weekly on Wednesdays, each ecosystem grouped into a single PR, to avoid piling onto Scala Steward's Sunday run

## Test plan
- [x] N/A — config-only change, picked up by GitHub automatically once merged to the default branch