### PR TITLE
fix(build): unbreak the release by fixing an unresolvable scaladoc link (#206)

### DIFF
--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerPool.scala
@@ -418,8 +418,8 @@ final class KafkaMessageTrackerPool(
 
   /** Records that one request has finished with this channel.
     *
-    * Reaching zero starts the idle clock; it does not release anything. See [[TrackerEntry]] for why the two are not the same
-    * event. Releasing happens in [[sweepIdleTrackers]], off the request path entirely.
+    * Reaching zero starts the idle clock; it does not release anything. See `TrackerEntry` for why the two are not the same
+    * event. Releasing happens in `sweepIdleTrackers`, off the request path entirely.
     */
   def releaseTracker(consumerTopic: String, messageMatcher: KafkaMatcher): Unit = {
     val mRef = new MatcherRef(messageMatcher)


### PR DESCRIPTION
`sbt ci-release` fails during `Compile / doc`, before any artifact reaches Sonatype. The
`v1.1.0` tag hit it: [run 30961046047](https://github.com/galax-io/gatling-kafka-plugin/actions/runs/30961046047).

```
KafkaMessageTrackerPool.scala:419:3: Could not find any member to link for "TrackerEntry".
[error] Scaladoc generation failed
```

`releaseTracker` is public, so Scaladoc generates its page and resolves every `[[...]]` in
its comment. `TrackerEntry` is a `private case class` and absent from the generated docs,
so the link cannot resolve; `-Xfatal-warnings` promotes the warning to an error.
`[[sweepIdleTrackers]]` is `private[client]` and equally unreachable, so it gets the same
treatment rather than failing the next release.

Nothing in the normal build runs `doc`, which is why `main` stayed green while every
release was broken.

**Verified:** `sbt scalafmtCheckAll scalafmtSbtCheck doc` is clean on this branch; it fails
on `main` with the error above.

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)