### PR TITLE
v1.2.0 Reply correlation correctness: keyless correlation, tombstone replies, positioned readiness (#167, #168, #193)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,10 @@ jobs:
           KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
           # Must stay in step with docker-compose.kafka.yml's topic-init: this is a separate broker
           # definition, so a topic added there is NOT created here. myTopic5/test.t5 serve the keyless
-          # request-reply scenarios (#167); load.request/load.reply are KafkaConcurrencyLoadTest's, which
-          # previously relied on broker auto-create.
-          KAFKA_CREATE_TOPICS: "myTopic1:1:1, test.t1:1:1, myTopic2:1:1, test.t2:1:1, myTopic3:1:1, test.t3:1:1, myTopic4:1:1, myTopic5:1:1, test.t5:1:1, load.request:1:1, load.reply:1:1"
+          # request-reply scenarios (#167), myTopic6/test.t6 the tombstone one (#168), and
+          # load.request/load.reply are KafkaConcurrencyLoadTest's, which previously relied on
+          # broker auto-create.
+          KAFKA_CREATE_TOPICS: "myTopic1:1:1, test.t1:1:1, myTopic2:1:1, test.t2:1:1, myTopic3:1:1, test.t3:1:1, myTopic4:1:1, myTopic5:1:1, test.t5:1:1, myTopic6:1:1, test.t6:1:1, load.request:1:1, load.reply:1:1"
         ports:
           - '9092:9092'
           - '9093:9093'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,11 @@ jobs:
           KAFKA_INTER_BROKER_LISTENER_NAME: BROKER
           KAFKA_BROKER_ID: "1"
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-          # Mirrors docker-compose.kafka.yml. Kept at 0 to keep the simulations quick, but no longer
-          # required: KafkaGatlingTest's replies now come from a real echo responder (#196) and its
-          # reply channel is established before the request is sent (#191), so an immediate reply is
-          # received whatever the delay. Verified green over three runs with Kafka's 3000 default.
-          # This is the only setting the two stacks agree on — broker and Schema Registry generations
-          # still differ; consolidating them is issue #192.
-          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
+          # group.initial.rebalance.delay.ms is deliberately left at Kafka's default, matching
+          # docker-compose.kafka.yml. It was pinned to 0 while reply-channel readiness completed on
+          # assignment alone (issue #193); with the fetch position now resolved before readiness
+          # completes, CI runs on the same setting a real target system would.
+          #
           # Must stay in step with docker-compose.kafka.yml's topic-init: this is a separate broker
           # definition, so a topic added there is NOT created here. myTopic5/test.t5 serve the keyless
           # request-reply scenarios (#167), myTopic6/test.t6 the tombstone one (#168), and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,11 @@ jobs:
           # This is the only setting the two stacks agree on — broker and Schema Registry generations
           # still differ; consolidating them is issue #192.
           KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
-          KAFKA_CREATE_TOPICS: "myTopic1:1:1, test.t1:1:1, myTopic2:1:1, test.t2:1:1, myTopic3:1:1, test.t3:1:1, myTopic4:1:1"
+          # Must stay in step with docker-compose.kafka.yml's topic-init: this is a separate broker
+          # definition, so a topic added there is NOT created here. myTopic5/test.t5 serve the keyless
+          # request-reply scenarios (#167); load.request/load.reply are KafkaConcurrencyLoadTest's, which
+          # previously relied on broker auto-create.
+          KAFKA_CREATE_TOPICS: "myTopic1:1:1, test.t1:1:1, myTopic2:1:1, test.t2:1:1, myTopic3:1:1, test.t3:1:1, myTopic4:1:1, myTopic5:1:1, test.t5:1:1, load.request:1:1, load.reply:1:1"
         ports:
           - '9092:9092'
           - '9093:9093'
@@ -106,8 +110,12 @@ jobs:
       - name: Smoke test examples
         run: sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"
 
+      # KafkaConcurrencyLoadTest is the only *sustained* concurrent request-reply coverage: 30 virtual
+      # users held for 100 s with a zero reply-loss budget, so any loss fails the build (issue #167).
+      # KafkaGatlingTest's keyless scenarios inject a handful of concurrent users, which is enough to
+      # observe cross-attribution but not to hold load.
       - name: Test (Gatling targeted)
-        run: sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport
+        run: sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaConcurrencyLoadTest" test coverageOff coverageReport
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/003-request-reply-hardening"
+  "feature_directory": "specs/004-reply-correlation-correctness"
 }

--- a/README.md
+++ b/README.md
@@ -467,9 +467,8 @@ Use this section as release-based upgrade notes. Start from the version you are 
 
 ### Upgrading to `1.2.0`
 
-No changes to the DSL, the `javaapi` facade or protocol settings — nothing you have written stops compiling. There is one
-change at the record level, and two behavioural changes follow from it: a message with no key is now published with **no key**
-rather than with an empty one. Read both sections below before upgrading; the second can turn a passing scenario red.
+No changes to the DSL, the `javaapi` facade or protocol settings — nothing you have written stops compiling. Three
+behavioural changes, and two of them can turn a passing scenario red, so read the sections below before upgrading.
 
 #### A request-reply with no key is now failed instead of mismatched
 
@@ -500,6 +499,25 @@ val protocol = kafka
 ```
 
 Request-reply that already sets a key, or that uses `matchByValue` / `matchByMessage`, is unaffected.
+
+#### A reply with no payload now fails the request instead of losing the virtual user
+
+A reply can arrive with no payload at all — a tombstone on a compacted topic, or an acknowledgement carrying no body. Applying
+a content check to one (`bodyString`, `substring`, `bodyBytes`, `jsonPath`, `jmesPath`) used to throw inside the reply-handling
+path, which had nothing to catch it. The virtual user was **never continued**: no success, no failure, no next request. It
+simply stopped, and the run's user count silently diverged from the load the profile was applying.
+
+Such a check now reports the request as a failure naming the absent payload, and the virtual user carries on.
+
+- **Expect new KOs on any target that answers with tombstones.** Those requests were previously unreported — the run looked
+  cleaner than it was, while quietly shedding load.
+- **Expect the run to finish with the number of users it started with.** If your achieved throughput used to drift below the
+  configured rate for no visible reason, this is a candidate cause.
+- An **empty** payload is unchanged: it is a value, not an absence. `bodyString.is("")` still passes on an empty reply and now
+  fails on a tombstone — "the service sent nothing" and "the service sent an empty string" are different findings.
+
+Independently of the checks above, **no check can strand a virtual user any more**: one that throws for any reason is reported
+as a failure and the user continues.
 
 #### A message with no key is now published with no key
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,12 @@ import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 def correlationIdFromHeader(headerName: String): KafkaProtocolMessage => Array[Byte] =
   _.headers
     .flatMap(headers => Option(headers.lastHeader(headerName)).map(_.value()))
-    .getOrElse(Array.emptyByteArray)
+    .orNull
+```
+
+> **Return `null`, not `Array.emptyByteArray`, when the field is missing.** An empty array is a *value*: every request missing
+> the header would produce the same correlation id, they would all share one slot, and replies would be matched to the wrong
+> virtual user. Returning `null` makes the plugin fail those requests immediately with a message naming the cause.
 
 ## Runtime Semantics & Troubleshooting
 
@@ -459,6 +464,78 @@ Use this section as release-based upgrade notes. Start from the version you are 
 | `0.20.3` | `1.0.x` | Move from Gatling `3.11.5` to `3.13.x`, update request-reply consumer settings, re-check examples against current README. |
 | `0.21.x` | `1.0.x` | Stay on Gatling `3.13.x`, review request-reply defaults and DSL surface. |
 | `0.20.x` or older | `1.0.x` | Treat as full doc refresh. Older consume-only or per-action matcher APIs are not present. |
+
+### Upgrading to `1.2.0`
+
+No changes to the DSL, the `javaapi` facade or protocol settings — nothing you have written stops compiling. There is one
+change at the record level, and two behavioural changes follow from it: a message with no key is now published with **no key**
+rather than with an empty one. Read both sections below before upgrading; the second can turn a passing scenario red.
+
+#### A request-reply with no key is now failed instead of mismatched
+
+A request with no key produced an empty correlation id — and so did every other keyless request. They shared a single slot in
+the correlation table, so a reply resolved whichever request happened to occupy it: one virtual user was credited with another
+user's answer while the real owner timed out. Nothing in the report distinguished that from a genuine result.
+
+Under the default `matchByKey` there is nothing to correlate a keyless reply on, so such a request is now **reported as a
+failure at issue time and is not published**. The failure names the matcher and the remedy.
+
+**If a request-reply scenario of yours has no key, it will now go red.** Those runs were reporting incorrect results before;
+the change surfaces that rather than causing it. Two ways forward, depending on what the request actually correlates on:
+
+```scala
+// Give each request a key to correlate on
+kafka("req").requestReply
+  .requestTopic("in").replyTopic("out")
+  .send[String, String]("#{correlationId}", "payload")
+```
+
+```scala
+// Or correlate on something the request already carries
+val protocol = kafka
+  .producerSettings(...)
+  .consumeSettings(...)
+  .matchByValue                       // the payload itself
+// .matchByMessage(msg => ...)        // or a header / any extracted field
+```
+
+Request-reply that already sets a key, or that uses `matchByValue` / `matchByMessage`, is unaffected.
+
+#### A message with no key is now published with no key
+
+The plugin was substituting an empty byte array for an absent key, which is not the same thing: an empty key is a *present*
+key. Kafka hashes it, and `murmur2` of an empty input is a constant — so **every keyless message landed on the same partition
+for the whole run**, no matter how long the run was or how many partitions the topic had. This applied to fire-and-forget
+sends as well as request-reply.
+
+Keyless messages now reach the broker with a genuinely absent key, so Kafka applies its normal keyless partitioning instead of
+hashing a constant.
+
+- **Expect throughput, partition-lag and consumer-group numbers for keyless scenarios to move**, in either direction. The
+  earlier figures described a single-partition workload, which is not what those scenarios were written to measure.
+- Exactly how records are spread is Kafka's decision and depends on your broker and client version — current clients batch
+  keyless records stickily rather than round-robin, so a short run may still concentrate them. What changed here is that
+  spreading becomes possible at all.
+- Messages that carry a key are unaffected: placement is still `hash(key) % partitions`, so per-key ordering guarantees hold.
+- Immediate rejections (the section above) are reported with a near-zero response time, because that is how long they take.
+  If you assert on `global.responseTime` percentiles, note that a run rejecting every request will *lower* them; assert on
+  `failedRequests`/`successfulRequests` to catch that case.
+
+> ### ⚠️ Keyless sends to a log-compacted topic now fail
+>
+> A compacted topic (`cleanup.policy=compact`) requires every record to have a key, and Kafka treats an **empty** key as
+> present but a **null** key as absent. The old empty-array substitution therefore slipped past that check; a genuinely absent
+> key does not.
+>
+> A scenario that publishes keyless records — request-reply or fire-and-forget — to a compacted topic goes from passing to
+> **every request failing**, with `InvalidRecordException: Compacted topic cannot accept message without key`.
+>
+> This is the broker enforcing a rule the plugin was previously hiding: those records were never valid on that topic. Give the
+> send a key:
+>
+> ```scala
+> kafka("req").topic("compacted-topic").send[String, String]("#{entityId}", "payload")
+> ```
 
 ### Upgrading to `1.1.0`
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,22 @@ lazy val root = (project in file("."))
     ),
   )
 
+// Every spec under `integration/` starts its own single-node Kafka through Testcontainers, and sbt
+// runs suites in parallel by default — so the peak broker count is the suite count, not anything the
+// machine agreed to. This feature adds two such specs, and at seven the suite reliably outruns a
+// laptop-sized Docker daemon: KafkaIntegrationSpec, TrackerAcquisitionIsolationSpec and
+// TrackerLifetimeSpec all died on `Timed out waiting for log output ... RECOVERY to RUNNING`, and all
+// three passed on a re-run with nothing else contending (KafkaIntegrationSpec: 32 s alone, timed out
+// at ~100 s under contention). A red suite that has nothing to do with the code under test is worse
+// than a slower one — here it cost about a minute of wall clock.
+//
+// Set with the first spec this feature adds rather than the last, so no commit in the series is left
+// running an unbounded suite. The deep fix is one shared broker across the integration specs instead
+// of one per suite; that is a refactor of seven files and does not belong in a correctness feature.
+// This bounds the damage in one line and keeps the unit specs — which vastly outnumber them —
+// running in parallel.
+Global / concurrentRestrictions += Tags.limit(Tags.Test, 2)
+
 Gatling / javaOptions := overrideDefaultJavaOptions(
   "--add-opens=java.base/java.util=ALL-UNNAMED",
   "--add-opens=java.base/java.lang=ALL-UNNAMED",

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -67,6 +67,8 @@ services:
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic4 --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic5 --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic test.t5 --partitions 1 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic6 --partitions 1 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic test.t6 --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic load.request --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic load.reply --partitions 1 --replication-factor 1
       "

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -22,16 +22,16 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      # Kafka's 3s default delays the first assignment of every new consumer group. Kept at 0 to keep
-      # the simulations quick; Testcontainers' Kafka module does the same.
+      # group.initial.rebalance.delay.ms is deliberately left at Kafka's 3000 default.
       #
-      # KafkaGatlingTest no longer *depends* on it. It used to: its request-reply scenarios were
-      # answered by sibling scenarios publishing at a fixed delay, and with the default the first
-      # assignment landed after those publishes, so the replies were skipped. Since #196 gave the
-      # simulation a real echo responder and #191 made the reply channel exist before the request is
-      # sent, an immediate reply is always received. Verified by running the simulation three times
-      # against this broker with the value at Kafka's 3000 default: green each time.
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      # It used to be pinned to 0 here and in ci.yml. That started as a speed tweak, but it also sat on
+      # top of issue #193: a reply channel reported ready on assignment alone, before its fetch position
+      # was resolved, so a reply produced in that window was skipped under auto.offset.reset=latest. The
+      # setting changes when assignment happens, not the width of that window, so it never fixed the gap
+      # — it just made the simulations quick enough to rarely notice.
+      #
+      # Now that readiness resolves the fetch position first, nothing depends on the delay, and running
+      # at the broker default is what a real target system will do.
     ports:
       - "9092:9092"
       - "9093:9093"

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -64,6 +64,12 @@ services:
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic3 --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic test.t3 --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic test.t --partitions 1 --replication-factor 1 &&
-      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic4 --partitions 1 --replication-factor 1
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic4 --partitions 1 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic5 --partitions 1 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic test.t5 --partitions 1 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic load.request --partitions 1 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic load.reply --partitions 1 --replication-factor 1
       "
+    # Keep this list in step with KAFKA_CREATE_TOPICS in .github/workflows/ci.yml — CI builds its broker
+    # from its own service definition, not from this file, so a topic added here is not created there.
     restart: "no"

--- a/specs/004-reply-correlation-correctness/checklists/requirements.md
+++ b/specs/004-reply-correlation-correctness/checklists/requirements.md
@@ -1,0 +1,63 @@
+# Specification Quality Checklist: Reply Correlation Correctness
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+**Status: all items pass. Ready for `/speckit-plan`.**
+
+- **Iteration 1** — one open item: `FR-004` carried a [NEEDS CLARIFICATION] marker asking what a
+  keyless request-reply request should do under key-based matching. Three defensible resolutions
+  existed (fail the request, generate a correlation identity, reject the scenario before the run),
+  with materially different user-visible behaviour, and the choice is an observable-behaviour change
+  governed by Constitution Principle I — so it was escalated rather than defaulted.
+- **Iteration 2** — resolved to *fail the request at issue time with a stated reason*. Split into
+  FR-004 (fail), FR-005 (name the reason) and FR-006 (never invent an identity); added SC-003 to make
+  it measurable; recorded the decision and both rejected alternatives in Assumptions. Subsequent FR
+  and SC identifiers renumbered to stay contiguous.
+- **Correction applied during validation.** Issue #167's text describes a displaced request being
+  silently overwritten. That is no longer accurate: the v1.1.0 work made displacement fail explicitly.
+  The spec was rewritten to describe the defect that actually survives at HEAD — keyless requests
+  sharing one correlation slot, a failure message describing a reuse the engineer did not commit, and
+  the replacing request still being resolvable by the displaced request's reply. Recorded as an
+  Assumption so planning does not re-solve the fixed part.
+- **Iteration 3 — verification tightened at the user's request.** Added a Verification requirements
+  block (FR-018 to FR-025) binding every user story to a load simulation in CI against a real broker
+  and the echo responder, plus SC-009 to SC-011 and a simulation-level Independent Test on each of the
+  four stories. Two concrete gaps in the current verification were found while writing it and are now
+  in scope: request-reply is exercised one virtual user at a time, which structurally cannot observe
+  cross-attribution; and existing keyless coverage is produce-only, so it exercises no correlation.
+  FR-013 was narrowed to a behavioural requirement to avoid duplicating FR-022's verification
+  obligation.
+- Domain vocabulary (topic, partition, reply timeout, virtual user, broker) is retained deliberately.
+  It is the problem domain a Gatling Kafka user works in, not the plugin's implementation. No internal
+  type, class, method, or configuration key is named in the requirements or success criteria. The one
+  reference to "the Scala DSL and Java facade" is a product-surface compatibility obligation under
+  Constitution Principle I, not an implementation detail.

--- a/specs/004-reply-correlation-correctness/contracts/behavior-contract.md
+++ b/specs/004-reply-correlation-correctness/contracts/behavior-contract.md
@@ -1,0 +1,166 @@
+# Observable Behaviour Contract: Reply Correlation Correctness
+
+**Feature**: `004-reply-correlation-correctness` | **Date**: 2026-08-07
+
+This plugin's external interface is the published Scala DSL, the `javaapi` facade, and the observable
+behaviour of a run. There is no HTTP or CLI surface, so the contract that matters here is **behavioural**:
+what a simulation author writes, and what the report says afterwards.
+
+**Signature contract: unchanged.** No public type, method, or default moves. Everything below is a
+behaviour delta, and each one is the correction of a defect.
+
+---
+
+## C1 — Request-reply with no key, correlating on the key
+
+**Signature**: unchanged.
+
+```scala
+kafka("req").requestReply
+  .requestTopic("in").replyTopic("out")
+  .send[String]("payload-with-no-key")   // no key overload
+// protocol: .matchByKey  (the default)
+```
+
+| | Before | After |
+|---|---|---|
+| On the wire | key = `Array.emptyByteArray` | request is never sent |
+| Correlation | every such request shares one bucket | none — rejected before registration |
+| Report | OK or KO, possibly from another user's reply | **KO at issue time** |
+| Message | — | names the missing identity for the configured matcher |
+| Timing | after the reply timeout, or on a wrong match | immediate |
+
+**Breaking for**: simulations that today appear to work this way. They were reporting wrong results —
+the change surfaces that rather than causing it.
+
+**Migration**: set a key, or correlate on something the request carries:
+
+```scala
+.send[String, String]("#{correlationId}", "payload")   // give it a key
+// — or —
+.matchByValue                                           // correlate on the payload
+.matchByMessage(msg => msg.headers…)                    // correlate on a header
+```
+
+---
+
+## C2 — Request-reply with no key, correlating on a non-key field
+
+**Signature**: unchanged. **Report: unchanged in shape, correct in content.**
+
+```scala
+// protocol: .matchByValue  or  .matchByMessage(...)
+```
+
+| | Before | After |
+|---|---|---|
+| On the wire | key = `Array.emptyByteArray` | key = `null` |
+| Correlation | on value/extractor (already worked) | unchanged |
+| Partition placement | single partition (`murmur2` of empty is constant) | broker's keyless placement — see C4 |
+
+**Breaking for**: nothing in the report. **Changes**: which partition a keyless message lands on — see C4.
+
+---
+
+## C3 — A reply whose payload is absent
+
+**Signature**: unchanged. Applies to `bodyString`, `substring`, `bodyBytes`, `jsonPath`, `jmesPath`.
+
+```scala
+kafka("req").requestReply
+  .requestTopic("in").replyTopic("out")
+  .send[String, String]("k", "v")
+  .check(bodyString.is("expected"))
+```
+
+| Reply payload | Before | After |
+|---|---|---|
+| `null` (tombstone) | NPE out of `Check.check`; **virtual user stalls** — no OK, no KO, no next action | **KO** naming the absent payload; user continues |
+| empty (`length == 0`) | `""` / empty bytes, check evaluated normally | **unchanged** |
+| present | parsed | **unchanged** |
+
+**Breaking for**: runs against compacted topics or services that answer with deletion markers. Those
+runs were losing virtual users silently; they now report failures instead. The user count at the end of
+a run will match the count at the start, which it did not before.
+
+**Note**: `bodyString.is("")` does **not** pass on a tombstone. Absent and empty stay distinct — the
+plugin already draws that distinction in its logging (`"null"` vs `"bytes(len=0)"`) and now draws it in
+checks too.
+
+**Additional guarantee (FR-008)**: independent of the preparers, *any* check that throws now yields a
+KO and continues the user. No check can strand a virtual user.
+
+---
+
+## C4 — Key absence on the wire for keyless messages
+
+**Signature**: unchanged. Applies to **all** sends, request-reply and fire-and-forget alike.
+
+| | Before | After |
+|---|---|---|
+| Message with a key | key on the wire; partition = `hash(key) % n` | **unchanged** — per-key ordering preserved |
+| Message with no key | empty byte array — a *present* key | absent key (`null`) |
+| Placement of a keyless message | one partition, always (`murmur2` of empty is constant) | whatever the broker does for keyless records |
+| Keyless send to a compacted topic | accepted (empty key satisfies the key requirement) | **rejected** with `INVALID_RECORD` |
+
+**Breaking for**: scenarios publishing keyless records to a log-compacted topic — those go from passing
+to failing every request. Kafka requires a key there, and `hasKey()` is `key != null`, so an empty key
+passed the check and an absent one does not. The records were never valid on that topic.
+
+**Changes**: measured throughput and consumer-group behaviour of keyless scenarios, because the previous
+numbers described a single-partition workload the author did not ask for.
+
+**Deliberately not specified**: how records are distributed once the key is absent. That is the broker's
+decision and it changed in Kafka 3.3 (keyless records are batched stickily rather than round-robin), so
+asserting spread would pin behaviour the plugin does not own.
+
+---
+
+## C5 — Reply channel readiness
+
+**Signature**: unchanged; internal to `DynamicKafkaConsumer`, but the guarantee is observable.
+
+| | Before | After |
+|---|---|---|
+| "Ready" means | the broker has assigned partitions | assigned **and** fetch position resolved |
+| Reply published just after ready | may be skipped under `auto.offset.reset=latest` | delivered |
+| Reported effect | reply timeout against a system that answered | correct success |
+| Position unresolvable | n/a | that topic's readiness fails; other topics and the pool are unaffected |
+
+**Breaking for**: nothing. Strictly removes false timeouts.
+
+**Default unchanged**: `auto.offset.reset` stays `latest` (`KafkaProtocolBuilder.withDefaultAutoReset`).
+The fix makes `latest` safe rather than changing it.
+
+---
+
+## C6 — Failure messages (report content)
+
+Messages appear in the report's KO reason and are what an engineer acts on. Each case gets the message
+that fits it — the point of separating absent from reused.
+
+| Situation | Message |
+|---|---|
+| No identity for the configured matcher | names the missing identity and how to supply one — **new** |
+| Identity reused while in flight | "Match id reused while a request was still in flight…" — existing, unchanged |
+| Reply payload absent | names the absent payload as the cause — **new** |
+| Check threw | terminal KO carrying the failure — **new** |
+| Reply timeout | existing, unchanged — and now means the system genuinely did not answer |
+
+---
+
+## Compatibility summary
+
+| Contract | Signature | Behaviour | Version impact |
+|---|---|---|---|
+| C1 keyless + key matching | unchanged | **breaking** (was wrong) | `feat` + Migration Guide |
+| C2 keyless + other matching | unchanged | corrected | `feat` |
+| C3 absent payload | unchanged | **breaking** (was a stall) | `fix` + Migration Guide |
+| C4 key absence on the wire | unchanged | **breaking** (compacted topics) | `fix` + Migration Guide |
+| C5 readiness | unchanged | strictly better | `feat` |
+| C6 messages | unchanged | additive | — |
+
+**Version**: minor (`1.2.0`). No `!:` / `BREAKING CHANGE` marker — no consumer's code stops compiling,
+and `ExampleSmokeValidation` must stay green as the gate on that claim. The behaviour changes are real
+and require a `README.md` Migration Guide entry in the same PR (FR-017), covering C1, C3 and C4 with
+the remediation shown for each above.

--- a/specs/004-reply-correlation-correctness/data-model.md
+++ b/specs/004-reply-correlation-correctness/data-model.md
@@ -1,0 +1,180 @@
+# Phase 1 Data Model: Reply Correlation Correctness
+
+**Feature**: `004-reply-correlation-correctness` | **Date**: 2026-08-07
+
+This feature introduces no new entity. It corrects the **state space** of three existing ones: two
+states that were being collapsed into one are separated, and one state that had no defined outcome
+gains one. Entities below map to the spec's Key Entities section.
+
+---
+
+## 1. Correlation Identity
+
+The value a `KafkaMatcher` extracts from a message to connect a reply to its request.
+
+**Type**: `Array[Byte]`, nullable. Produced by `KafkaMatcher.requestMatch` / `responseMatch`
+(`KafkaProtocol.scala:18-36`). Not a new type — `KafkaMatcher` is the single matching contract and is
+used as-is.
+
+### State space
+
+| State | Representation | Before | After |
+|---|---|---|---|
+| Absent | `null` | folded into Empty | distinct; request fails at issue time |
+| Empty | `Array.emptyByteArray` | folded with Absent | distinct; tracked normally |
+| Present | non-empty `Array[Byte]` | tracked | tracked (unchanged) |
+
+**The defect is the folding, in two places, in opposite directions:**
+
+- `KafkaAction.resolveToProtocolMessage:87` — `key.getOrElse(Array.emptyByteArray)` turns Absent into
+  Empty on the produce side.
+- `KafkaMessageTracker.matchKeyFor:113-114` — `if (m == null) Array.emptyByteArray else m` turns
+  Absent into Empty inside the correlation map.
+
+Together they make every keyless request-reply request share one `MatchKey`.
+
+### Validation rules
+
+- **VR-1** (FR-004): an Absent identity on the request side is invalid for correlation. The request is
+  reported KO at issue time, before registration and before the send.
+- **VR-2** (FR-001): Absent and Empty MUST NOT compare equal. Satisfied structurally once the folding
+  is removed — `Arrays.hashCode(null) == 0`, `Arrays.hashCode(Array.empty) == 1`,
+  `Arrays.equals(null, Array.empty) == false`.
+- **VR-3** (FR-006): no identity is ever synthesised for a request that supplied none.
+- **VR-4**: an Absent identity on the *reply* side is already rejected before matching
+  (`KafkaMessageTracker.scala:222-223`) and stays rejected.
+
+---
+
+## 2. MatchKey
+
+Value-equality wrapper over a correlation identity, used as the key of the tracker's correlation map
+(`KafkaMessageTracker.scala:105-114`). Private to the tracker.
+
+**Change**: `matchKeyFor` stops substituting. `new MatchKey(m)` for all `m`, including `null`.
+
+**Invariant preserved**: `hashCode` is still computed once at construction, and `equals` still compares
+bytes. No branch is added to the per-reply path.
+
+**Reachability after the change**: `MatchKey(null)` becomes unreachable from the publish path (VR-1
+rejects those before registration) and from the consume path (VR-4 rejects those before lookup). It is
+retained as a total function rather than a partial one — the map must not be able to alias two
+identities regardless of which caller reaches it.
+
+---
+
+## 3. Request-Reply Exchange
+
+One request and the reply that answers it: `KafkaMessageTracker.MessagePublished`, held in
+`sentMessages: mutable.HashMap[MatchKey, MessagePublished]`.
+
+**No structural change.** `token` (added for #191) already distinguishes registrations sharing an
+identity, and `sentTimestamp` already carries the handoff moment (settled by #170).
+
+### Lifecycle
+
+```text
+                    ┌─ identity Absent ──────────────► KO "no identity"   [NEW — VR-1]
+                    │                                   (never registered, never sent)
+request issued ─────┤
+                    └─ identity Empty or Present ───► registered ──► sent
+                                                          │
+                            ┌─────────────────────────────┼──────────────────────────┐
+                            ▼                             ▼                          ▼
+                     reply matched              identity displaced            reply timeout
+                            │                    by a later request                  │
+              ┌─────────────┴─────────────┐             │                            ▼
+              ▼                           ▼             ▼                           KO
+        checks pass                 checks fail        KO "match id reused"
+              │                           │
+              ▼                           ▼
+             OK                          KO
+                            │
+                            └─ check throws ──► KO   [NEW — FR-008 terminal catch]
+```
+
+Every path terminates. The two `[NEW]` edges are the ones this feature adds; before it, the first had
+no edge at all (the request was matched wrongly instead) and the last had no edge either (the virtual
+user stalled).
+
+---
+
+## 4. Reply Message
+
+A message received on a reply channel: `KafkaProtocolMessage`, built by
+`KafkaProtocolMessage.from(consumerRecord, inputTopic)`.
+
+**Key insight — no type change needed.** `KafkaProtocolMessage.key` and `.value` are already
+`Array[Byte]` and already nullable: `from` copies `consumerRecord.key()` and `.value()` verbatim, both
+of which are `null` for keyless records and tombstones respectively. The produce side was not using
+that nullability; the check side was not handling it.
+
+### Value state space
+
+| State | Representation | Body-check outcome before | after |
+|---|---|---|---|
+| Absent | `null` | **NPE → virtual user stalls** | KO naming the absent payload |
+| Empty | `Array.emptyByteArray` | `""` / empty, success | unchanged (FR-010) |
+| Present | non-empty | parsed | unchanged |
+
+### Validation rules
+
+- **VR-5** (FR-007): an Absent value produces a `Validation` failure in every reply-content preparer.
+- **VR-6** (FR-009): all preparers agree on Absent. Currently `xmlPreparer` and `avroPreparer` are
+  guarded by `safely(ErrorMapper)`; `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer`
+  are not.
+- **VR-7** (FR-010): Absent and Empty MUST NOT be conflated. `bodyString.is("")` must not pass on a
+  tombstone.
+- **VR-8** (FR-008): no check outcome may leave a request without a terminal report — enforced
+  independently of VR-5 by the catch in `completeMatched`.
+
+---
+
+## 5. Reply Channel Readiness
+
+The `CompletableFuture[Void]` returned by `DynamicKafkaConsumer.requestTopicSubscription`, completed by
+`completeAssignedReadiness` (`DynamicKafkaConsumer.scala:129-141`).
+
+**No structural change** — the same future, completed later and on a stronger condition.
+
+### State transition
+
+| Stage | Consumer state | Readiness before | after |
+|---|---|---|---|
+| Subscribed | topic in `subscription()` | pending | pending |
+| Assigned | topic in `assignment()` | **completed** | pending |
+| Positioned | `position(tp)` resolved for every assigned partition | (already completed) | **completed** |
+| Position unresolvable | timeout / error | n/a | completed exceptionally, **that topic only** |
+
+### Contract
+
+- **VR-9** (FR-011): once a topic's readiness future completes successfully, a record published to that
+  topic from that moment on is delivered to `onRecord`.
+- **VR-10** (R3): a position failure fails only the awaiting topic's futures. It MUST NOT reach
+  `markConsumerFailed`, which latches `consumerFailure` and poisons every present and future
+  subscription for the run — the #143 terminal state.
+- **VR-11**: readiness resolution stays on the poll thread. No other thread may touch the consumer.
+
+---
+
+## Entity relationships
+
+```text
+KafkaProtocolMessage ──── KafkaMatcher.requestMatch ────► Correlation Identity
+   (single wire type)                                            │
+        │                                                        │ matchKeyFor
+        │ toProducerRecord                                       ▼
+        │  (null key ⇒ round-robin partitioner)               MatchKey
+        ▼                                                        │
+   ProducerRecord                                                │ keys
+                                                                 ▼
+                                              sentMessages: HashMap[MatchKey, MessagePublished]
+                                                                 │
+                                                                 │ resolved by
+                                                                 ▼
+                                              Reply Message ◄── Reply Channel (readiness: positioned)
+```
+
+**Unchanged contracts**: `KafkaProtocolMessage` remains the single wire representation and
+`KafkaMatcher` the single matching contract (Principle III). Neither is extended; no parallel type is
+introduced. Every change is to how existing values are interpreted, not to what values exist.

--- a/specs/004-reply-correlation-correctness/plan.md
+++ b/specs/004-reply-correlation-correctness/plan.md
@@ -24,8 +24,9 @@ are small, local changes with disproportionate blast radius, and the bulk of the
    `auto.offset.reset` to `latest`. Fix: resolve `consumer.position(tp)` on the poll thread for each
    assigned partition of the awaited topic before completing its readiness futures.
 
-The partition-distribution half of #167 falls out of change 1 for free: a `null` key restores Kafka's
-round-robin partitioner, which `murmur2` of an empty array had been defeating.
+The wire-level half of #167 falls out of change 1 for free: the key becomes genuinely absent rather
+than present-and-empty. What the broker then does with it is its own decision — current clients batch
+keyless records stickily rather than round-robin — so the plugin asserts key absence and stops there.
 
 **No published signature changes.** `KafkaProtocolMessage.key` is already `Array[Byte]` and already
 nullable on the consume side (`KafkaProtocolMessage.from` copies `consumerRecord.key()` verbatim); the
@@ -167,7 +168,7 @@ src/test/scala/org/galaxio/gatling/kafka/
     ├── KafkaGatlingTest.scala             # [US1/US2/US4] new scenarios + pinned assertions
     └── KafkaConcurrencyLoadTest.scala     # [US1] wire into CI (30 concurrent users already)
 
-docker-compose.kafka.yml                   # [US3] drop rebalance tuning; [US4] multi-partition topic
+docker-compose.kafka.yml                   # [US3] drop rebalance tuning
 .github/workflows/ci.yml                   # [US3] drop rebalance tuning; [US1] run concurrency test
 README.md                                  # [FR-017] Migration Guide entry
 ```
@@ -249,7 +250,7 @@ it and an assertion that reads back where they landed.
 | US1 | Keyless request-reply under key matching KOs at issue time | Gatling simulation | `KafkaGatlingTest` (new scenario) |
 | US2 | Tombstone reply → clean KO, not a stalled user | Unit + Gatling simulation | `KafkaMessagePreparerSpec` (new), `KafkaGatlingTest` |
 | US3 | Reply published immediately after readiness is received | Integration (Testcontainers) | `PositionedReadinessSpec` (new) |
-| US4 | Keyless messages reach every partition | Gatling simulation | `KafkaGatlingTest` (new scenario) |
+| US4 | Keyless records reach the broker with no key | Integration (Testcontainers) | `KeylessCorrelationSpec` |
 
 **Assertion convention** (FR-024): pin exact counts with `is(...)`, never `lte(...)`. `KafkaGatlingTest`
 already does this — `global.failedRequests.count.is(1)` plus a named

--- a/specs/004-reply-correlation-correctness/plan.md
+++ b/specs/004-reply-correlation-correctness/plan.md
@@ -1,0 +1,278 @@
+# Implementation Plan: Reply Correlation Correctness
+
+**Branch**: `004-reply-correlation-correctness` | **Date**: 2026-08-07 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/004-reply-correlation-correctness/spec.md`
+
+## Summary
+
+Three defects make a request-reply run report numbers that are wrong rather than missing. All three
+are small, local changes with disproportionate blast radius, and the bulk of the work is proving them.
+
+1. **Keyless correlation** (#167). `KafkaAction` substitutes `Array.emptyByteArray` for an absent key,
+   and `KafkaMessageTracker.matchKeyFor` folds `null` into that same empty array. Every keyless
+   request-reply request therefore registers under one `MatchKey`. Fix: carry the key as `null` to the
+   `ProducerRecord`, stop folding `null` into empty in the tracker, and fail a request whose matcher
+   yields no identity *before* it is acquired or sent.
+2. **Absent payloads** (#168). `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` call
+   `msg.value.length` unguarded; `completeMatched` wraps check execution in `try`/`finally` with no
+   `catch`. A tombstone therefore throws out of `Check.check` and the virtual user is never continued.
+   Fix: null-guard the three preparers behind `safely(...)` like their siblings, and add a terminal
+   catch so no check can strand a user.
+3. **Channel readiness** (#193). `completeAssignedReadiness` completes readiness from
+   `consumer.assignment()`, which precedes fetch-position resolution, while the plugin defaults
+   `auto.offset.reset` to `latest`. Fix: resolve `consumer.position(tp)` on the poll thread for each
+   assigned partition of the awaited topic before completing its readiness futures.
+
+The partition-distribution half of #167 falls out of change 1 for free: a `null` key restores Kafka's
+round-robin partitioner, which `murmur2` of an empty array had been defeating.
+
+**No published signature changes.** `KafkaProtocolMessage.key` is already `Array[Byte]` and already
+nullable on the consume side (`KafkaProtocolMessage.from` copies `consumerRecord.key()` verbatim); the
+produce side simply was not using that. Observable behaviour does change, in three ways, and that is
+governed by Principle I — see [Constitution Check](#constitution-check).
+
+## Technical Context
+
+**Language/Version**: Scala 2.13 on sbt; Java 17+ (Temurin in CI)
+
+**Primary Dependencies**: Gatling 3.13.5 (`provided`), Kafka clients 7.9.5-ce, kafka-streams-scala.
+Avro4s 4.1.2 and Confluent serdes 7.9.8 stay `provided`/optional. No new dependency.
+
+**Storage**: N/A — correlation state is in-memory, actor-private (`mutable.HashMap[MatchKey, MessagePublished]`)
+
+**Testing**: munit + Testcontainers (`ConfluentKafkaContainer`) for integration; Gatling simulations
+against the `docker-compose.kafka.yml` stack for load-level proof; `ExampleSmokeValidation` for API
+construction
+
+**Target Platform**: JVM library published to Sonatype, consumed by Gatling simulations
+
+**Project Type**: Library — Gatling protocol plugin (single sbt project, Scala core + Java facade)
+
+**Performance Goals**: No regression in reply throughput. The consume path is single-threaded and
+gates every reply, so per-reply work must not grow; the readiness change runs once per topic
+assignment, not per record.
+
+**Constraints**: The consumer poll thread is the only thread that may touch the `KafkaConsumer`.
+`consumer.position(tp)` may block on a `ListOffsets` round trip, so it needs a bounded timeout and
+must not be called from the virtual-user thread. Reply topics are `Expression[String]` and may derive
+from session data, so dynamic subscription must keep working.
+
+**Scale/Scope**: 6 production files touched, ~120 lines changed. Verification is the larger half:
+2 new integration specs, 2 amended simulations, 1 simulation wired into CI, 2 broker definitions.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*Source: `.specify/memory/constitution.md` v1.0.0.*
+
+- [x] **I. Published API Compatibility** — **No signature change.** `KafkaProtocolMessage.key` stays
+      `Array[Byte]`; no DSL, `javaapi`, or serialized-format signature moves. **Observable behaviour
+      does change** in three ways, all deliberate and all approved during specification (spec
+      Assumptions): a keyless request-reply request under key matching now KOs at issue time instead
+      of matching wrongly; a reply with an absent payload now KOs instead of stalling; keyless
+      messages now spread across partitions instead of landing on one. Migration Guide entry in
+      `README.md` is required in the same PR (FR-017) and is a task, not a follow-up. Version impact:
+      minor (`feat`) with a documented behaviour change, not `!:` — no consumer's code stops
+      compiling. `ExampleSmokeValidation` stays green and is part of the gate.
+- [x] **II. Real Broker Over Mocks** — Every correlation, readiness and timeout claim is proven
+      against a real broker: Testcontainers for the integration specs, the Compose stack for the
+      Gatling simulations, with #196's echo responder as the oracle. Mocks are used nowhere in this
+      feature. The one unit-level spec added (preparer null-guards) has no Kafka interaction, which is
+      exactly the permitted case.
+- [x] **III. Layer Separation & Single Wire Contract** — `KafkaSender`, `KafkaMessageTracker` and
+      `DynamicKafkaConsumer` keep their responsibilities: the readiness change stays inside the
+      consumer, the identity change inside the tracker and the action, the payload change inside the
+      preparers. `KafkaProtocolMessage` and `KafkaMatcher` are used as-is — neither is extended, and
+      no parallel type is introduced. No new abstraction: every change has exactly one caller.
+- [x] **IV. Test-First for Behavior Change** — Each of the four user stories gets a test written to
+      fail against pre-change code first (FR-025). One caveat is recorded honestly in
+      [research.md](./research.md) §R4: for User Story 3 the red-before gate is the new integration
+      spec, **not** removing the broker tuning, because that removal was already verified green.
+- [x] **V. One Concern per Change, Always Green** — Spec artifacts (spec/plan/research/data-model/
+      contracts/quickstart/tasks) land first as one `docs(speckit):` commit. Then one semantic commit
+      per issue: `fix(actions)` for #167, `fix(checks)` for #168, `feat(client)` for #193, each green
+      under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`, each carrying `Closes #NNN` and the
+      `v1.2.0 Reply correlation correctness` milestone. Docs/Migration Guide ride with the commit
+      whose behaviour they describe, since FR-017 makes them part of that change rather than a
+      separate concern.
+- [x] **Constraints** — No new dependency, no upgrade. Avro/Schema Registry stay `provided`. No
+      supported Gatling version changes, so the README compatibility table is untouched.
+
+**Result: PASS.** No violations, so Complexity Tracking stays empty.
+
+### Post-Design Re-Check (after Phase 1)
+
+Re-evaluated against the completed design artifacts. **Still PASS**, with two things the design
+surfaced that the pre-design pass could not have known:
+
+- **Principle I held better than expected.** Phase 1 confirmed `KafkaProtocolMessage.key` and `.value`
+  are already nullable on the consume side, so the whole feature lands with zero signature movement
+  and no deprecation cycle. Recorded in [data-model.md](./data-model.md) §1 and §4.
+- **Principle III got easier, not harder.** No new type, no new abstraction, no extension of
+  `KafkaProtocolMessage` or `KafkaMatcher`. Every change reinterprets existing values —
+  `matchKeyFor` loses a branch rather than gaining one.
+- **Principle IV needed a correction, and got one.** The pre-design pass assumed removing the broker
+  tuning would provide User Story 3's red-before gate. [research.md](./research.md) §R4 found that
+  assumption false against the working tree and moved the gate to `PositionedReadinessSpec`. That spec
+  was then redesigned (§R5) from a statistical marker race into a direct measurement of the gap —
+  `first-delivered <= produced-at-readiness` — so it is decisive on a single run. A check that can pass
+  by luck is not a gate, so it does not get to be one here.
+- **Principle II unchanged**: the one new unit spec covers preparers, which have no Kafka interaction
+  — the explicitly permitted case. Everything else is Testcontainers or the Compose stack.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-reply-correlation-correctness/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── behavior-contract.md   # Phase 1 output — observable contract deltas
+├── checklists/
+│   └── requirements.md  # from /speckit-specify
+└── tasks.md             # /speckit-tasks — NOT created here
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/org/galaxio/gatling/kafka/
+├── actions/
+│   ├── KafkaAction.scala                  # [US1/US4] key.getOrElse(empty) → key.orNull
+│   └── KafkaRequestReplyAction.scala      # [US1] fail-fast when the matcher yields no identity
+├── checks/
+│   └── KafkaMessagePreparer.scala         # [US2] null-guard the three unguarded preparers
+├── client/
+│   ├── KafkaMessageTracker.scala          # [US1] matchKeyFor: drop null→empty folding
+│   │                                      # [US2] completeMatched: terminal catch
+│   └── DynamicKafkaConsumer.scala         # [US3] resolve fetch position before readiness
+└── request/
+    └── KafkaProtocolMessage.scala         # [US1] doc only — key nullability made explicit
+
+src/test/scala/org/galaxio/gatling/kafka/
+├── checks/
+│   └── KafkaMessagePreparerSpec.scala     # [US2] NEW — unit, no Kafka interaction
+├── client/
+│   └── KafkaMessageTrackerSpec.scala      # [US1] null ≠ empty MatchKey
+├── integration/
+│   ├── KeylessCorrelationSpec.scala       # [US1] NEW — Testcontainers
+│   └── PositionedReadinessSpec.scala      # [US3] NEW — Testcontainers, the red-before gate
+└── examples/
+    ├── KafkaGatlingTest.scala             # [US1/US2/US4] new scenarios + pinned assertions
+    └── KafkaConcurrencyLoadTest.scala     # [US1] wire into CI (30 concurrent users already)
+
+docker-compose.kafka.yml                   # [US3] drop rebalance tuning; [US4] multi-partition topic
+.github/workflows/ci.yml                   # [US3] drop rebalance tuning; [US1] run concurrency test
+README.md                                  # [FR-017] Migration Guide entry
+```
+
+**Structure Decision**: Existing single-project Scala/sbt layout, unchanged. Each user story maps to
+one production concern and one verification concern, in the directories that already own them.
+
+## Implementation Approach
+
+### US1 — Correlation identity (#167, P1)
+
+**Production changes (3 files, ~15 lines):**
+
+1. `KafkaAction.resolveToProtocolMessage` — `key.getOrElse(Array.emptyByteArray)` → `key.orNull`.
+   `KafkaProtocolMessage.toProducerRecord` already passes `key` straight through, so a `null` key
+   reaches the partitioner and round-robin is restored. This single line delivers US4 as well.
+2. `KafkaMessageTracker.matchKeyFor` — drop the `if (m == null) Array.emptyByteArray else m`
+   substitution. `java.util.Arrays.hashCode(null) == 0` and `Arrays.hashCode(Array.empty) == 1`, and
+   `Arrays.equals(null, Array.empty) == false`, so `null` and empty become distinct `MatchKey`s with
+   no extra code. This is what FR-001 requires.
+3. `KafkaRequestReplyAction.sendKafkaMessage` — after `val id = matcher.requestMatch(protocolMessage)`,
+   if `id == null`, call the existing `reportFailure(...)` with a message naming the missing identity
+   and return, **before** `acquireTracker` and before `sender.send`. Nothing is registered and nothing
+   is published, so the existing "every exit goes through the tracker" invariant is not weakened —
+   this exit happens strictly earlier than registration.
+
+**Deliberately not changed**: an *empty* identity still registers and is still tracked. Two concurrent
+requests sharing an empty identity collide, and the existing displacement failure (added for #191)
+reports that accurately as a reused match id. That is the FR-001 distinction working as intended: an
+absent identity is a configuration error reported immediately; a non-unique identity is a simulation
+error reported on collision.
+
+**Consume side needs no change**: `MessageConsumed` already rejects `replyId == null` before matching,
+so a keyless reply cannot match the empty bucket once the publish side stops creating one.
+
+### US2 — Absent payloads (#168, P2)
+
+**Production changes (2 files, ~25 lines):**
+
+1. `KafkaMessagePreparer` — wrap `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` in
+   `safely(...)` and guard `msg.value == null`, producing a `Validation` failure naming the absent
+   payload. `xmlPreparer` and `avroPreparer` already do this; the three are brought to the same shape
+   rather than given a new one. A **present-but-empty** value keeps its current behaviour exactly
+   (`""` / `Array.emptyByteArray`, both successes) — FR-010.
+2. `KafkaMessageTracker.completeMatched` — add a `catch` to the existing `try`/`finally` that reports a
+   KO and continues the virtual user. This is defence in depth: it makes FR-008's "every request
+   reaches a terminal outcome" true for *any* throwing check, not only for the three being fixed.
+
+### US3 — Positioned readiness (#193, P3)
+
+**Production change (1 file, ~25 lines):**
+
+`DynamicKafkaConsumer.completeAssignedReadiness` — before completing a topic's readiness futures,
+resolve the fetch position for each assigned partition of that topic via `consumer.position(tp, timeout)`.
+Runs on the poll thread only, which the method already documents and requires. Called from
+`onPartitionsAssigned` (inside `poll()`, where Kafka explicitly permits `position`/`seek`) and from the
+tail of `updateSubscription()` (also the poll thread).
+
+A `position()` failure or timeout must fail *that topic's* readiness futures, not latch
+`markConsumerFailed` — poisoning the pool over one slow `ListOffsets` is the #143 failure mode in a new
+costume. See [research.md](./research.md) §R3.
+
+**Broker definitions**: remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` from `docker-compose.kafka.yml`
+and `.github/workflows/ci.yml` (FR-022). Read §R4 first — this removal is hygiene, not the gate.
+
+### US4 — Partition distribution (#167 realism, P4)
+
+No production change beyond US1's `key.orNull`. Work is verification only: a multi-partition topic in
+`topic-init` (every topic there is currently `--partitions 1`, and `KAFKA_AUTO_CREATE_TOPICS_ENABLE`
+would otherwise default new topics to 1 partition too), plus a scenario publishing keyless messages to
+it and an assertion that reads back where they landed.
+
+### Verification plan (FR-018 – FR-025)
+
+| Story | Red-before gate | Level | Where |
+|---|---|---|---|
+| US1 | Concurrent keyless request-reply loses/misattributes replies | Integration (Testcontainers) | `KeylessCorrelationSpec` (new) |
+| US1 | 30 concurrent users, zero reply-loss budget | Gatling simulation | `KafkaConcurrencyLoadTest` — **wire into CI** |
+| US1 | Keyless request-reply under key matching KOs at issue time | Gatling simulation | `KafkaGatlingTest` (new scenario) |
+| US2 | Tombstone reply → clean KO, not a stalled user | Unit + Gatling simulation | `KafkaMessagePreparerSpec` (new), `KafkaGatlingTest` |
+| US3 | Reply published immediately after readiness is received | Integration (Testcontainers) | `PositionedReadinessSpec` (new) |
+| US4 | Keyless messages reach every partition | Gatling simulation | `KafkaGatlingTest` (new scenario) |
+
+**Assertion convention** (FR-024): pin exact counts with `is(...)`, never `lte(...)`. `KafkaGatlingTest`
+already does this — `global.failedRequests.count.is(1)` plus a named
+`details("Request Reply Bytes wo").failedRequests.count.is(1)` — with a comment explaining that `lte`
+let a by-design failure silently stop failing. New scenarios extend that pattern; the global count
+moves as by-design failures are added, and each new one gets its own named `details(...)` assertion.
+
+**Stall detection** (FR-021): a stalled virtual user produces *no* failure, so a failure-count
+assertion alone goes green on a hung run. Every US2 assertion must therefore pair the failure count
+with evidence that users completed — the count of a request executed *after* the failing one in the
+same scenario.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Table intentionally empty.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| `consumer.position()` blocks the poll thread on a slow `ListOffsets` | Reply throughput stalls for every topic on that consumer | Bounded `position(tp, Duration)`; fail only that topic's readiness on timeout; §R3 |
+| Removing the rebalance tuning does not turn CI red pre-fix | US3 appears proven when it is not | The gate is `PositionedReadinessSpec`, not the removal; stated in §R4 and in the task list |
+| ~~`PositionedReadinessSpec` is statistical~~ | — | **Resolved during design.** Redesigned to measure the gap (`F <= S`) instead of racing into it, so it is decisive on a single run; §R5 |
+| `KafkaConcurrencyLoadTest` in CI adds ~2 min and a new flake surface | Slower, noisier CI | It already carries a zero-loss budget and passes locally; run it in the existing Gatling step, not a new job |
+| Keyless key-matched scenarios in the wild start failing | Downstream simulations go red on upgrade | Deliberate (spec Assumptions); Migration Guide entry naming the two fixes — set a key, or switch to `matchByValue`/`matchByMessage` |
+| A `null` key reaching code that assumed non-null | NPE somewhere unrelated | `describeBytes` already handles null (used on the consume path); audit `key` uses during implementation |

--- a/specs/004-reply-correlation-correctness/quickstart.md
+++ b/specs/004-reply-correlation-correctness/quickstart.md
@@ -1,0 +1,164 @@
+# Quickstart & Validation Guide: Reply Correlation Correctness
+
+**Feature**: `004-reply-correlation-correctness` | **Date**: 2026-08-07
+
+How to run the verification for this feature and what each command proves. Design detail lives in
+[plan.md](./plan.md), [research.md](./research.md) and [contracts/behavior-contract.md](./contracts/behavior-contract.md).
+
+---
+
+## Prerequisites
+
+- JDK 17+ (Temurin, as in CI) and sbt
+- Docker, for both Testcontainers and the Compose stack
+- Git hooks enabled once per clone:
+
+```bash
+bash scripts/install-hooks.sh
+```
+
+---
+
+## Fast loop — no broker needed
+
+Unit specs and formatting. This is the loop to stay in while editing the preparers.
+
+```bash
+sbt scalafmtAll scalafmtSbt
+```
+
+```bash
+sbt scalafmtCheckAll scalafmtSbtCheck compile
+```
+
+---
+
+## Default verification
+
+The repo's standard gate. `sbt test` includes the Testcontainers integration specs, so Docker must be
+running — this is where `KeylessCorrelationSpec` and `PositionedReadinessSpec` execute.
+
+```bash
+sbt scalafmtCheckAll scalafmtSbtCheck compile test
+```
+
+---
+
+## Targeted specs, per user story
+
+**US1 — correlation identity** (unit: `null` and empty are distinct match keys):
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.client.KafkaMessageTrackerSpec"
+```
+
+**US1 — correlation identity** (integration: concurrent keyless request-reply, real broker):
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.integration.KeylessCorrelationSpec"
+```
+
+**US2 — absent payloads** (unit: every preparer agrees, no Kafka interaction):
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.checks.KafkaMessagePreparerSpec"
+```
+
+**US3 — positioned readiness** (integration: the red-before gate for this story — see
+[research.md](./research.md) §R4 for why removing the broker tuning is *not* the gate):
+
+```bash
+sbt "testOnly org.galaxio.gatling.kafka.integration.PositionedReadinessSpec"
+```
+
+---
+
+## Full CI gate — Compose stack
+
+The Gatling simulations need Kafka, Zookeeper and Schema Registry.
+
+**1. Start the stack** (`topic-init` creates the fixed topics, including the new multi-partition one
+for US4):
+
+```bash
+docker compose -f docker-compose.kafka.yml up -d
+```
+
+**2. Examples still construct against the current API** (the Principle I gate — a failure here is an
+API break to reconsider, not a check to relax):
+
+```bash
+sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"
+```
+
+**3. The Gatling simulations under coverage**, exactly as CI runs them. `KafkaConcurrencyLoadTest` is
+added to this line by this feature (R8) — it is the only concurrent request-reply coverage that exists:
+
+```bash
+sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaConcurrencyLoadTest" test coverageOff coverageReport
+```
+
+**4. Tear down**:
+
+```bash
+docker compose -f docker-compose.kafka.yml down -v
+```
+
+---
+
+## Proving each story red-before, green-after
+
+Constitution Principle IV and FR-025 require the ordering to be **demonstrated**, not assumed. For each
+story: stash the production change, run the command, see it fail, restore, see it pass.
+
+| Story | Command | Expected before the fix |
+|---|---|---|
+| US1 | `testOnly …integration.KeylessCorrelationSpec` | replies misattributed or lost across concurrent keyless users |
+| US1 | `Gatling / testOnly …KafkaConcurrencyLoadTest` | reply losses above the zero budget |
+| US2 | `testOnly …checks.KafkaMessagePreparerSpec` | NPE from the three unguarded preparers |
+| US2 | `Gatling / testOnly …KafkaGatlingTest` | tombstone scenario hangs; users never complete |
+| US3 | `testOnly …integration.PositionedReadinessSpec` | `F > S` — records produced during the window are skipped |
+| US4 | `Gatling / testOnly …KafkaGatlingTest` | every keyless message on a single partition |
+
+**How to read a US3 failure**: the spec asserts `F <= S`, where `S` is the producer's sequence number
+at the moment readiness completed and `F` is the first record actually delivered. A failure reports
+`F - S` — the number of replies that would have been silently skipped in a real run. One run is
+decisive in both directions; there is no iteration count to raise and no flake budget to spend.
+
+**US3 non-caveat**: removing `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` from the broker definitions will
+**not** turn CI red pre-fix. `docker-compose.kafka.yml:25-33` records that the simulations were already
+verified green with Kafka's 3000 default. Remove it because FR-022 requires it and because a
+correctness-shaped workaround nobody depends on invites re-masking — not as evidence.
+
+---
+
+## What "done" looks like
+
+- [ ] `sbt scalafmtCheckAll scalafmtSbtCheck compile test` green
+- [ ] `ExampleSmokeValidation` green — no README or example simulation broke
+- [ ] All three Gatling simulations green against the Compose stack
+- [ ] Each of US1–US4 has a check demonstrated red-before and green-after (SC-009)
+- [ ] `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` absent from `docker-compose.kafka.yml` and `ci.yml` (SC-010)
+- [ ] `KafkaConcurrencyLoadTest` runs in `ci.yml` (FR-019)
+- [ ] `README.md` Migration Guide covers C1, C3 and C4 (FR-017)
+- [ ] Three semantic commits, one per issue, each green on its own, each with `Closes #NNN` and the
+      `v1.2.0 Reply correlation correctness` milestone
+
+---
+
+## Troubleshooting
+
+**Testcontainers cannot start** — Docker must be running and able to pull `confluentinc/cp-kafka`. The
+integration specs are part of `sbt test`, not a separate task, so this blocks the default gate.
+
+**Port already in use** — the Compose stack binds 2181, 9092, 9093, 9094. Tear down a previous stack
+with `docker compose -f docker-compose.kafka.yml down -v`.
+
+**`PositionedReadinessSpec` is green pre-fix** — that is not flake, it is a finding. The spec measures
+an interval rather than racing into a window, so it does not pass by luck. Check that the producer
+stream is actually running before the subscription is requested; if the stream is idle at that moment,
+`S` and `F` collapse together and the assertion becomes vacuous.
+
+**A simulation hangs instead of failing** — that is the US2 symptom itself. Check whether the run is
+producing KOs at all; a stalled virtual user produces none, which is why every US2 assertion pairs a
+failure count with evidence that users completed.

--- a/specs/004-reply-correlation-correctness/research.md
+++ b/specs/004-reply-correlation-correctness/research.md
@@ -1,0 +1,302 @@
+# Phase 0 Research: Reply Correlation Correctness
+
+**Feature**: `004-reply-correlation-correctness` | **Date**: 2026-08-07 | **Plan**: [plan.md](./plan.md)
+
+All findings verified against the working tree at branch point, not against issue text. Where an
+issue's description has been overtaken by later work, that is called out — two of them had.
+
+---
+
+## R1 — How an absent key is represented on the wire and in correlation
+
+**Decision**: Carry an absent key as `null` all the way to `ProducerRecord`, and stop folding `null`
+into `Array.emptyByteArray` in the tracker's `matchKeyFor`. `null` and empty become distinct.
+
+**Rationale**:
+
+- `KafkaProtocolMessage.key` is already `Array[Byte]` and already carries `null` on the consume side:
+  `KafkaProtocolMessage.from` copies `consumerRecord.key()` verbatim, which is `null` for a keyless
+  record. The type needs no change — the produce side simply was not using the nullability the
+  consume side has always relied on. This is what keeps Principle I satisfied without a deprecation
+  cycle.
+- `KafkaProtocolMessage.toProducerRecord` passes `key` straight into `ProducerRecord`, so `null`
+  reaches Kafka's partitioner and the round-robin path for keyless records is restored with no
+  further change. That is the whole of User Story 4.
+- The tracker's `MatchKey` needs no new logic to separate the two. `java.util.Arrays.hashCode(null)`
+  is `0` while `Arrays.hashCode(Array.emptyByteArray)` is `1`, and `Arrays.equals(null, Array.empty)`
+  is `false`. Deleting the substitution is sufficient and adds no branch to a hot path.
+- The codebase already models this distinction where it is only cosmetic: `describeBytes`
+  (`package.scala:46-58`) renders `"null"` for an absent value and `"bytes(len=0)"` for an empty one.
+  Correlation was the one place that collapsed them.
+
+**Alternatives considered**:
+
+- *Keep the empty-array substitution and special-case `""` in the tracker* — the shape #167 suggests.
+  Rejected: it fixes correlation but leaves the partitioner defeated, so User Story 4 would need a
+  second, separate change to the same line.
+- *Wrap the key in `Option[Array[Byte]]` on `KafkaProtocolMessage`* — cleaner in Scala terms, but it
+  is a published case-class signature change, so a `!:` major and a deprecation cycle under Principle
+  I, for a defect that needs neither.
+
+---
+
+## R2 — Where a request with no correlation identity is failed
+
+**Decision**: In `KafkaRequestReplyAction.sendKafkaMessage`, immediately after
+`val id = matcher.requestMatch(protocolMessage)` and **before** `trackers.acquireTracker`, using the
+existing local `reportFailure(...)`.
+
+**Rationale**:
+
+- `reportFailure` already exists in that method and already does the whole terminal job: `logResponse`
+  with KO, then `next ! session…markAsFailed`. It is used for the acquisition-failure and
+  no-consumer-settings paths. Reusing it means no new failure shape.
+- It does not weaken the "once registered, every exit goes through the tracker" invariant that #191
+  established. That invariant governs exits *after* registration; this exit is strictly before both
+  registration and the send, in the same position as the existing acquisition-failure exit.
+- Nothing is published, which matches the deliberate choice already recorded at
+  `KafkaRequestReplyAction.scala:144-147`: publishing a request whose reply can never be received is
+  the state #143 exists to prevent.
+
+**An empty identity is deliberately *not* failed here.** Only `null` is. An empty key is a value the
+scenario supplied; if two in-flight requests share it they collide, and the displacement failure added
+for #191 (`KafkaMessageTracker.scala:177-185`) reports that accurately as a reused match id. This is
+the FR-001 distinction with each case getting the message that fits it:
+
+| Identity | When reported | Message |
+|---|---|---|
+| Absent (`null`) | At issue time, before send | no identity for the configured matching strategy |
+| Empty, unique in flight | Normal correlation | — |
+| Empty or otherwise reused while in flight | On collision | match id reused while a request was still in flight |
+
+**Alternatives considered**:
+
+- *Fail inside the tracker on registration* — rejected: the message would already be on the wire, and
+  the tracker cannot un-send it.
+- *Reject at build time* — cannot be complete, since `attributes.key` is `Option[Expression[K]]` and an
+  expression can resolve to nothing per session. Kept available as an addition for the statically
+  detectable case (no key expression configured at all), not as a replacement.
+
+---
+
+## R3 — Resolving the fetch position on the poll thread
+
+**Decision**: In `completeAssignedReadiness`, for each assigned partition of a topic awaiting
+readiness, call `consumer.position(tp, timeout)` before completing that topic's readiness futures. On
+timeout or failure, fail **only that topic's** futures; do not call `markConsumerFailed`.
+
+**Rationale**:
+
+- `position()` is legal from both call sites. `completeAssignedReadiness` is invoked from
+  `onPartitionsAssigned` — which the Kafka client runs on the poll thread inside `poll()`, and where
+  `position`/`seek` are explicitly supported — and from the tail of `updateSubscription()`, which
+  `run()` calls on the same thread. The method already documents "Runs on the consumer thread only,
+  since it reads the consumer's assignment."
+- `position()` resolves the fetch position, performing a `ListOffsets` round trip when none is cached.
+  That is precisely the work that currently happens *after* readiness is declared, and moving it in
+  front of the completion is what makes "ready" mean "a reply published from now on will be seen".
+- The bounded overload (`position(TopicPartition, Duration)`) exists so a slow or unavailable
+  coordinator cannot park the single poll thread indefinitely. That thread timestamps every reply for
+  every topic on the consumer, so an unbounded block there is a whole-run stall.
+- Failing only the awaiting topic is deliberate. `markConsumerFailed` latches
+  `consumerFailure` and fails every pending and future subscription for the rest of the run — the
+  terminal state #143 was fixed to prevent. A `ListOffsets` timeout on one topic must not reproduce it.
+
+**Cost**: once per topic per assignment, not per record. The per-reply path is untouched.
+
+**Alternatives considered**:
+
+- *Poll once with a short timeout and treat a completed poll as positioned* — indirect, and a poll that
+  returns no records does not prove a position was resolved for the topic being awaited.
+- *`seekToEnd` then `position`* — `seekToEnd` is lazy and only sets a pending reset, so it moves the
+  problem rather than resolving it; it would also override a legitimate committed offset for a group
+  that has one.
+- *Set `auto.offset.reset=earliest` by default* — changes a published default (Principle I), and
+  replays the entire reply topic history into a load run.
+
+---
+
+## R4 — Does removing the rebalance tuning give a red-before gate? **No.**
+
+**Finding (contradicts #193's premise).** #193 says the readiness gap is "masked, not fixed, by
+`KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0` in both broker definitions". The working tree says
+otherwise. `docker-compose.kafka.yml:25-33` carries a comment recording that the setting was retained
+**for speed, not correctness**, and that the simulation was verified green with Kafka's 3000 default:
+
+> KafkaGatlingTest no longer *depends* on it. […] Since #196 gave the simulation a real echo responder
+> and #191 made the reply channel exist before the request is sent, an immediate reply is always
+> received. Verified by running the simulation three times against this broker with the value at
+> Kafka's 3000 default: green each time.
+
+**Decision**: Still remove the setting (FR-022 requires it, and keeping a correctness-shaped workaround
+that nobody depends on invites re-masking later) — but treat the removal as **hygiene, not proof**. The
+red-before gate for User Story 3 is the new `PositionedReadinessSpec`.
+
+**Why the two facts are compatible**: the rebalance delay changes *when* the first assignment happens.
+The defect lives in the window *between* assignment and position resolution, which the delay neither
+widens nor narrows. The simulations pass at 3000 because their replies happen to arrive after position
+resolution, not because the window is closed.
+
+**Consequence for the spec**: SC-005 reads "where the same verification against the current behaviour
+fails". That is satisfied by `PositionedReadinessSpec`, not by the tuning removal. Recorded here so the
+task list does not assert a red-before that will not appear, and flagged to the user.
+
+---
+
+## R5 — Making positioned readiness observable, decisively
+
+**Decision**: A Testcontainers integration spec, `PositionedReadinessSpec`, that **measures the size of
+the gap** rather than racing to land inside it. Against a fresh topic and consumer group with
+`auto.offset.reset=latest`:
+
+1. Start a producer emitting a **continuous numbered stream** to the topic, and let it run before the
+   subscription is requested, so the log-end offset is already moving.
+2. Request the topic subscription and block on the returned readiness future.
+3. The instant readiness completes, read the sequence number the producer has reached — call it `S`.
+4. Let the consumer receive; take the sequence number of the **first record actually delivered** — `F`.
+5. Assert `F <= S`. One assertion, no tolerance, no repetition.
+
+**Rationale**: readiness completing means "everything published from now on will be seen". `S` is
+exactly "now". So `F <= S` *is* the contract, expressed directly.
+
+Pre-fix, readiness completes inside `onPartitionsAssigned` while position resolution is still pending;
+the position then resolves to the log-end offset at *resolution* time, which is well past `S` because
+the stream never stopped. `F > S`, and the difference is every record produced during the window —
+tens of records over milliseconds, not a knife-edge. Post-fix the position is resolved before the
+future completes, so `F <= S` always.
+
+**This replaces an earlier statistical design** (publish one marker after readiness, repeat 25 times,
+hope to land in the window). That version could go green pre-fix by luck, and a check that passes by
+luck proves nothing. The continuous stream converts the race into a measured interval: the assertion is
+decisive in both directions on a single run.
+
+**Reporting**: on failure, report `F - S` — the number of replies that would have been silently
+skipped. That number is the defect, stated in the units a reader cares about.
+
+**Alternatives considered**:
+
+- *Single marker published after readiness, N iterations, zero tolerance* — the original design.
+  Rejected: statistical, slow, and green-by-luck pre-fix is possible. Superseded by the above.
+- *Inject a `MockConsumer` and assert `position()` is called before the future completes* — also
+  deterministic, but `DynamicKafkaConsumer` builds its `KafkaConsumer` internally, so it needs a new
+  injection seam on a published class (Principle III) and asserts consumer lifecycle against a stub,
+  which Principle II names explicitly. Not needed now that the broker-level assertion is decisive.
+- *Assert on consumer metrics / log-end offset via AdminClient* — proves where the position ended up,
+  not that it was resolved before readiness was announced. Measures the wrong edge.
+
+---
+
+## R6 — Absent payload: failure, not empty value
+
+**Decision**: `msg.value == null` produces a `Validation` failure naming the absent payload, in all
+three currently unguarded preparers. A **present-but-empty** value keeps today's behaviour exactly.
+
+**Rationale**:
+
+- The shape already exists in the same file. `xmlPreparer` and `avroPreparer`
+  (`KafkaMessagePreparer.scala:53-62`) wrap the identical work in `safely(ErrorMapper) { … }`. Bringing
+  `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` to that shape is consistency, not a
+  new pattern — which is also the strongest evidence the omission was an oversight.
+- Returning `""` for an absent payload would make `bodyString.is("")` pass on a tombstone, silently
+  equating "the service sent nothing" with "the service sent an empty string". A check that cannot
+  distinguish those is worse than one that fails.
+- `stringBodyPreparer` and `bytesBodyPreparer` already branch on `value.length > 0` to return `""` /
+  `Array.emptyByteArray`, so the empty case is explicitly handled today and must not regress (FR-010).
+
+**Second layer**: `completeMatched` (`KafkaMessageTracker.scala:153-163`) is `try`/`finally` with no
+`catch`. Even with the three preparers fixed, any throwing check strands the virtual user — no KO, no
+continuation. Adding a `catch` that reports KO and continues makes FR-008 true for all checks rather
+than for the three being repaired. Both layers are needed: the preparer fix gives a *good* message, the
+catch guarantees a *terminal* one.
+
+---
+
+## R7 — Observing partition placement
+
+**Decision**: Create one explicitly multi-partition topic in `docker-compose.kafka.yml`'s `topic-init`,
+publish keyless messages to it from a Gatling scenario, and read placement back with an `AdminClient` /
+consumer assertion after the run.
+
+**Rationale**: every topic in `topic-init` is currently created `--partitions 1`, and
+`KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"` means an unlisted topic is auto-created with the broker
+default of 1 partition. Without an explicit multi-partition topic there is nothing for the defect to be
+visible against — the assertion would pass trivially both before and after.
+
+The assertion must observe placement directly (per-partition end offsets, or consuming and grouping by
+partition). The defective behaviour raises no error: all messages arrive, on one partition.
+
+---
+
+## R8 — Wiring `KafkaConcurrencyLoadTest` into CI
+
+**Decision**: Add it to the existing Gatling step in `ci.yml`.
+
+**Rationale**:
+
+- It is already exactly what FR-019 asks for and does not exist elsewhere: 30 concurrent virtual users,
+  a ramp, a dedicated echo responder, real DSL/action pipeline. Its header states it is "Not wired into
+  CI; run manually", and it already carries a **zero** reply-loss budget with the comment that every
+  known source of loss is closed.
+- Every request-reply scenario in `KafkaGatlingTest` injects `atOnceUsers(1)`. A one-user-at-a-time
+  profile cannot observe a reply attributed to the wrong user, so `KafkaGatlingTest` alone can never
+  satisfy FR-019 no matter what assertions it gains.
+- Adding it to the existing step rather than a new job keeps one Compose stack and one coverage run.
+
+**Cost**: its injection window is ~110s plus setup, against the existing 120s `maxDuration` for
+`KafkaGatlingTest`. Roughly doubles the Gatling step. Accepted — it is the only concurrent coverage
+there is.
+
+**Alternative considered**: *raise `KafkaGatlingTest`'s request-reply scenarios to multiple users
+instead*. Rejected as a replacement: that simulation's assertions are built around exactly-one
+by-design failure (`scnRRwo`), and multiplying users multiplies that expected count, weakening the
+pinned-count convention FR-024 depends on. Worth doing **as well**, for the keyless scenarios only,
+where the expected count stays derivable.
+
+---
+
+## R9 — Observed during baseline: a first-run reply-timeout flake matching the US3 signature
+
+**Recorded 2026-08-07 while establishing the T003 baseline.** Not a decision — an observation that
+bears on §R4 and on how much the Gatling simulations can be trusted as a US3 gate.
+
+`KafkaGatlingTest` was run twice against the same broker (a Compose stack that had been up for three
+days, with `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0` still in place):
+
+| Run | Result | Failed events | Errors | Duration |
+|---|---|---|---|---|
+| 1st, immediately after `compose up -d` re-ran `topic-init` | **FAIL** | 3 (expected 1) | 2 × `Reply timeout after 5000 ms`, 1 × `Reply timeout after 60000 ms` | 65 s |
+| 2nd, same stack, nothing changed | **PASS** | 1 (as designed) | 1 × `Reply timeout after 5000 ms` | 10 s |
+
+Both `Request Reply String` and `Request Reply Bytes` timed out in the first run. The echo responder
+was demonstrably alive — `awaitResponderReady` probes every route and throws otherwise, and it passed —
+so those two requests timed out against a responder that was answering. That is precisely the User
+Story 3 signature.
+
+**What this does and does not establish:**
+
+- It does **not** prove the assignment-vs-position gap caused it. A first join to a consumer group after
+  a long idle period involves coordinator state this observation cannot see into, and n=1.
+- It does show the defect class is reachable in practice, which §R4 could not demonstrate from the
+  compose comment alone. §R4's conclusion stands — removing the rebalance tuning is still not a gate —
+  but the underlying gap is less theoretical than that section implies.
+- It confirms **the Gatling simulations cannot be the US3 gate in either direction**: they are
+  timing-dependent enough to fail spuriously on a cold path and pass on a warm one. `PositionedReadinessSpec`
+  (§R5) measuring `F <= S` remains the only decisive check.
+
+**Consequence for the work**: none of the plan changes. It reinforces T023 as the gate and is a caution
+against reading a green simulation run as evidence that US3 is fixed.
+
+## Resolved unknowns
+
+| Unknown from Technical Context | Resolution |
+|---|---|
+| Absent-key representation | `null` end to end; `MatchKey` separates it from empty for free — R1 |
+| Where to fail an uncorrelatable request | Before `acquireTracker`, via the existing `reportFailure` — R2 |
+| Is `position()` safe on the poll thread | Yes, from both call sites; bounded, and fails only the awaited topic — R3 |
+| Does dropping the broker tuning prove anything | **No** — hygiene only; the gate is `PositionedReadinessSpec` — R4 |
+| How to prove positioned readiness | Continuous stream; assert `F <= S` in one decisive run — R5 |
+| Absent vs empty payload semantics | Absent → failure; empty → unchanged; plus a terminal catch — R6 |
+| How to observe partition spread | Explicit multi-partition topic + direct placement assertion — R7 |
+| Where concurrent coverage comes from | Wire the existing `KafkaConcurrencyLoadTest` into CI — R8 |
+
+**No NEEDS CLARIFICATION markers remain.**

--- a/specs/004-reply-correlation-correctness/spec.md
+++ b/specs/004-reply-correlation-correctness/spec.md
@@ -1,0 +1,397 @@
+# Feature Specification: Reply Correlation Correctness
+
+**Feature Branch**: `004-reply-correlation-correctness`
+
+**Created**: 2026-08-07
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/gatling-kafka-plugin/milestone/3"
+
+Milestone **v1.2.0 Reply correlation correctness** collects the defects that make a request-reply run
+report numbers that are *wrong rather than missing*. Its own summary is the shape of the problem:
+results are silently wrong — replies attributed to the wrong virtual user, stalled users, and false
+timeouts against a system that answered.
+
+One of its four issues has landed: request-reply latency no longer excludes the produce round trip
+(#170). Three remain, and each produces a report a performance engineer would read as a finding about
+the system under test when it is actually an artefact of the tool:
+
+- **Every keyless request is tracked as if it were the same request** (#167). When a request-reply
+  request carries no key, the plugin substitutes an empty key, and an empty key is indistinguishable
+  from an absent one in the correlation bookkeeping. Every keyless user therefore shares one slot, and
+  each new request displaces the one before it. Since v1.1.0 a displaced request is at least failed
+  rather than lost — but it is failed with an explanation about reusing a correlation id, which the
+  engineer never did, and the request that *replaces* it goes on to be resolved by the displaced
+  request's reply. So the surviving defect is a reply credited to a virtual user that did not send the
+  matching request, alongside an advisory failure that misdescribes its own cause. The same
+  substitution also puts a *present* key on the wire where there should be none. Kafka hashes it, and
+  `murmur2` of an empty input is a constant, so every keyless message lands on one partition for the
+  whole run — and a log-compacted topic, which requires a key, silently accepts records it should have
+  rejected.
+- **A reply with no payload hangs the virtual user that receives it** (#168). Body checks against a
+  reply whose payload is absent — routine on compacted topics, and legitimate for any service that
+  answers with a deletion marker — fail in a way the reply-handling path does not catch. The virtual
+  user is never continued: no success, no failure, no next request. It simply stops, and the run's
+  reported user count silently diverges from the load actually applied.
+- **A reply channel reports ready before it can receive** (#193). Readiness is declared when the
+  broker has assigned partitions, which happens before the channel has resolved where in each
+  partition to read from. The plugin reads from the end of the topic by default, so a reply produced
+  in that window is skipped and its request fails on the reply timeout — indistinguishable from a
+  system under test that never answered. Today this is not fixed but *masked*, by a broker-side
+  rebalance-delay setting present in this project's own Compose stack and CI and absent from any real
+  target system. The project therefore cannot currently detect the defect it is shipping.
+
+The first is a correctness defect that misattributes results between users. The second turns a normal
+message into a lost virtual user. The third manufactures failures against a healthy system. All three
+are invisible in the report: nothing in the output distinguishes them from a genuine finding.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A reply is always reported against the user that sent the request (Priority: P1)
+
+A performance engineer runs a request-reply scenario in which requests carry no key. Many virtual users
+run concurrently. Where the scenario correlates on something the request actually carries — a
+self-describing payload, or a header the service echoes — every reply is attributed to the virtual
+user whose request it answers and to no other. Where the scenario correlates on the key it never set,
+the engineer is told so immediately and in those terms, instead of receiving results in which one user
+is credited with another's reply.
+
+**Why this priority**: This is the defect that makes the report actively misleading rather than
+incomplete. A misattributed reply corrupts two measurements at once — a false success for one user and
+a false timeout for another — and both look exactly like real results. Every other number in the run
+is downstream of correlation being right.
+
+**Independent Test**: As a load simulation in CI against a real broker and the echo responder — run
+concurrent keyless request-reply virtual users correlating on a non-key field, and assert that the
+count of successful responses equals the count of requests, that no request is reported as timed out,
+and that no reply is reported against a user that did not send it. Separately, run the same scenario
+correlating on the key and assert every request fails at issue time with a reason naming the missing
+key. Concurrency is essential: a one-user-at-a-time profile cannot expose this defect.
+
+**Acceptance Scenarios**:
+
+1. **Given** two or more virtual users concurrently issue request-reply requests that carry no key,
+   **When** the system under test answers each of them, **Then** each virtual user is reported with
+   the outcome of its own reply and none is reported as timed out.
+2. **Given** a keyless request-reply request is in flight, **When** a second keyless request is issued
+   before the first has been answered, **Then** the first request remains tracked and is still able to
+   be matched by its own reply.
+3. **Given** a request-reply scenario whose requests carry no key and whose configured matching
+   strategy correlates on the key, **When** the scenario runs, **Then** each such request is reported
+   as a failure naming the missing identity as the cause, at the moment it is issued rather than after
+   a reply timeout, and no wrong match is ever reported.
+
+---
+
+### User Story 2 - A reply with no payload fails cleanly instead of stopping the user (Priority: P2)
+
+A performance engineer runs a request-reply scenario against a service that can answer with an empty
+payload — a deletion marker on a compacted topic, or an acknowledgement carrying no body. The scenario
+applies a body-content check to every reply. When such a reply arrives, the check fails, the request is
+reported as a failure with a reason the engineer can read, and the virtual user continues to its next
+request. The run finishes with the number of users it started with.
+
+**Why this priority**: A stalled virtual user is worse than a failed one. It removes load the profile
+was supposed to apply without recording anything, so the achieved throughput no longer matches the
+configured throughput and nothing in the report explains the gap. Reply-content checks are the normal
+way request-reply scenarios are written, so any target that emits empty payloads triggers this.
+
+**Independent Test**: As a load simulation in CI against a real broker — run a request-reply scenario
+with a reply-content check against a responder that answers with an absent payload, and assert both
+that every request is reported as a failure with a stated reason and that every virtual user reaches
+the end of its scenario. The second assertion is the one that catches the defect: a stalled user
+produces no failure, so a failure-count assertion alone would go green on a hung run.
+
+**Acceptance Scenarios**:
+
+1. **Given** a request-reply request with a check on the reply's textual content, **When** the reply
+   arrives with no payload, **Then** the request is reported as a failure whose message identifies the
+   missing payload and the virtual user proceeds to its next action.
+2. **Given** the same scenario using a structured-content check instead of a textual one, **When** the
+   reply arrives with no payload, **Then** the outcome is the same failure-and-continue behaviour, not
+   a different one per check type.
+3. **Given** a run in which every reply has no payload, **When** the run completes, **Then** the number
+   of virtual users that finished equals the number that started.
+
+---
+
+### User Story 3 - A reported timeout always means the system did not answer (Priority: P3)
+
+A performance engineer starts a run whose request-reply traffic begins immediately, against a service
+that answers every request well within the configured reply timeout. No request is reported as timed
+out. The engineer can treat a reply timeout in the report as evidence about the system under test,
+including on the very first requests of a run and in any environment, without needing to tune the
+broker to make the tool behave.
+
+**Why this priority**: This defect fabricates failures rather than misattributing them, and it is
+concentrated at the start of a run where it is easiest to dismiss as warm-up. It is ranked below the
+first two because its blast radius is narrower — a bounded window at channel start rather than every
+keyless request or every empty reply — but it is the one the project currently cannot see at all,
+because the environment that would reveal it is configured to hide it.
+
+**Independent Test**: As a load simulation in CI — run request-reply traffic that starts at the very
+beginning of the run against the echo responder, in an environment using the broker's default
+group-rebalance behaviour with the test-only tuning removed, and assert zero unexpected reply
+timeouts. Removing that tuning is part of the test: with it in place the simulation passes whether or
+not the defect is fixed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reply channel is being established for a topic, **When** the plugin reports that channel
+   as ready, **Then** a reply published from that moment onward is received and matched.
+2. **Given** the project's own automated verification, **When** it runs against a broker configured
+   with default group-rebalance behaviour and no test-only tuning, **Then** request-reply scenarios
+   answered by a real responder report zero reply timeouts.
+3. **Given** a run whose first request-reply request is issued as early as the profile allows,
+   **When** the system under test answers it within the reply timeout, **Then** it is reported as a
+   success and not as a timeout.
+
+---
+
+### User Story 4 - Keyless traffic spreads across partitions like a real producer's (Priority: P4)
+
+A performance engineer runs a throughput scenario that publishes keyless messages to a multi-partition
+topic, in order to measure how the system under test scales across partitions and consumer-group
+members. The messages are distributed across all of the topic's partitions, the way a message with no
+key is distributed by any ordinary producer, so the run measures the partitioned system the engineer
+intended to test.
+
+**Why this priority**: This is realism rather than correctness — the reported numbers are true, but
+they describe a single-partition workload the engineer did not ask for. It is ranked last because it
+misleads about *what was tested* rather than about *what happened*, and because it shares a root cause
+with User Story 1 and will follow from it.
+
+**Independent Test**: As a load simulation in CI against a real broker — publish a large number of
+keyless messages to a topic created with several partitions, then read back where they landed and
+assert that every partition received messages rather than all of them arriving on one. The assertion
+has to observe placement directly; no error is raised by the defective behaviour.
+
+**Acceptance Scenarios**:
+
+1. **Given** a topic with more than one partition, **When** a scenario publishes many messages that
+   carry no key, **Then** every partition of that topic receives at least one message.
+2. **Given** a scenario that publishes messages which do carry a key, **When** it runs, **Then** the
+   existing per-key partition placement is unchanged, so keyed ordering guarantees still hold.
+
+---
+
+### Edge Cases
+
+- Two keyless request-reply requests are in flight at once and both replies arrive nearly
+  simultaneously — each must resolve its own request, and neither may resolve the other's.
+- A request is failed for colliding with another request's correlation identity — the reported reason
+  must distinguish an identity the scenario genuinely reused from one the scenario never supplied,
+  because the corrective action differs and only the first is a duplicate.
+- A request supplies a key that resolves to an empty value, distinct from supplying no key at all —
+  the two must not be treated as the same request, and the distinction must be stable across both the
+  Scala and Java surfaces.
+- A reply arrives carrying no key, no payload, or neither, on a channel where some requests are keyed
+  and others are not.
+- A reply arrives for a request that has already been reported as timed out — the late reply must not
+  resurrect the request or be attributed to a different one.
+- A body check is applied to a reply whose payload is present but empty, as opposed to absent — an
+  empty payload is a value and must keep its current behaviour.
+- The broker reassigns partitions mid-run, so a channel that was ready becomes unready and ready again
+  — readiness must be re-established on the same terms, not assumed to persist.
+- A reply channel is established for a topic that has no messages yet and no committed position.
+- A run applies a ramp or a delayed start, so the first request-reply request is issued long after the
+  protocol was built.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Correlation identity**
+
+- **FR-001**: The plugin MUST distinguish a request that supplies no key from a request that supplies
+  an empty key, and MUST NOT treat the two as the same request for correlation purposes.
+- **FR-002**: Concurrent request-reply requests that each supply a distinct correlation identity MUST
+  remain independently tracked; issuing one MUST NOT displace or resolve another, and supplying no key
+  MUST NOT be what makes two such requests collide.
+- **FR-003**: A reply MUST be reported only against the request it answers. The plugin MUST NOT report
+  a reply against any other request under any timing of arrival.
+- **FR-004**: When a request-reply request cannot be correlated to a reply under the configured
+  matching strategy — because it supplies no identity that strategy can match on — the plugin MUST
+  report that request as a failure at the moment it is issued, rather than send it and produce a match
+  that may be wrong or a timeout that misrepresents the system under test.
+- **FR-005**: The failure reported under FR-004 MUST name the reason — that the request supplies no
+  identity for the configured matching strategy — so an engineer can act on it directly rather than
+  infer it from timeouts.
+- **FR-006**: The plugin MUST NOT invent an identity on the engineer's behalf for a request that
+  supplies none. Nothing may be added to a message that the scenario did not ask to be there.
+
+**Absent payloads**
+
+- **FR-007**: A check against the content of a reply that carries no payload MUST produce a reported
+  failure for that request, with a message identifying the absent payload as the cause.
+- **FR-008**: A reply that carries no payload MUST NOT prevent the virtual user from continuing to its
+  next action. Every request MUST reach a terminal reported outcome — success, failure, or timeout.
+- **FR-009**: All reply-content check types MUST behave consistently for an absent payload; a given
+  reply MUST NOT succeed under one check type and stall the user under another.
+- **FR-010**: A reply whose payload is present but empty MUST retain its existing behaviour and MUST
+  NOT be reclassified as a failure by this change.
+
+**Channel readiness**
+
+- **FR-011**: The plugin MUST NOT report a reply channel as ready until a reply published from that
+  moment onward would be received by it.
+- **FR-012**: A reply published after a channel is reported ready MUST be delivered to correlation,
+  irrespective of how quickly it follows the request.
+- **FR-013**: Reliable reply delivery MUST NOT depend on non-default broker configuration. The
+  plugin MUST behave correctly against a broker in its default state, since a target system is not
+  something a performance engineer can retune to accommodate the tool. (The matching verification
+  obligation is FR-022.)
+
+**Partition distribution**
+
+- **FR-014**: Messages that supply no key MUST be published with an absent key, not with an empty one,
+  so that the broker applies its keyless placement strategy instead of hashing a constant. How records
+  are then distributed is the broker's decision and MUST NOT be specified here — it varies by client
+  version, and pinning it would test the broker rather than the plugin.
+- **FR-015**: Messages that supply a key MUST retain their existing partition placement, so per-key
+  ordering guarantees relied on by existing scenarios are unaffected.
+
+**Compatibility**
+
+- **FR-016**: The published Scala DSL and Java facade MUST keep compiling unchanged for existing
+  scenarios; this feature MUST NOT require a source change to a scenario that does not rely on the
+  defective behaviour.
+- **FR-017**: Any change to observable outcomes for an existing scenario — a keyless request-reply
+  request that previously reported a match and now reports a failure, a reply with no payload that
+  previously stalled its user and now fails it, and keyless messages moving off a single partition —
+  MUST ship with a Migration Guide entry describing what changes, what an engineer should expect to
+  see differently in their results, and how to restore a working scenario in each case.
+
+**Verification**
+
+- **FR-018**: Every user story in this specification MUST be proven by a load simulation in the
+  project's own automated verification, running against a real broker and a real responder in CI.
+  Unit-level assertions alone MUST NOT be accepted as proof for any of them, because every defect in
+  this feature is a property of a concurrent run rather than of a function.
+- **FR-019**: Correlation coverage MUST inject more than one virtual user concurrently into the same
+  reply channel. A single-user profile cannot observe a reply being attributed to the wrong user, so
+  it MUST NOT be relied on as evidence for User Story 1.
+- **FR-020**: Request-reply with requests that supply no key MUST be covered by a simulation, both in
+  the form that correlates on a non-key field and in the form that correlates on the key. Existing
+  keyless coverage is produce-only and MUST NOT be counted as request-reply coverage.
+- **FR-021**: Replies carrying no payload MUST be covered by a simulation in which the responder
+  answers with an absent payload, asserting both the resulting failure count and that every virtual
+  user reaches the end of its scenario.
+- **FR-022**: Readiness coverage MUST run against a broker using its default group-rebalance
+  behaviour. The test-only rebalance tuning MUST be removed from every broker definition the project
+  controls, so that CI itself is what proves the gap is closed rather than what hides it.
+- **FR-023**: Key absence on the wire MUST be asserted by reading published records back and inspecting
+  their keys, rather than inferred from the absence of errors — the defective behaviour raises none.
+  The assertion MUST fail rather than pass if fewer records are read back than were published.
+- **FR-024**: Simulation assertions MUST pin exact expected counts in both directions, following the
+  convention already established in the project's verification: a scenario that stops failing MUST
+  fail the run exactly as a new failure does. Upper-bound-only assertions MUST NOT be used for any
+  criterion in this feature.
+- **FR-025**: Each simulation added or amended for this feature MUST fail against the behaviour that
+  exists before the change and pass after it, and that ordering MUST be demonstrated rather than
+  assumed.
+
+### Key Entities
+
+- **Request-Reply Exchange**: One request sent by one virtual user and the single reply that answers
+  it. Carries the identity used to correlate the two, the moment the request was handed off, and the
+  deadline past which it is reported as timed out. Must belong to exactly one virtual user for its
+  whole life.
+- **Correlation Identity**: The value that connects a reply back to its request under the configured
+  matching strategy. Must be able to represent "this request has no identity to correlate on" as a
+  state distinct from "this request's identity is empty", because those two lead to different
+  reported outcomes.
+- **Reply Channel**: The shared means by which replies for one topic are received on behalf of every
+  virtual user awaiting one. Has a readiness state that, once reported ready, promises delivery of
+  everything published from that point on.
+- **Reply Message**: A message received on a reply channel. Its identity and its payload are each
+  independently allowed to be absent, and each absence has a defined reported outcome.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a run of at least 20 concurrent keyless request-reply virtual users correlating on a
+  non-key field against a responder that answers every request, 100% of requests are reported with the
+  outcome of their own reply, 0 are reported as timed out, and 0 replies are reported against a user
+  that did not send the matching request.
+- **SC-002**: Across the same run, the number of reported successes plus failures equals the number of
+  requests issued — no reply is counted twice and none is unaccounted for.
+- **SC-003**: In a run whose requests supply no key while correlating on the key, 100% of requests are
+  reported as failures naming the missing key, 0 are reported as successes, and 0 are reported as
+  timeouts — the outcome is immediate and identical for every request rather than dependent on timing.
+- **SC-004**: In a run where every reply carries no payload and every request has a reply-content
+  check, 100% of requests are reported as failures with a stated reason and 100% of virtual users
+  reach the end of their scenario.
+- **SC-005**: Request-reply verification passes against a broker using default group-rebalance
+  behaviour with 0 reply timeouts, where the same verification against the current behaviour fails.
+- **SC-006**: A reported reply timeout corresponds to a request the system under test did not answer
+  within the configured window in 100% of observed cases.
+- **SC-007**: In a run publishing at least 20 keyless messages, 100% of the records read back from the
+  broker carry no key, and the count read back equals the count published.
+- **SC-008**: Every simulation in the project's examples and documentation continues to compile and
+  run against the released interface without source changes.
+- **SC-009**: Each of the four user stories has at least one simulation assertion in CI that fails
+  against the pre-change behaviour and passes after the change — 4 of 4 stories covered, 0 relying on
+  unit-level assertions alone.
+- **SC-010**: The full CI verification passes with the test-only rebalance tuning removed from every
+  broker definition the project controls, and 0 such settings remain.
+- **SC-011**: Request-reply simulation coverage includes at least one scenario running concurrent
+  virtual users against a shared reply channel, where the pre-change behaviour produces at least one
+  misattributed or timed-out request and the post-change behaviour produces none.
+
+## Assumptions
+
+- **Scope is the three open issues in milestone v1.2.0** — #167 (keyless correlation and partition
+  distribution), #168 (absent payloads in reply-content checks), and #193 (channel readiness meaning
+  positioned rather than merely assigned, and removing the broker-side rebalance-delay setting that
+  masks it from this project's Compose stack and CI). Issue #170 in the same milestone has already
+  landed and is not revisited here.
+- **A request that supplies no identity to correlate on fails, and the plugin does not invent one.**
+  Decided during specification (FR-004 to FR-006). The alternatives considered were generating a
+  correlation identity per request, and rejecting the scenario before the run starts. Generating one
+  was rejected because it puts a key on the wire the scenario never asked for: the system under test
+  sees it, the message becomes keyed and so hashes to a single partition, contradicting FR-014, and
+  matching then depends on the target echoing a value it was never told about. Build-time rejection
+  was rejected as a *replacement* because keys are session-derived and their absence is often knowable
+  only at runtime, so a runtime path is required regardless; it remains available as an addition
+  during planning if the absence is statically detectable.
+- **This is a deliberate, breaking behaviour change for keyless key-matched scenarios.** Such
+  scenarios report matches today and will report failures after this change. Those matches are the
+  defect, so the change is a correction rather than a regression — but it is observable, so it is
+  governed by Constitution Principle I and carries the Migration Guide obligation in FR-017.
+- **An absent payload is a failure, not an empty value.** A reply-content check applied to a reply with
+  no payload is treated as a failed check rather than as a check against an empty string. This follows
+  #168's stated intent and keeps a deliberate check honest; scenarios that want to accept such replies
+  are expected to express that intent explicitly rather than have it inferred.
+- **Partition distribution applies to every send, not only request-reply.** Restoring ordinary
+  no-key partition behaviour changes fire-and-forget scenarios as well. This is treated as correcting
+  the plugin's realism rather than as a new capability, and is covered by the Migration Guide
+  requirement in FR-016.
+- **Reply topics stay dynamically discovered.** Reply topics may depend on session data and cannot be
+  harvested before a run starts, so this feature makes readiness *correct*, not unnecessary. A
+  protocol-level declaration of reply topics for warm-up is explicitly out of scope — #193 records it
+  as an optimisation with no defect behind it.
+- **The v1.1.0 baseline is assumed, not re-solved.** A request displaced from a correlation slot is
+  already failed explicitly rather than silently lost, and a request is already registered before it is
+  handed to the producer. This feature builds on both. What remains of #167 is that keyless requests
+  share one slot at all, that the resulting failure describes a reuse the engineer did not commit, and
+  that the request which replaces a displaced one can still be resolved by the displaced one's reply.
+- **The correlation table stays where it is.** Moving correlation state out of the tracker is out of
+  scope: #193 records that register-before-send plus mailbox ordering already establish the required
+  happens-before, and that work landed with milestone v1.1.0.
+- **Verification uses a real broker and a real responder, at simulation level.** The echo responder
+  introduced in #196 is the oracle for the readiness and correlation criteria, and every user story is
+  proven by a load simulation in CI rather than by unit assertions (FR-018 to FR-025). Two gaps in the
+  current verification are known and in scope to close: request-reply is exercised only one virtual
+  user at a time, which structurally cannot observe a reply attributed to the wrong user; and the
+  existing keyless coverage publishes without expecting a reply, so it exercises no correlation at
+  all. The convention of pinning exact failure counts in both directions is already established in the
+  project's verification and is adopted here rather than invented.
+- **Existing measurement semantics are unchanged.** Request-reply latency is measured from the moment
+  the request is handed to the producer, as decided and shipped with #170. Nothing in this feature
+  moves the reported clock.
+- **No new dependency is expected**, and no change to the published Scala DSL or Java facade
+  signatures is expected. If the resolution of FR-004 requires either, it is an API-surface decision
+  requiring approval before implementation.

--- a/specs/004-reply-correlation-correctness/spec.md
+++ b/specs/004-reply-correlation-correctness/spec.md
@@ -162,15 +162,16 @@ they describe a single-partition workload the engineer did not ask for. It is ra
 misleads about *what was tested* rather than about *what happened*, and because it shares a root cause
 with User Story 1 and will follow from it.
 
-**Independent Test**: As a load simulation in CI against a real broker — publish a large number of
-keyless messages to a topic created with several partitions, then read back where they landed and
-assert that every partition received messages rather than all of them arriving on one. The assertion
-has to observe placement directly; no error is raised by the defective behaviour.
+**Independent Test**: As an integration test against a real broker — publish keyless messages through
+the DSL, read them back, and assert every record carries no key. The assertion has to read the records
+themselves; the defective behaviour raises no error. Placement is deliberately not asserted: it is the
+broker's decision and changed in Kafka 3.3, so pinning it would test the broker rather than the plugin.
 
 **Acceptance Scenarios**:
 
-1. **Given** a topic with more than one partition, **When** a scenario publishes many messages that
-   carry no key, **Then** every partition of that topic receives at least one message.
+1. **Given** a scenario publishes messages that carry no key, **When** those records are read back
+   from the broker, **Then** every one of them carries an absent key rather than an empty one — which
+   is what lets the broker apply its keyless placement at all.
 2. **Given** a scenario that publishes messages which do carry a key, **When** it runs, **Then** the
    existing per-key partition placement is unchanged, so keyed ordering guarantees still hold.
 

--- a/specs/004-reply-correlation-correctness/tasks.md
+++ b/specs/004-reply-correlation-correctness/tasks.md
@@ -151,19 +151,19 @@ of its scenario.
 
 ### Tests for User Story 2 (MANDATORY — write first, confirm they FAIL) ⚠️
 
-- [ ] T016 [P] [US2] New unit spec `KafkaMessagePreparerSpec` covering all five preparers against absent, empty and present payloads — absent yields a `Validation` failure naming the cause, empty keeps today's behaviour (`""` / empty bytes, success), present parses — in `src/test/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparerSpec.scala` (VR-5 – VR-7)
-- [ ] T017 [P] [US2] Unit test that a check which throws still produces a terminal KO and still continues the virtual user, in `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala` (VR-8)
-- [ ] T018 [US2] Run `sbt "testOnly org.galaxio.gatling.kafka.checks.KafkaMessagePreparerSpec org.galaxio.gatling.kafka.client.KafkaMessageTrackerSpec"` against unmodified code and record that T016 fails with an NPE and T017 fails with no continuation
+- [X] T016 [P] [US2] New unit spec `KafkaMessagePreparerSpec` covering all five preparers against absent, empty and present payloads — absent yields a `Validation` failure naming the cause, empty keeps today's behaviour (`""` / empty bytes, success), present parses — in `src/test/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparerSpec.scala` (VR-5 – VR-7)
+- [X] T017 [P] [US2] Unit test that a check which throws still produces a terminal KO and still continues the virtual user, in `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala` (VR-8)
+- [X] T018 [US2] Red-before demonstrated: three NPEs, `Cannot read the array length because ... KafkaProtocolMessage.value() is null`, from stringBodyPreparer/bytesBodyPreparer/jsonPathPreparer. xmlPreparer passed — it was already wrapped in `safely`, which is the evidence the other three were an oversight. After the fix: 19/19 across both specs.
 
 ### Implementation for User Story 2
 
-- [ ] T019 [US2] Null-guard `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` behind `safely(...)`, matching the existing shape of `xmlPreparer`/`avroPreparer` in the same file, in `src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala` (research §R6)
-- [ ] T020 [US2] Add a `catch` to the `try`/`finally` in `completeMatched` that reports KO and continues the virtual user, in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` (VR-8; **same file as T009 — sequence after Phase 3**)
+- [X] T019 [US2] Null-guard `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` behind `safely(...)`, matching the existing shape of `xmlPreparer`/`avroPreparer` in the same file, in `src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala` (research §R6)
+- [X] T020 [US2] Add a `catch` to the `try`/`finally` in `completeMatched` that reports KO and continues the virtual user, in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` (VR-8; **same file as T009 — sequence after Phase 3**)
 
 ### Simulation-level verification for User Story 2 (FR-021)
 
-- [ ] T021 [US2] Add a request-reply scenario answered with an absent payload and carrying a reply-content check, asserting **both** the exact KO count and that a request executed after it in the same scenario also ran — a stalled user produces no failure, so a failure count alone goes green on a hung run — in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`
-- [ ] T022 [US2] Add a Migration Guide entry for contract C3 — an absent reply payload now KOs instead of stalling the user, and `bodyString.is("")` does not pass on a tombstone — in `README.md`
+- [X] T021 [US2] Add a request-reply scenario answered with an absent payload and carrying a reply-content check, asserting **both** the exact KO count and that a request executed after it in the same scenario also ran — a stalled user produces no failure, so a failure count alone goes green on a hung run — in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`
+- [X] T022 [US2] Add a Migration Guide entry for contract C3 — an absent reply payload now KOs instead of stalling the user, and `bodyString.is("")` does not pass on a tombstone — in `README.md`
 
 **Checkpoint**: US1 and US2 both independently functional.
 
@@ -180,14 +180,14 @@ first record delivered. One run, decisive in both directions.
 
 ### Tests for User Story 3 (MANDATORY — write first, confirm they FAIL) ⚠️
 
-- [ ] T023 [US3] New Testcontainers spec `PositionedReadinessSpec` — fresh topic and consumer group with `auto.offset.reset=latest`, a continuous numbered producer stream started **before** the subscription request, capture `S` when readiness completes and `F` from the first delivered record, assert `F <= S` and report `F - S` on failure — in `src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala` (research §R5)
-- [ ] T024 [US3] Run `sbt "testOnly org.galaxio.gatling.kafka.integration.PositionedReadinessSpec"` against unmodified code and record `F > S` with the observed gap size; if it passes pre-change the stream was idle at readiness, so fix `src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala` before concluding the defect is absent
+- [X] T023 [US3] New Testcontainers spec `PositionedReadinessSpec` — fresh topic and consumer group with `auto.offset.reset=latest`, a continuous numbered producer stream started **before** the subscription request, capture `S` when readiness completes and `F` from the first delivered record, assert `F <= S` and report `F - S` on failure — in `src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala` (research §R5)
+- [X] T024 [US3] Red-before demonstrated, and it is the first direct reproduction of #193: "the channel reported ready at record 107 but the first record it delivered was 110: 3 records published after readiness were skipped". Research §R4 had established that removing the broker workaround could not demonstrate the defect, and §R9 recorded only one unexplained observation; this measures it.
 
 ### Implementation for User Story 3
 
-- [ ] T025 [US3] In `completeAssignedReadiness`, resolve `consumer.position(tp, timeout)` for every assigned partition of a topic awaiting readiness **before** completing that topic's futures, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (research §R3, VR-9)
-- [ ] T026 [US3] On position timeout or failure, complete **only that topic's** readiness futures exceptionally and do not call `markConsumerFailed`, which would poison the pool for the rest of the run — the #143 terminal state — in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-10)
-- [ ] T027 [US3] Confirm both call sites remain poll-thread-only (`onPartitionsAssigned` and the tail of `updateSubscription()`) and update `completeAssignedReadiness`'s scaladoc to state that readiness now means positioned rather than merely assigned, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-11)
+- [X] T025 [US3] In `completeAssignedReadiness`, resolve `consumer.position(tp, timeout)` for every assigned partition of a topic awaiting readiness **before** completing that topic's futures, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (research §R3, VR-9)
+- [X] T026 [US3] On position timeout or failure, complete **only that topic's** readiness futures exceptionally and do not call `markConsumerFailed`, which would poison the pool for the rest of the run — the #143 terminal state — in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-10)
+- [X] T027 [US3] Confirm both call sites remain poll-thread-only (`onPartitionsAssigned` and the tail of `updateSubscription()`) and update `completeAssignedReadiness`'s scaladoc to state that readiness now means positioned rather than merely assigned, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-11)
 
 ### Broker-definition cleanup for User Story 3 (FR-022)
 
@@ -195,9 +195,9 @@ first record delivered. One run, decisive in both directions.
 > `docker-compose.kafka.yml:25-33` records that the simulations were already verified green at Kafka's
 > 3000 default. It is hygiene, not the gate. The gate is T023.
 
-- [ ] T028 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` and its explanatory comment from `docker-compose.kafka.yml`
-- [ ] T029 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` from `.github/workflows/ci.yml`
-- [ ] T030 [US3] Re-run the Compose-stack simulation suite per [quickstart.md](./quickstart.md) step 3 with the setting gone and confirm green (SC-010)
+- [X] T028 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` and its explanatory comment from `docker-compose.kafka.yml`
+- [X] T029 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` from `.github/workflows/ci.yml`
+- [X] T030 [US3] Re-run the Compose-stack simulation suite per [quickstart.md](./quickstart.md) step 3 with the setting gone and confirm green (SC-010)
 
 **Checkpoint**: US1, US2 and US3 all independently functional.
 
@@ -216,13 +216,13 @@ landed — every partition receives messages.
 
 ### Tests for User Story 4 (MANDATORY — write first, confirm they FAIL) ⚠️
 
-- [X] T031 [US4] Add an explicitly multi-partition topic to the `topic-init` service in `docker-compose.kafka.yml` — every existing topic there is `--partitions 1` and `KAFKA_AUTO_CREATE_TOPICS_ENABLE` would otherwise auto-create at 1 partition, leaving nothing for the defect to be visible against (research §R7). **Same file as T028 — sequence after it**
-- [X] T032 [US4] Add a scenario publishing keyless messages to that topic with an assertion that reads placement back directly (per-partition end offsets, or consume and group by partition) and requires every partition to have received messages — the defective behaviour raises no error, so absence of failure proves nothing — in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`
-- [X] T033 [US4] Run `sbt "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest"` against unmodified code and record that T032's messages all land on a single partition
+- [X] T031 [US4] ~~Add an explicitly multi-partition topic~~ — **dropped.** Asserting partition spread tests the broker, not the plugin, and it changed in Kafka 3.3 (keyless records batch stickily). No multi-partition topic exists in either broker definition — every existing topic there is `--partitions 1` and `KAFKA_AUTO_CREATE_TOPICS_ENABLE` would otherwise auto-create at 1 partition, leaving nothing for the defect to be visible against (research §R7). **Same file as T028 — sequence after it**
+- [X] T032 [US4] ~~Assert placement~~ — **replaced** by reading records back and asserting the key is absent, in `KeylessCorrelationSpec`. Placement (per-partition end offsets, or consume and group by partition) and requires every partition to have received messages — the defective behaviour raises no error, so absence of failure proves nothing — in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`
+- [X] T033 [US4] Red-before demonstrated against unmodified code: every keyless record reached the broker carrying a present (empty) key
 
 ### Verification for User Story 4
 
-- [X] T034 [US4] Confirm keyed messages still land by `hash(key) % n` by asserting placement for an existing keyed scenario in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala` (contract C4, FR-015)
+- [X] T034 [US4] ~~Assert keyed placement~~ — **dropped** with T031: keyed placement is unchanged by this feature and asserting it would pin broker behaviour (contract C4, FR-015)
 - [X] T035 [US4] Add a Migration Guide entry for contract C4 — keyless messages now spread across partitions, so keyless throughput numbers may move because they previously described a single-partition workload — in `README.md`
 
 **Checkpoint**: All four stories independently functional.
@@ -231,12 +231,12 @@ landed — every partition receives messages.
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T036 Run `sbt scalafmtAll scalafmtSbt`, then confirm `sbt scalafmtCheckAll scalafmtSbtCheck compile test` is green at the repository root
-- [ ] T037 Run `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` — the Principle I gate; a failure here is an API break to reconsider, not a check to relax (SC-008)
-- [ ] T038 Run the full CI Gatling line including `KafkaConcurrencyLoadTest` per [quickstart.md](./quickstart.md) step 3
-- [ ] T039 Walk the red-before/green-after table in [quickstart.md](./quickstart.md) and confirm all four stories are demonstrated in both directions (SC-009)
-- [ ] T040 Verify the Migration Guide section of `README.md` covers contracts C1, C3 and C4 with remediation for each (FR-017)
-- [ ] T041 Split the work into the three semantic commits in [Commit & Issue Mapping](#commit--issue-mapping-principle-v), each green on its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [X] T036 Run `sbt scalafmtAll scalafmtSbt`, then confirm `sbt scalafmtCheckAll scalafmtSbtCheck compile test` is green at the repository root
+- [X] T037 Run `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` — the Principle I gate; a failure here is an API break to reconsider, not a check to relax (SC-008)
+- [X] T038 Run the full CI Gatling line including `KafkaConcurrencyLoadTest` per [quickstart.md](./quickstart.md) step 3
+- [X] T039 Walk the red-before/green-after table in [quickstart.md](./quickstart.md) and confirm all four stories are demonstrated in both directions (SC-009)
+- [X] T040 Verify the Migration Guide section of `README.md` covers contracts C1, C3 and C4 with remediation for each (FR-017)
+- [X] T041 Split the work into the three semantic commits in [Commit & Issue Mapping](#commit--issue-mapping-principle-v), each green on its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
 - [ ] T042 Open one PR per issue, each assigned to milestone `v1.2.0 Reply correlation correctness` with `Closes #NNN`, and verify each with `scripts/check-linkage.sh --pr <N>`
 
 ---

--- a/specs/004-reply-correlation-correctness/tasks.md
+++ b/specs/004-reply-correlation-correctness/tasks.md
@@ -1,0 +1,338 @@
+---
+
+description: "Task list for 004-reply-correlation-correctness"
+---
+
+# Tasks: Reply Correlation Correctness
+
+**Input**: Design documents from `/specs/004-reply-correlation-correctness/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md),
+[data-model.md](./data-model.md), [contracts/behavior-contract.md](./contracts/behavior-contract.md)
+
+**Tests**: MANDATORY per Constitution Principle IV. Every task below that changes observable behaviour
+has a test task before it, and each must be demonstrated failing against pre-change code (FR-025).
+Per Principle II, Kafka behaviour is tested against Testcontainers or the `docker-compose.kafka.yml`
+stack — never mocks.
+
+**Organization**: One phase per user story, in spec priority order.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel — different files, no dependency on an incomplete task
+- **[Story]**: US1–US4 from [spec.md](./spec.md)
+
+## Path Conventions
+
+Single-module Scala/sbt project:
+
+- **Plugin sources**: `src/main/scala/org/galaxio/gatling/kafka/{protocol,actions,client,checks,request}/`
+- **Tests**: `src/test/scala/org/galaxio/gatling/kafka/{client,checks,actions,integration,examples}/`
+- **Broker/CI truth**: `docker-compose.kafka.yml`, `.github/workflows/ci.yml`
+
+---
+
+## Scope & Effort
+
+Production change is **~50 lines across 6 files**. Verification is roughly 70% of the work — 3 new test
+files, 3 amended simulations, 2 broker definitions, 2 CI edits.
+
+| Story | Issue | Production change | Value |
+|---|---|---|---|
+| US1 | #167 (p0) | 2 lines + a guard | Replies stop being credited to the wrong virtual user |
+| US2 | #168 (p1) | ~20 lines | Virtual users stop disappearing on an empty reply |
+| US3 | #193 (p1) | ~25 lines | False timeouts at channel start disappear |
+| US4 | #167 (p0) | none — falls out of US1 | Keyless traffic stops collapsing onto one partition |
+
+**T014 is the single highest-value line in this list.** It wires the already-written
+`KafkaConcurrencyLoadTest` into CI. Today every request-reply scenario in CI runs `atOnceUsers(1)`, so
+concurrency defects cannot be caught at all — for this feature or any future one. Do it early in
+Phase 3.
+
+**If scope must be cut**, drop from the bottom: US3's evidence of real-world impact is the weakest
+(research §R4 — the project's own simulations already pass without the broker workaround). US1+US2+US4
+is a coherent release that closes three quarters of the milestone.
+
+---
+
+## Commit & Issue Mapping (Principle V)
+
+One tracked issue = one semantic commit, green on its own. Spec artifacts land first, separately.
+
+| Commit | Issues | Phases | Milestone |
+|---|---|---|---|
+| `docs(speckit): add 004-reply-correlation-correctness spec/plan/tasks` | — | Phase 1 | v1.2.0 |
+| `fix(actions): correlate keyless request-reply per request (#167)` | Closes #167 | Phase 3 + Phase 6 | v1.2.0 |
+| `fix(checks): fail cleanly on replies with no payload (#168)` | Closes #168 | Phase 4 | v1.2.0 |
+| `feat(client): complete reply readiness only once positioned (#193)` | Closes #193 | Phase 5 | v1.2.0 |
+
+**US1 and US4 share issue #167** — both come from the same `key.orNull` change. Separate phases because
+they are independently testable; one commit because they are one fix.
+
+**Migration Guide entries ride with the commit whose behaviour they describe** (FR-017), not in a
+separate docs PR. This is the one deliberate departure from "docs go in their own PR", justified in
+[plan.md](./plan.md) Constitution Check §V.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Land the spec, and establish the baseline that "fails before" is measured against
+
+- [X] T001 Commit every artifact under `specs/004-reply-correlation-correctness/` as one `docs(speckit):` commit, before any `fix`/`feat` commit (Principle V, spec-first) — landed as `72fde73`
+- [X] T002 Confirm the pre-change baseline is green by running `sbt scalafmtCheckAll scalafmtSbtCheck compile test` at the repository root — 57 passed, 0 failed
+- [X] T003 Start the broker stack with `docker compose -f docker-compose.kafka.yml up -d` and confirm `KafkaGatlingTest` and `KafkaJavaapiMethodsGatlingTest` pass unchanged — green on re-run; **first run after an idle broker failed with 2 extra reply timeouts**, see research §R9
+
+**Checkpoint**: A known-green baseline exists, so any red produced later is attributable to a new test.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Blocking prerequisites for all stories
+
+**There are none.** The three defects live in different layers — `actions/` + `client/` for #167,
+`checks/` for #168, `client/` for #193 — and no story depends on another's production change. Every
+story is unblocked after Phase 1.
+
+What needs coordination is **shared files**: five are touched by more than one story and must not be
+edited in parallel. See [Shared-file constraints](#shared-file-constraints-).
+
+**Checkpoint**: All four stories may proceed, in priority order or in parallel.
+
+---
+
+## Phase 3: User Story 1 — A reply is always reported against the user that sent the request (P1) 🎯 MVP
+
+**Goal**: Keyless request-reply requests stop sharing one correlation slot. Where correlation is
+possible, each reply reaches its own virtual user; where it is not, the request fails at issue time with
+a reason naming the missing identity.
+
+**Independent Test**: Concurrent keyless request-reply users correlating on a non-key field against the
+echo responder — request count equals success count, zero timeouts, zero cross-attribution. Separately,
+the same scenario correlating on the key — every request KOs at issue time.
+
+### Tests for User Story 1 (MANDATORY — write first, confirm they FAIL) ⚠️
+
+- [X] T004 [P] [US1] Unit test that `null` and `Array.emptyByteArray` produce distinct match keys, so a reply with an empty id cannot resolve a request registered with none. Two *null* registrations are not covered here and cannot be: the tracker now refuses to register a null match id at all (`Arrays.equals(null, null)` is true, so they would alias). That refusal is asserted separately. In `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala`
+- [X] T005 [P] [US1] Unit test that a request-reply whose matcher yields `null` is reported KO at issue time with a message naming the missing identity, and is never handed to the sender, in `src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala`
+- [X] T006 [P] [US1] New Testcontainers spec `KeylessCorrelationSpec` in `src/test/scala/org/galaxio/gatling/kafka/integration/KeylessCorrelationSpec.scala`, with two tests modelled on `ReplyRegistrationRaceSpec`:
+  - **(a) the red-before gate** — N concurrent keyless exchanges under `KafkaKeyMatcher`: every request must be KO'd with the missing-identity message, none sent, none matched. Pre-fix this fails because the requests collapse into one slot, producing a mix of wrongly-matched OKs and "match id reused" KOs.
+  - **(b) a guard on the fix** — N concurrent keyless exchanges under `KafkaValueMatcher` with distinct values: every request matched to its own reply, zero timeouts. This passes before *and* after; it exists so making the key `null` cannot silently break correlation that already worked.
+- [X] T007 [US1] Red-before demonstrated. Unit: 3 failed / 21 passed — absent-vs-empty match id resolved wrongly (got 1 match, expected 0); no-correlation-id reported no outcome at all (got 0, expected 1). Integration (production files reverted to HEAD): gate test (a) FAILED at 33 s with 0 of 24 requests rejected — all were registered and sent; guard test (b) passed, as expected for a matcher that never reads the key. After the fix: 24/24 unit, 2/2 integration.
+
+### Implementation for User Story 1
+
+- [X] T008 [P] [US1] Replace `key.getOrElse(Array.emptyByteArray)` with `key.orNull` in `resolveToProtocolMessage` in `src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAction.scala` (data-model §1; also delivers US4)
+- [X] T009 [P] [US1] Remove the `if (m == null) Array.emptyByteArray else m` substitution from `matchKeyFor` in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` so `null` and empty become distinct `MatchKey`s (data-model §2, VR-2)
+- [X] T010 [US1] After `val id = matcher.requestMatch(protocolMessage)` in `sendKafkaMessage`, report KO via the existing `reportFailure(...)` and return when `id == null` — before `acquireTracker` and before `sender.send` — in `src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala` (research §R2, VR-1)
+- [X] T011 [P] [US1] Document in scaladoc that `key` and `value` are nullable and that absent differs from empty, in `src/main/scala/org/galaxio/gatling/kafka/request/KafkaProtocolMessage.scala`
+- [X] T012 [US1] Audit every read of `KafkaProtocolMessage.key` under `src/main/scala/org/galaxio/gatling/kafka/` for a non-null assumption now that the produce side can carry `null` (`describeBytes` in `package.scala` already handles it; confirm the rest)
+
+### Simulation-level verification for User Story 1 (FR-018, FR-019)
+
+- [X] T013 [US1] Add a keyless request-reply scenario correlating on value with **concurrent** user injection, plus a keyless scenario correlating on the key whose requests must all KO, using exact-count `is(...)` assertions and a named `details(...)` per expected failure, in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala` (FR-024)
+- [X] T014 [US1] Add `"Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaConcurrencyLoadTest"` to the existing Gatling step in `.github/workflows/ci.yml` and correct its scaladoc header in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaConcurrencyLoadTest.scala`, which currently says "Not wired into CI" (research §R8, FR-019 — **do this first in the phase**)
+- [X] T015 [US1] Add a Migration Guide entry for contract C1 — keyless request-reply under key matching now fails, with both remediations (set a key, or `matchByValue`/`matchByMessage`) — in `README.md`
+
+**Checkpoint**: US1 complete and independently verifiable. This is the MVP — the defect that makes the
+report actively wrong rather than merely incomplete.
+
+---
+
+## Phase 4: User Story 2 — A reply with no payload fails cleanly instead of stopping the user (P2)
+
+**Goal**: A reply carrying no payload produces a readable KO and the virtual user continues. No check,
+of any kind, can leave a request without a terminal outcome.
+
+**Independent Test**: A request-reply scenario with a reply-content check against a responder answering
+with an absent payload — every request KOs with a stated reason, and every virtual user reaches the end
+of its scenario.
+
+### Tests for User Story 2 (MANDATORY — write first, confirm they FAIL) ⚠️
+
+- [ ] T016 [P] [US2] New unit spec `KafkaMessagePreparerSpec` covering all five preparers against absent, empty and present payloads — absent yields a `Validation` failure naming the cause, empty keeps today's behaviour (`""` / empty bytes, success), present parses — in `src/test/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparerSpec.scala` (VR-5 – VR-7)
+- [ ] T017 [P] [US2] Unit test that a check which throws still produces a terminal KO and still continues the virtual user, in `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala` (VR-8)
+- [ ] T018 [US2] Run `sbt "testOnly org.galaxio.gatling.kafka.checks.KafkaMessagePreparerSpec org.galaxio.gatling.kafka.client.KafkaMessageTrackerSpec"` against unmodified code and record that T016 fails with an NPE and T017 fails with no continuation
+
+### Implementation for User Story 2
+
+- [ ] T019 [US2] Null-guard `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` behind `safely(...)`, matching the existing shape of `xmlPreparer`/`avroPreparer` in the same file, in `src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala` (research §R6)
+- [ ] T020 [US2] Add a `catch` to the `try`/`finally` in `completeMatched` that reports KO and continues the virtual user, in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` (VR-8; **same file as T009 — sequence after Phase 3**)
+
+### Simulation-level verification for User Story 2 (FR-021)
+
+- [ ] T021 [US2] Add a request-reply scenario answered with an absent payload and carrying a reply-content check, asserting **both** the exact KO count and that a request executed after it in the same scenario also ran — a stalled user produces no failure, so a failure count alone goes green on a hung run — in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`
+- [ ] T022 [US2] Add a Migration Guide entry for contract C3 — an absent reply payload now KOs instead of stalling the user, and `bodyString.is("")` does not pass on a tombstone — in `README.md`
+
+**Checkpoint**: US1 and US2 both independently functional.
+
+---
+
+## Phase 5: User Story 3 — A reported timeout always means the system did not answer (P3)
+
+**Goal**: A reply channel reports ready only once it can actually receive, so a reply published from
+that moment on is never skipped and never becomes a false timeout.
+
+**Independent Test**: `PositionedReadinessSpec` — with a continuous numbered producer stream running,
+assert `F <= S`, where `S` is the producer sequence at the moment readiness completed and `F` is the
+first record delivered. One run, decisive in both directions.
+
+### Tests for User Story 3 (MANDATORY — write first, confirm they FAIL) ⚠️
+
+- [ ] T023 [US3] New Testcontainers spec `PositionedReadinessSpec` — fresh topic and consumer group with `auto.offset.reset=latest`, a continuous numbered producer stream started **before** the subscription request, capture `S` when readiness completes and `F` from the first delivered record, assert `F <= S` and report `F - S` on failure — in `src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala` (research §R5)
+- [ ] T024 [US3] Run `sbt "testOnly org.galaxio.gatling.kafka.integration.PositionedReadinessSpec"` against unmodified code and record `F > S` with the observed gap size; if it passes pre-change the stream was idle at readiness, so fix `src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala` before concluding the defect is absent
+
+### Implementation for User Story 3
+
+- [ ] T025 [US3] In `completeAssignedReadiness`, resolve `consumer.position(tp, timeout)` for every assigned partition of a topic awaiting readiness **before** completing that topic's futures, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (research §R3, VR-9)
+- [ ] T026 [US3] On position timeout or failure, complete **only that topic's** readiness futures exceptionally and do not call `markConsumerFailed`, which would poison the pool for the rest of the run — the #143 terminal state — in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-10)
+- [ ] T027 [US3] Confirm both call sites remain poll-thread-only (`onPartitionsAssigned` and the tail of `updateSubscription()`) and update `completeAssignedReadiness`'s scaladoc to state that readiness now means positioned rather than merely assigned, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-11)
+
+### Broker-definition cleanup for User Story 3 (FR-022)
+
+> Sequence **after** T025–T026. Research §R4 found this removal does **not** turn CI red pre-fix —
+> `docker-compose.kafka.yml:25-33` records that the simulations were already verified green at Kafka's
+> 3000 default. It is hygiene, not the gate. The gate is T023.
+
+- [ ] T028 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` and its explanatory comment from `docker-compose.kafka.yml`
+- [ ] T029 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` from `.github/workflows/ci.yml`
+- [ ] T030 [US3] Re-run the Compose-stack simulation suite per [quickstart.md](./quickstart.md) step 3 with the setting gone and confirm green (SC-010)
+
+**Checkpoint**: US1, US2 and US3 all independently functional.
+
+---
+
+## Phase 6: User Story 4 — Keyless traffic spreads across partitions (P4)
+
+**Goal**: Keyless messages are distributed across a topic's partitions the way any ordinary producer
+distributes them, so a keyless throughput run measures the partitioned system it was meant to measure.
+
+**Independent Test**: Publish many keyless messages to a multi-partition topic and read back where they
+landed — every partition receives messages.
+
+> **No production change of its own.** This falls out of T008 (`key.orNull`) and ships in the #167
+> commit with Phase 3.
+
+### Tests for User Story 4 (MANDATORY — write first, confirm they FAIL) ⚠️
+
+- [X] T031 [US4] Add an explicitly multi-partition topic to the `topic-init` service in `docker-compose.kafka.yml` — every existing topic there is `--partitions 1` and `KAFKA_AUTO_CREATE_TOPICS_ENABLE` would otherwise auto-create at 1 partition, leaving nothing for the defect to be visible against (research §R7). **Same file as T028 — sequence after it**
+- [X] T032 [US4] Add a scenario publishing keyless messages to that topic with an assertion that reads placement back directly (per-partition end offsets, or consume and group by partition) and requires every partition to have received messages — the defective behaviour raises no error, so absence of failure proves nothing — in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`
+- [X] T033 [US4] Run `sbt "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest"` against unmodified code and record that T032's messages all land on a single partition
+
+### Verification for User Story 4
+
+- [X] T034 [US4] Confirm keyed messages still land by `hash(key) % n` by asserting placement for an existing keyed scenario in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala` (contract C4, FR-015)
+- [X] T035 [US4] Add a Migration Guide entry for contract C4 — keyless messages now spread across partitions, so keyless throughput numbers may move because they previously described a single-partition workload — in `README.md`
+
+**Checkpoint**: All four stories independently functional.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T036 Run `sbt scalafmtAll scalafmtSbt`, then confirm `sbt scalafmtCheckAll scalafmtSbtCheck compile test` is green at the repository root
+- [ ] T037 Run `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` — the Principle I gate; a failure here is an API break to reconsider, not a check to relax (SC-008)
+- [ ] T038 Run the full CI Gatling line including `KafkaConcurrencyLoadTest` per [quickstart.md](./quickstart.md) step 3
+- [ ] T039 Walk the red-before/green-after table in [quickstart.md](./quickstart.md) and confirm all four stories are demonstrated in both directions (SC-009)
+- [ ] T040 Verify the Migration Guide section of `README.md` covers contracts C1, C3 and C4 with remediation for each (FR-017)
+- [ ] T041 Split the work into the three semantic commits in [Commit & Issue Mapping](#commit--issue-mapping-principle-v), each green on its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [ ] T042 Open one PR per issue, each assigned to milestone `v1.2.0 Reply correlation correctness` with `Closes #NNN`, and verify each with `scripts/check-linkage.sh --pr <N>`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: no dependencies
+- **Phase 2 (Foundational)**: empty — nothing blocks the stories
+- **Phases 3–6 (Stories)**: depend only on Phase 1. Priority order is P1 → P2 → P3 → P4, but the
+  production changes are independent
+- **Phase 7 (Polish)**: depends on every story intended for the release
+
+### Shared-file constraints ⚠️
+
+Five files are touched by more than one story. These tasks **must not** run in parallel:
+
+| File | Tasks | Order |
+|---|---|---|
+| `client/KafkaMessageTracker.scala` | T009 (US1), T020 (US2) | T009 → T020 |
+| `examples/KafkaGatlingTest.scala` | T013 (US1), T021 (US2), T032 + T034 (US4) | T013 → T021 → T032 → T034 |
+| `docker-compose.kafka.yml` | T028 (US3), T031 (US4) | T028 → T031 |
+| `.github/workflows/ci.yml` | T014 (US1), T029 (US3) | T014 → T029 |
+| `README.md` | T015 (US1), T022 (US2), T035 (US4) | T015 → T022 → T035 |
+
+Because these span commits, apply each edit inside the commit that owns it — do not batch the file.
+
+### Ordering constraints within stories
+
+- **All tests before their implementation**, each demonstrated failing (T007, T018, T024, T033)
+- **T008 before T032** — US4's assertion cannot pass until `key.orNull` lands
+- **T025–T026 before T028–T029** — fix the readiness gap before removing the broker workaround
+- **T010 after T009** — fail-fast reads the identity `matchKeyFor` must already treat correctly
+
+### Parallel Opportunities
+
+- T004, T005, T006 — three different test files, fully parallel
+- T008, T009, T011 — three different production files, fully parallel
+- T016, T017 — different test files, parallel
+- Across stories: US1 and US3 share no files at all and can be built simultaneously by two people
+- US2 and US4 each collide with US1 on at least one file (see table), so they trail it
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write all three failing tests together:
+Task: "Unit test null vs empty match keys in src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala"
+Task: "Unit test keyless KO at issue time in src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala"
+Task: "Testcontainers KeylessCorrelationSpec in src/test/scala/org/galaxio/gatling/kafka/integration/KeylessCorrelationSpec.scala"
+
+# Then the three independent production edits together:
+Task: "key.orNull in src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAction.scala"
+Task: "Drop the null substitution in matchKeyFor in src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala"
+Task: "Document key/value nullability in src/main/scala/org/galaxio/gatling/kafka/request/KafkaProtocolMessage.scala"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP — User Story 1 only
+
+1. Phase 1 (Setup)
+2. Phase 3 (US1), starting with T014 — one line, and it is what makes every later concurrency claim
+   checkable
+3. **STOP and VALIDATE**: concurrent keyless correlation correct, keyless key-matched requests KO at
+   issue time
+4. Ships as the `fix(actions): … (#167)` commit
+
+US1 alone is a defensible release: it removes the failure that misattributes results between virtual
+users, which is the one that makes a report actively wrong.
+
+### Incremental delivery
+
+1. Setup → baseline green
+2. **US1 + US4** → one commit, `Closes #167` → the report stops lying about who owns a reply
+3. **US2** → one commit, `Closes #168` → no virtual user can be lost to a check
+4. **US3** → one commit, `Closes #193` → a timeout means the system did not answer
+5. Polish → three PRs, one milestone, release-ready
+
+### Parallel team strategy
+
+- Developer A: US1 then US4 — same commit, same files
+- Developer B: US3 — zero file overlap with US1, fully independent
+- Developer C: US2 — waits on T009 for `KafkaMessageTracker.scala`, otherwise independent
+
+---
+
+## Notes
+
+- `[P]` = different files, no dependency on an incomplete task
+- Verify every test fails before implementing it — FR-025 requires it demonstrated, not assumed
+- Commit per issue, not per task (Principle V) — three commits after the spec commit
+- Only contracts C1, C3 and C4 need Migration Guide entries; C5 is strictly an improvement
+- Do not treat removing `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` as evidence the readiness gap is
+  closed — research §R4 explains why it stays green either way

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaAction.scala
@@ -84,7 +84,22 @@ abstract class KafkaAction[K: ClassTag, V: ClassTag](
       value         <- serializeValue(producerTopic, s)
       headers       <- traverse(attributes.headers.map(_(s)))
     } yield KafkaProtocolMessage(
-      key.getOrElse(Array.emptyByteArray),
+      // `orNull`, not an empty array. Substituting one collapsed two distinct states into one and cost
+      // both correctness and realism (issue #167):
+      //
+      //   - Correlation: an empty key is a value, and every keyless request produced the same one, so
+      //     they all shared a single slot in the tracker's correlation table. A reply resolved whichever
+      //     request happened to occupy it, crediting one virtual user with another's answer.
+      //   - The wire: an empty array is a *present* key. Kafka hashes it, and murmur2 of an empty input is
+      //     constant, so keyless records could never be placed as keyless records — and a log-compacted
+      //     topic, which requires a key, accepted records it should have rejected. How the broker places a
+      //     genuinely keyless record is its own decision and has changed across versions, so the plugin
+      //     asserts the key is absent and asserts nothing about placement.
+      //
+      // `KafkaProtocolMessage.key` has always been nullable on the consume side — `from` copies
+      // `consumerRecord.key()` verbatim, which is null for a keyless record. This makes the produce side
+      // agree with it, so no signature changes.
+      key.orNull,
       value,
       producerTopic,
       consumerTopic.getOrElse(producerTopic),

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessages.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessages.scala
@@ -1,5 +1,7 @@
 package org.galaxio.gatling.kafka.actions
 
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.{KafkaKeyMatcher, KafkaMatcher, KafkaMessageMatcher, KafkaValueMatcher}
+
 private[actions] object KafkaRequestFailureMessages {
   def buildFailure(error: String): String =
     s"Failed to build request: ${Option(error).getOrElse("unknown error")}"
@@ -9,4 +11,38 @@ private[actions] object KafkaRequestFailureMessages {
 
   def sendFailure(exception: Throwable): String =
     sendFailure(Option(exception.getMessage).getOrElse(exception.getClass.getSimpleName))
+
+  /** Reported when a request-reply supplies nothing the configured matcher can correlate a reply on — in practice a request
+    * with no key under the default `matchByKey`.
+    *
+    * Such a request used to be tracked under an empty correlation id, which every other keyless request shared, so a reply
+    * resolved whichever one happened to occupy that slot: one virtual user was credited with another's answer and the real
+    * owner timed out (issue #167). There is no correct correlation to perform here, so the request is failed before it is sent
+    * rather than sent and mismatched.
+    *
+    * Names the remedy as well as the cause: the fix is a scenario change, and a message that only states the problem leaves the
+    * reader to guess which of the three matchers they should be using.
+    */
+  def missingCorrelationId(matcherName: String, remedy: String): String =
+    s"Cannot correlate a reply: this request supplies no value for the configured message matcher ($matcherName). $remedy"
+
+  /** The remedy half of [[missingCorrelationId]], chosen from what the matcher reads.
+    *
+    * Parameterising the diagnosis but hardcoding the fix produced advice that contradicted itself: a `matchByValue` user whose
+    * payload was null was told to "correlate with matchByValue", which they already were. What to do about an absent id depends
+    * on what the matcher looks at, so it is derived from the same place the name is.
+    */
+  def remedyFor(matcher: KafkaMatcher): String = matcher match {
+    case KafkaKeyMatcher        =>
+      "Set a key on the request, or correlate on something it already carries with matchByValue/matchByMessage."
+    case KafkaValueMatcher      =>
+      "matchByValue correlates on the payload, so the payload cannot be null — give this request a body, or " +
+        "correlate on a key or header instead."
+    case _: KafkaMessageMatcher =>
+      "matchByMessage correlates on whatever your extractor returns, and it returned nothing for this request. " +
+        "Return a value that is unique per request — and note that returning an empty array instead of null is not a fix: " +
+        "every request that does so shares one correlation id."
+    case _                      =>
+      "The configured matcher returned nothing for this request. Correlate on a value that is present and unique per request."
+  }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyAction.scala
@@ -10,6 +10,7 @@ import io.gatling.core.session.Session
 import io.gatling.core.stats.StatsEngine
 import org.galaxio.gatling.kafka.client.KafkaMessageTracker
 import org.galaxio.gatling.kafka.protocol.KafkaComponents
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.galaxio.gatling.kafka.request.builder.KafkaAttributes
 
@@ -42,6 +43,18 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
   private def failureType(error: Throwable): Option[String] =
     Option(error).map(e => if (e.getClass.getSimpleName.nonEmpty) e.getClass.getSimpleName else e.getClass.getName)
 
+  /** How the configured matcher is named in a failure message.
+    *
+    * Two hazards, both of which [[failureType]] above already handles for exceptions: Scala objects report a trailing `$` from
+    * `getSimpleName`, which would print `KafkaKeyMatcher$`, and an anonymous `new KafkaMatcher { … }` — reachable, since the
+    * trait and `KafkaProtocol` are both public — reports the empty string, which would leave the message with empty parentheses
+    * where the diagnostic name belongs.
+    */
+  private def matcherName(matcher: KafkaMatcher): String = {
+    val simple = matcher.getClass.getSimpleName.stripSuffix("$")
+    if (simple.nonEmpty) simple else matcher.getClass.getName
+  }
+
   override def sendKafkaMessage(requestNameString: String, protocolMessage: KafkaProtocolMessage, session: Session): Unit = {
     val requestStartDate = clock.nowMillis
 
@@ -66,89 +79,106 @@ class KafkaRequestReplyAction[K: ClassTag, V: ClassTag](
         val matcher       = components.kafkaProtocol.messageMatcher
         val id            = matcher.requestMatch(protocolMessage)
 
-        // Acquire, register, then send — in that order, and the order is the point.
-        //
-        // Sending first meant the request was on the wire, and answerable, before anything was watching
-        // for its answer: the pending record was only created from the producer's acknowledgement
-        // callback, which under load can run after a fast responder's reply has already been polled and
-        // broadcast. The reply then matched nothing, was discarded silently, and the request failed on
-        // its reply timeout — indistinguishable from a system under test that never answered (issue
-        // #191).
-        //
-        // Registering first replaces that race with a causal chain: the record is enqueued before the
-        // send, a reply cannot exist before the send, and Gatling's mailbox preserves enqueue order
-        // across producer threads. Acquisition is asynchronous (issue #163), so this still does not
-        // block the virtual user.
-        trackers.acquireTracker(
-          protocolMessage.producerTopic,
-          consumerTopic,
-          matcher,
-          None,
-          components.kafkaProtocol.timeout,
-        )(
-          tracker => {
-            // Distinguishes this registration from any other sharing the same match id — which is the
-            // message key under the default matcher, so a feeder cycling a fixed key set, or a request
-            // with no key at all, reuses it constantly.
-            val token       = registrationToken.incrementAndGet()
-            // The handoff, and what the request is measured from.
-            //
-            // Not the request's start: the reply budget must not be charged for channel acquisition, or a
-            // request can be reported as timed out moments after it was sent. And not the broker's
-            // acknowledgement, which is where this used to start — that excluded the produce leg from
-            // every reported time, understating what the virtual user waits for and leaving this the only
-            // Gatling protocol that measures from something other than handing the request over.
-            val handedOffAt = clock.nowMillis
-            tracker ! KafkaMessageTracker
-              .MessagePublished(
-                id,
-                handedOffAt,
-                components.kafkaProtocol.timeout.toMillis,
-                attributes.checks,
-                session,
-                next,
-                requestNameString,
-                onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
-                token = token,
-              )
-            // The record is registered, so from here every exit has to go through the tracker: it owns
-            // the single terminal outcome and the channel reference. Reporting from this frame instead
-            // would leave the record behind, and its later timeout would report the request a second
-            // time and advance the same virtual user twice.
-            try
-              components.sender.send(protocolMessage)(
-                rm =>
-                  if (logger.underlying.isDebugEnabled) {
-                    logMessage(
-                      s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${rm.topic()}",
-                      protocolMessage,
-                    )
+        if (id == null) {
+          // Nothing to correlate a reply on, so no correct outcome is available later — only a wrong
+          // one. Under the default `matchByKey` this is a request with no key, and it used to be tracked
+          // under an empty correlation id that every other keyless request also produced: they shared a
+          // single slot, and a reply resolved whichever request happened to occupy it, crediting one
+          // virtual user with another's answer while the real owner timed out (issue #167).
+          //
+          // Failed here, before acquisition and before the send, for the same reason the acquisition
+          // failure below does not publish: a request whose reply could never be matched must not reach
+          // the system under test. Nothing is registered at this point, so this frame owns the outcome —
+          // the "every exit goes through the tracker" rule starts at registration, further down.
+          val message = KafkaRequestFailureMessages
+            .missingCorrelationId(matcherName(matcher), KafkaRequestFailureMessages.remedyFor(matcher))
+          logger.error(message)
+          reportFailure(message, None)
+        } else {
+          // Acquire, register, then send — in that order, and the order is the point.
+          //
+          // Sending first meant the request was on the wire, and answerable, before anything was watching
+          // for its answer: the pending record was only created from the producer's acknowledgement
+          // callback, which under load can run after a fast responder's reply has already been polled and
+          // broadcast. The reply then matched nothing, was discarded silently, and the request failed on
+          // its reply timeout — indistinguishable from a system under test that never answered (issue
+          // #191).
+          //
+          // Registering first replaces that race with a causal chain: the record is enqueued before the
+          // send, a reply cannot exist before the send, and Gatling's mailbox preserves enqueue order
+          // across producer threads. Acquisition is asynchronous (issue #163), so this still does not
+          // block the virtual user.
+          trackers.acquireTracker(
+            protocolMessage.producerTopic,
+            consumerTopic,
+            matcher,
+            None,
+            components.kafkaProtocol.timeout,
+          )(
+            tracker => {
+              // Distinguishes this registration from any other sharing the same match id — the message
+              // key under the default matcher, so a feeder cycling a fixed key set reuses it constantly.
+              val token       = registrationToken.incrementAndGet()
+              // The handoff, and what the request is measured from.
+              //
+              // Not the request's start: the reply budget must not be charged for channel acquisition, or a
+              // request can be reported as timed out moments after it was sent. And not the broker's
+              // acknowledgement, which is where this used to start — that excluded the produce leg from
+              // every reported time, understating what the virtual user waits for and leaving this the only
+              // Gatling protocol that measures from something other than handing the request over.
+              val handedOffAt = clock.nowMillis
+              tracker ! KafkaMessageTracker
+                .MessagePublished(
+                  id,
+                  handedOffAt,
+                  components.kafkaProtocol.timeout.toMillis,
+                  attributes.checks,
+                  session,
+                  next,
+                  requestNameString,
+                  onComplete = () => trackers.releaseTracker(consumerTopic, matcher),
+                  token = token,
+                )
+              // The record is registered, so from here every exit has to go through the tracker: it owns
+              // the single terminal outcome and the channel reference. Reporting from this frame instead
+              // would leave the record behind, and its later timeout would report the request a second
+              // time and advance the same virtual user twice.
+              try
+                components.sender.send(protocolMessage)(
+                  rm =>
+                    if (logger.underlying.isDebugEnabled) {
+                      logMessage(
+                        s"Record sent user=${session.userId} key=${describeBytes(protocolMessage.key)} topic=${rm.topic()}",
+                        protocolMessage,
+                      )
+                    },
+                  e => {
+                    logger.error(e.getMessage, e)
+                    tracker ! KafkaMessageTracker.SendFailed(id, e.getMessage, token, failureType(e))
                   },
-                e => {
+                )
+              catch {
+                // The producer reports only ApiException through the callback and rethrows the rest here —
+                // a closed producer, an interrupt, a serializer failure. Letting that escape would reach
+                // the acquisition failure handler below, which knows nothing about the record just
+                // registered.
+                case NonFatal(e) =>
                   logger.error(e.getMessage, e)
                   tracker ! KafkaMessageTracker.SendFailed(id, e.getMessage, token, failureType(e))
-                },
-              )
-            catch {
-              // The producer reports only ApiException through the callback and rethrows the rest here —
-              // a closed producer, an interrupt, a serializer failure. Letting that escape would reach
-              // the acquisition failure handler below, which knows nothing about the record just
-              // registered.
-              case NonFatal(e) =>
-                logger.error(e.getMessage, e)
-                tracker ! KafkaMessageTracker.SendFailed(id, e.getMessage, token, failureType(e))
-            }
-          },
-          e => {
-            logger.error(e.getMessage, e)
-            // Nothing was published. Approved deliberately rather than as a side effect: there is no
-            // ordering that both registers before the send and still publishes when acquisition fails,
-            // and publishing a request whose reply can never be received is the state issue #143 exists
-            // to prevent from the other direction. The virtual user sees the same KO as before.
-            reportFailure(e.getMessage, failureType(e))
-          },
-        )
-      case None           =>
+              }
+            },
+            e => {
+              logger.error(e.getMessage, e)
+              // Nothing was published. Approved deliberately rather than as a side effect: there is no
+              // ordering that both registers before the send and still publishes when acquisition fails,
+              // and publishing a request whose reply can never be received is the state issue #143 exists
+              // to prevent from the other direction. The virtual user sees the same KO as before.
+              reportFailure(e.getMessage, failureType(e))
+            },
+          )
+        }
+
+      case None =>
         val msg =
           s"Request-reply requires consumer settings (consumeSettings) in the Kafka protocol configuration, " +
             s"otherwise the virtual user will hang for ${components.kafkaProtocol.timeout} with no reply"

--- a/src/main/scala/org/galaxio/gatling/kafka/checks/AvroBodyCheckBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/checks/AvroBodyCheckBuilder.scala
@@ -19,9 +19,15 @@ object AvroBodyCheckBuilder {
     val tExtractor = new Extractor[KafkaProtocolMessage, T] {
       val name                                                         = "avroBody"
       val arity                                                        = "find"
-      def apply(prepared: KafkaProtocolMessage): Validation[Option[T]] = {
-        Try(Option(implicitly[Serde[T]].deserializer().deserialize(prepared.consumerTopic, prepared.value))).toValidation
-      }
+      def apply(prepared: KafkaProtocolMessage): Validation[Option[T]] =
+        // The absent-payload guard belongs here, not on `KafkaMessagePreparer.avroPreparer`. This extractor is what
+        // `KafkaCheckSupport.avroBody` and the Java facade actually reach: they materialize through
+        // `kafkaStatusCheckMaterializer`, whose preparer is the identity, so `prepared` is the raw message and nothing
+        // upstream has looked at the payload. Guarding the preparer instead left a tombstone under `avroBody` reporting
+        // Gatling's generic "found nothing" while every other content check named the absent payload (issue #168, FR-009).
+        KafkaMessagePreparer.withPayload(prepared) {
+          Try(Option(implicitly[Serde[T]].deserializer().deserialize(prepared.consumerTopic, prepared.value))).toValidation
+        }
     }.expressionSuccess
 
     new Find.Default[KafkaMessageCheckType, KafkaProtocolMessage, T](tExtractor, displayActualValue = true)

--- a/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala
@@ -25,13 +25,43 @@ object KafkaMessagePreparer {
       .map(header => Try(Charset.forName(new String(header.value(), StandardCharsets.UTF_8))).toValidation)
       .getOrElse(cfg.core.charset.success)
 
+  /** Reported when a check is applied to a reply that carries no payload at all.
+    *
+    * Distinct from an empty payload on purpose. An empty value is something the system under test sent; `null` is the absence
+    * of a value — a tombstone, which is ordinary traffic on a compacted topic. Collapsing the two would let `bodyString.is("")`
+    * pass on a record that says "this key is deleted", which is a different finding from "the service replied with an empty
+    * string" (issue #168).
+    */
+  private val NoPayload = "the reply carries no payload, so there is nothing to check against"
+
+  // XML-specific, and deliberately not applied to the string/JSON/Avro preparers: labelling a malformed-JSON or
+  // deserialization failure "Could not parse response into a DOM Document" sends the reader looking for XML that was
+  // never involved. Those paths already return a Validation of their own (`Try(...).toValidation`,
+  // `jsonParsers.safeParse`), so they need no mapper at all.
+  private val XmlErrorMapper = "Could not parse response into a DOM Document: " + _
+
+  private val AvroErrorMapper = "Could not deserialize response with the configured Avro serde: " + _
+
+  /** Absent payload short-circuits to a failure; everything else keeps its existing behaviour.
+    *
+    * The `msg.value.length` reads below all NPE on a tombstone, and that exception escapes `Check.check` into the tracker,
+    * whose `try`/`finally` has no `catch` — so the virtual user is never continued and simply stops, with nothing in the report
+    * (issue #168).
+    */
+  private[checks] def withPayload[T](msg: KafkaProtocolMessage)(f: => Validation[T]): Validation[T] =
+    if (msg.value == null) NoPayload.failure else f
+
   def stringBodyPreparer(configuration: GatlingConfiguration): KafkaMessagePreparer[String] =
     msg =>
-      messageCharset(configuration, msg)
-        .map(cs => if (msg.value.length > 0) new String(msg.value, cs) else "")
+      withPayload(msg) {
+        messageCharset(configuration, msg)
+          .map(cs => if (msg.value.length > 0) new String(msg.value, cs) else "")
+      }
 
   val bytesBodyPreparer: KafkaMessagePreparer[Array[Byte]] = msg =>
-    (if (msg.value.length > 0) msg.value else Array.emptyByteArray).success
+    withPayload(msg) {
+      (if (msg.value.length > 0) msg.value else Array.emptyByteArray).success
+    }
 
   private val CharsParsingThreshold = 200 * 1000
 
@@ -40,24 +70,31 @@ object KafkaMessagePreparer {
       configuration: GatlingConfiguration,
   ): Preparer[KafkaProtocolMessage, JsonNode] =
     msg =>
-      messageCharset(configuration, msg)
-        .flatMap(bodyCharset =>
-          if (msg.value.length > CharsParsingThreshold)
-            jsonParsers.safeParse(new ByteArrayInputStream(msg.value))
-          else
-            jsonParsers.safeParse(new String(msg.value, bodyCharset)),
-        )
+      withPayload(msg) {
+        messageCharset(configuration, msg)
+          .flatMap(bodyCharset =>
+            if (msg.value.length > CharsParsingThreshold)
+              jsonParsers.safeParse(new ByteArrayInputStream(msg.value))
+            else
+              jsonParsers.safeParse(new String(msg.value, bodyCharset)),
+          )
+      }
 
-  private val ErrorMapper = "Could not parse response into a DOM Document: " + _
-
+  // These two never threw — `safely` already caught it — but they reported the absent payload as a
+  // parse error, which sends the reader looking at their document instead of at the reply. Same guard,
+  // so all five preparers give one answer to one condition (FR-009).
   def xmlPreparer(configuration: GatlingConfiguration): KafkaMessagePreparer[XdmNode] =
     msg =>
-      safely(ErrorMapper) {
-        messageCharset(configuration, msg).map(cs => XmlParsers.parse(new ByteArrayInputStream(msg.value), cs))
+      withPayload(msg) {
+        safely(XmlErrorMapper) {
+          messageCharset(configuration, msg).map(cs => XmlParsers.parse(new ByteArrayInputStream(msg.value), cs))
+        }
       }
 
   def avroPreparer[T <: GenericRecord: Serde](config: GatlingConfiguration, topic: String): KafkaMessagePreparer[T] = msg =>
-    safely(ErrorMapper) {
-      messageCharset(config, msg).map(_ => implicitly[Serde[T]].deserializer().deserialize(topic, msg.value))
+    withPayload(msg) {
+      safely(AvroErrorMapper) {
+        messageCharset(config, msg).map(_ => implicitly[Serde[T]].deserializer().deserialize(topic, msg.value))
+      }
     }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
@@ -13,6 +13,7 @@ import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, ConcurrentLin
 import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 object DynamicKafkaConsumer {
 
@@ -34,6 +35,14 @@ object DynamicKafkaConsumer {
     * nothing depends on it — an idle consumer should cost nothing.
     */
   private val idleBackoffMillis: Long = 1000L
+
+  /** Total budget for resolving fetch positions in one pass, across **all** assigned partitions.
+    *
+    * Bounded because the pass runs on the single thread that timestamps every reply for every topic on this consumer, and it
+    * can run inside `poll()` via the rebalance listener: an unbounded wait there stalls the whole run, and a per-partition
+    * budget would multiply by the assignment width and blow `max.poll.interval.ms` on a wide topic.
+    */
+  private val positionTimeoutMillis: Long = 10000L
 
   private[client] val consumerFailedMessage = "Kafka consumer failed; dynamic consumer can no longer be used"
   private[client] val consumerClosedMessage = "Kafka consumer is closed; topic subscription will not complete"
@@ -126,17 +135,75 @@ final class DynamicKafkaConsumer[K, V] private (
     awaitingAssignment.clear()
   }
 
-  /** Completes readiness for every topic the consumer currently holds partitions for. Runs on the consumer thread only, since
-    * it reads the consumer's assignment.
+  /** Resolves the fetch position for **every** assigned partition, then completes readiness for the topics awaiting it.
+    *
+    * Assignment alone is not enough. It precedes fetch-position resolution, and the plugin defaults `auto.offset.reset` to
+    * `latest`, so a reply produced between the two is skipped: the position resolves to the log end *after* that record, the
+    * request never sees its answer, and it fails on the reply timeout — indistinguishable from a system under test that never
+    * replied (issue #193).
+    *
+    * Positions are resolved for the whole assignment rather than only for awaited topics, because readiness is not a one-shot
+    * property. The plugin calls `subscribe` on every reply-topic acquisition and every idle removal, and the default eager
+    * assignor revokes and re-assigns *all* partitions each time — so a topic that completed readiness earlier gets fresh,
+    * unpositioned partitions and would silently reopen the same window. Scoping this to `awaitingAssignment` made the fix hold
+    * only until the second acquisition of a run, and leaned entirely on `enable.auto.commit` defaulting to true to restore the
+    * position from the pre-revoke commit.
     */
-  private def completeAssignedReadiness(): Unit =
-    if (!awaitingAssignment.isEmpty) {
-      consumer.assignment().asScala.map(_.topic()).toSet.foreach { (topic: String) =>
-        val pending = awaitingAssignment.remove(topic)
-        if (pending != null) {
-          pending.forEach(_.complete(null))
+  private def completeAssignedReadiness(): Unit = {
+    val assigned = consumer.assignment()
+    if (!assigned.isEmpty) {
+      val failure = resolvePositions(assigned)
+      if (!awaitingAssignment.isEmpty) {
+        assigned.asScala.map(_.topic()).toSet.foreach { (topic: String) =>
+          val pending = awaitingAssignment.remove(topic)
+          if (pending != null) {
+            failure match {
+              case None        => pending.forEach(_.complete(null))
+              case Some(cause) => pending.forEach(_.completeExceptionally(cause))
+            }
+          }
         }
       }
+    }
+  }
+
+  /** Resolves the fetch position for the whole assignment under **one** deadline, returning the failure rather than throwing.
+    *
+    * One budget for the pass, not one per partition. `position` takes a per-call timeout, so looping it handed each partition a
+    * fresh 10 s and made the real bound `10 s × partitions` on the single thread that timestamps every reply for every topic —
+    * long enough on a wide topic to blow `max.poll.interval.ms` and get the consumer evicted, which is the opposite of what the
+    * bound was for. In practice the first call resolves every partition that needs it, so the rest are cache hits.
+    *
+    * Failure is scoped to the awaiting topics on purpose. Routing it through `markConsumerFailed` would latch `consumerFailure`
+    * and refuse every present and future subscription for the rest of the run — the terminal state issue #143 exists to prevent
+    * — over what may be one slow `ListOffsets`.
+    *
+    * `WakeupException` propagates: it is how `close()` interrupts a blocked call, and swallowing it would break shutdown.
+    * `InterruptException` deliberately does **not** propagate. It is a `KafkaException`, not a
+    * `java.lang.InterruptedException`, so the run loop's interrupt arm never matches it and it would reach the catch-all that
+    * latches a permanent consumer failure — again #143, reached by the one exception a rethrow was meant to protect. Treated as
+    * a position failure instead; `running` still governs shutdown.
+    */
+  private def resolvePositions(partitions: util.Collection[TopicPartition]): Option[Throwable] =
+    try {
+      val deadline = System.currentTimeMillis() + DynamicKafkaConsumer.positionTimeoutMillis
+      partitions.forEach { tp =>
+        val remaining = math.max(1L, deadline - System.currentTimeMillis())
+        consumer.position(tp, Duration.ofMillis(remaining))
+      }
+      None
+    } catch {
+      case e: WakeupException =>
+        throw e
+      case NonFatal(e)        =>
+        logger.error(s"Could not resolve a fetch position for $partitions; failing readiness for those topics only", e)
+        Some(
+          new IllegalStateException(
+            s"Reply channel is subscribed to $partitions but its fetch position could not be resolved, " +
+              "so a reply published now could be skipped; failing this topic rather than reporting it ready",
+            e,
+          ),
+        )
     }
 
   private def markConsumerFailed(exception: Exception): Unit = {

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -40,9 +40,11 @@ object KafkaMessageTracker {
     * every reported time, understating what the virtual user actually waits for.
     *
     * The match id is not an identity. With the default key matcher it *is* the message key, so a feeder cycling a fixed key set
-    * — or any request that sets no key at all, which serialises to the same empty id — reuses it constantly. Without a token, a
-    * [[SendFailed]] for one request lands on whichever record happens to hold the key at the time and fails it with an
-    * unrelated error.
+    * reuses it constantly — as does any extractor that falls back to a constant. Without a token, a [[SendFailed]] for one
+    * request lands on whichever record happens to hold the key at the time and fails it with an unrelated error.
+    *
+    * A request that supplies *no* id never gets here: [[org.galaxio.gatling.kafka.actions.KafkaRequestReplyAction]] fails it
+    * before registration, because there is nothing to correlate a reply on (issue #167).
     */
   final case class MessagePublished(
       matchId: Array[Byte],
@@ -101,6 +103,10 @@ object KafkaMessageTracker {
     * The alternative was Base64-encoding the id to get a `String` key, which allocated an encoder result on every publish,
     * every acknowledgement, every delivery failure and every reply — three or four times per request on the tracker's single
     * thread — purely to obtain something with value equality. `Array[Byte]` has reference equality, hence the wrapper.
+    *
+    * An absent id and an empty one are different keys. `java.util.Arrays` gives that for free — `hashCode(null)` is 0 against 1
+    * for an empty array, and `equals(null, Array.emptyByteArray)` is false — so no branch is needed here, and none is on the
+    * per-reply path.
     */
   private final class MatchKey(val bytes: Array[Byte]) {
     override val hashCode: Int               = java.util.Arrays.hashCode(bytes)
@@ -110,8 +116,16 @@ object KafkaMessageTracker {
     }
   }
 
-  private def matchKeyFor(m: Array[Byte]): MatchKey =
-    new MatchKey(if (m == null) Array.emptyByteArray else m)
+  /** No substitution. This used to fold `null` into `Array.emptyByteArray`, which made "this request has no id" and "this
+    * request's id is empty" the same map key: every keyless request-reply shared one slot, and a reply carrying an empty key
+    * resolved whichever request currently held it (issue #167).
+    *
+    * What removing it buys is exactly one thing — an absent id and an empty one no longer collide. It does **not** make the
+    * table injective: `java.util.Arrays.equals(null, null)` is `true`, so two null ids would still alias each other. Nothing
+    * here prevents that, which is why a null id is refused at both edges instead — `MessagePublished` will not register one and
+    * `MessageConsumed` will not look one up. Those two guards are the invariant; this function only stops widening it.
+    */
+  private def matchKeyFor(m: Array[Byte]): MatchKey = new MatchKey(m)
 }
 
 /** Actor to record request and response Kafka Events, publishing data to the Gatling core DataWriter
@@ -165,6 +179,20 @@ class KafkaMessageTracker[K, V](
   override def init(): Behavior[TrackerMessage] = {
     // The request is registered here, before it is handed to the producer, so a reply cannot be looked
     // up before the record for it exists (issue #191). The acknowledgement timestamp is not known yet
+    case messageSent: MessagePublished if messageSent.matchId == null =>
+      // The table cannot hold this safely: `Arrays.equals(null, null)` is true, so two of these would
+      // alias each other and re-create issue #167 one key over. The sending side rejects such a request
+      // before it gets here, so this is the symmetric guard to the one `MessageConsumed` already has —
+      // reject at both edges rather than trusting a caller a layer away.
+      logger.error("Refusing to register a request with no match id; it could not be correlated to any reply")
+      failPending(
+        messageSent,
+        clock.nowMillis,
+        None,
+        "Cannot correlate a reply: this request was registered with no match id",
+      )
+      stay
+
     case messageSent: MessagePublished =>
       val key = matchKeyFor(messageSent.matchId)
       if (logger.underlying.isDebugEnabled) {
@@ -220,10 +248,17 @@ class KafkaMessageTracker[K, V](
       val message = responseTransformer.map(_(forTransformMessage)).getOrElse(forTransformMessage)
       val replyId = messageMatcher.responseMatch(message)
       if (replyId == null) {
-        logger.error("no messageMatcher key for read message {}", message.key)
+        // describeBytes, not the raw array: this is the one branch a keyless reply reaches, and `{}` on an
+        // Array[Byte] renders as `[B@1f2e3d`, which tells the reader nothing about why it failed to match.
+        logger.error("no messageMatcher key for read message {}", describeBytes(message.key))
       } else {
-        if (message.key == null || message.value == null) {
-          logger.warn(" --- received message with null key or value")
+        // Only the value. An absent key stopped being suspicious when the plugin started publishing one —
+        // a keyless request-reply correlating on the value or a header is a supported shape and the
+        // migration guide recommends it, so warning per reply would put a line on the thread that gates
+        // reply throughput for every message of a normal run (issue #167). A null value still deserves a
+        // mention: it is what breaks body checks (issue #168).
+        if (message.value == null && logger.underlying.isDebugEnabled) {
+          logger.debug(" --- received message with null value (tombstone)")
         }
         // Every one of these renders the whole payload, one String per character, and SLF4J's
         // placeholder form defers formatting but not argument evaluation. Guarded so a reply costs

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -14,6 +14,7 @@ import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.galaxio.gatling.kafka.{KafkaCheck, KafkaLogging}
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 import scala.concurrent.duration.DurationInt
 
 object KafkaMessageTracker {
@@ -158,23 +159,69 @@ class KafkaMessageTracker[K, V](
       })
     }
 
-  /** Reports a matched reply, whether or not the acknowledgement has landed yet. The caller has already removed the record. */
+  /** Reports a matched reply, whether or not the acknowledgement has landed yet. The caller has already removed the record.
+    *
+    * The `try` covers **only** check evaluation, not the reporting that follows it. That distinction is the whole safety of
+    * this method: `executeNext` logs the response *and* advances the virtual user, so wrapping it as well meant a throw after
+    * the response had already been dispatched would run it a second time — two stats entries for one request and the same user
+    * pushed down the chain twice, in an actor built around exactly one terminal outcome.
+    *
+    * Catching around the check is what issue #168 needs. A check that throws used to escape into a `try`/`finally` with nothing
+    * to catch it: the record had already been removed from `sentMessages`, so no timeout scan could fail it either, and
+    * `next ! session` was never reached — the virtual user simply stopped, with nothing in the report. The preparers no longer
+    * throw on a tombstone, but the guarantee worth having is "no check can strand a virtual user", and that has to hold for
+    * check types this plugin does not own.
+    */
   private def completeMatched(
       published: MessagePublished,
       receivedTimestamp: Long,
       message: KafkaProtocolMessage,
   ): Unit =
-    try
-      processMessage(
-        published.session,
-        published.sentTimestamp,
-        receivedTimestamp,
-        published.checks,
-        message,
-        published.next,
-        published.requestName,
-      )
-    finally published.onComplete()
+    try {
+      val outcome =
+        try Right(Check.check(message, published.session, published.checks))
+        catch {
+          case NonFatal(e) =>
+            logger.error(s"Check execution failed for ${published.requestName}; reporting it as a failure", e)
+            Left(s"Check execution failed: ${Option(e.getMessage).getOrElse(e.getClass.getSimpleName)}")
+        }
+
+      outcome match {
+        case Left(errorMessage)                    =>
+          executeNext(
+            published.session.markAsFailed,
+            published.sentTimestamp,
+            receivedTimestamp,
+            KO,
+            published.next,
+            published.requestName,
+            message.responseCode,
+            Some(errorMessage),
+          )
+        case Right((newSession, Some(Failure(m)))) =>
+          executeNext(
+            newSession.markAsFailed,
+            published.sentTimestamp,
+            receivedTimestamp,
+            KO,
+            published.next,
+            published.requestName,
+            message.responseCode,
+            Some(m),
+          )
+        case Right((newSession, _))                =>
+          executeNext(
+            newSession,
+            published.sentTimestamp,
+            receivedTimestamp,
+            OK,
+            published.next,
+            published.requestName,
+            None,
+            None,
+          )
+      }
+    } finally published.onComplete()
 
   override def init(): Behavior[TrackerMessage] = {
     // The request is registered here, before it is handed to the producer, so a reply cannot be looked
@@ -390,34 +437,5 @@ class KafkaMessageTracker[K, V](
       message,
     )
     next ! session.logGroupRequestTimings(sentTimestamp, receivedTimestamp)
-  }
-
-  /** Processes a matched message
-    */
-  private def processMessage(
-      session: Session,
-      sentTimestamp: Long,
-      receivedTimestamp: Long,
-      checks: List[KafkaCheck],
-      message: KafkaProtocolMessage,
-      next: Action,
-      requestName: String,
-  ): Unit = {
-    val (newSession, error) = Check.check(message, session, checks)
-    error match {
-      case Some(Failure(errorMessage)) =>
-        executeNext(
-          newSession.markAsFailed,
-          sentTimestamp,
-          receivedTimestamp,
-          KO,
-          next,
-          requestName,
-          message.responseCode,
-          Some(errorMessage),
-        )
-      case _                           =>
-        executeNext(newSession, sentTimestamp, receivedTimestamp, OK, next, requestName, None, None)
-    }
   }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/request/KafkaProtocolMessage.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/KafkaProtocolMessage.scala
@@ -7,10 +7,15 @@ import org.apache.kafka.common.header.Headers
 /** Topic may either be an 'input' or an 'output' topic. If both are defined here, the serdes may need to pick one without any
   * real prior knowledge (see KafkaProtocolBuilderNew.matchByMessage)
   *
+  * `key` and `value` are both nullable, and an absent one is distinct from an empty one — the distinction Kafka itself draws. A
+  * null key means the record carries none, which is what makes the partitioner spread it round-robin; a null value is a
+  * tombstone. `from` has always copied both straight off the `ConsumerRecord`, so a received message can carry either. Code
+  * reading them must handle null rather than assume a zero-length array (issues #167 and #168).
+  *
   * @param key
-  *   the event Key
+  *   the event Key, or null when the record has none
   * @param value
-  *   the event 'data'
+  *   the event 'data', or null for a tombstone
   * @param producerTopic
   *   The name of the Kafka topic to which the message will be sent.
   * @param consumerTopic

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestFailureMessagesSpec.scala
@@ -1,5 +1,6 @@
 package org.galaxio.gatling.kafka.actions
 
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.{KafkaKeyMatcher, KafkaMessageMatcher, KafkaValueMatcher}
 import org.scalatest.funsuite.AnyFunSuite
 
 class KafkaRequestFailureMessagesSpec extends AnyFunSuite {
@@ -49,5 +50,37 @@ class KafkaRequestFailureMessagesSpec extends AnyFunSuite {
     val message = KafkaRequestFailureMessages.sendFailure(exception)
 
     assert(message == "Failed to send request to Kafka broker: broker unavailable")
+  }
+
+  test("missing correlation id names the matcher that could not correlate") {
+    val message = KafkaRequestFailureMessages
+      .missingCorrelationId("KafkaKeyMatcher", KafkaRequestFailureMessages.remedyFor(KafkaKeyMatcher))
+
+    assert(message.contains("KafkaKeyMatcher"))
+    assert(message.contains("supplies no value"))
+  }
+
+  test("the remedy fits the matcher that failed, rather than always advising a key") {
+    // Parameterising the diagnosis but hardcoding the fix told a matchByValue user to "correlate with
+    // matchByValue", which they already were.
+    assert(KafkaRequestFailureMessages.remedyFor(KafkaKeyMatcher).contains("Set a key"))
+
+    val byValue = KafkaRequestFailureMessages.remedyFor(KafkaValueMatcher)
+    assert(byValue.contains("payload cannot be null"))
+    assert(!byValue.contains("Set a key"))
+
+    val byMessage = KafkaRequestFailureMessages.remedyFor(KafkaMessageMatcher(_.key))
+    assert(byMessage.contains("extractor"))
+    // The trap this whole change is about: an empty array is not "no id", it is one shared id.
+    assert(byMessage.contains("empty array"))
+  }
+
+  test("missing correlation id is distinguishable from a reused match id") {
+    // Two different defects with two different remedies: no identity at all versus an identity that is
+    // not unique. Reporting the second wording for the first is what issue #167 did.
+    val message = KafkaRequestFailureMessages
+      .missingCorrelationId("KafkaKeyMatcher", KafkaRequestFailureMessages.remedyFor(KafkaKeyMatcher))
+
+    assert(!message.contains("reused"))
   }
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/actions/KafkaRequestReplyActionSpec.scala
@@ -1,0 +1,173 @@
+package org.galaxio.gatling.kafka.actions
+
+import io.gatling.commons.stats.{KO, Status}
+import io.gatling.commons.util.Clock
+import io.gatling.commons.validation._
+import io.gatling.core.CoreComponents
+import io.gatling.core.action.Action
+import io.gatling.core.actor.ActorSystem
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.session.Session
+import io.gatling.core.stats.RecordingStatsEngine
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, Serdes}
+import org.galaxio.gatling.kafka.client.{KafkaMessageTrackerPool, KafkaSender}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.{KafkaKeyMatcher, KafkaValueMatcher}
+import org.galaxio.gatling.kafka.protocol.{KafkaComponents, KafkaProtocol}
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.KafkaAttributes
+
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import scala.concurrent.duration.DurationInt
+
+/** Issue #167 — a request-reply that supplies nothing the configured matcher can correlate on must be failed before it is sent,
+  * not sent and then mismatched.
+  *
+  * Under the default `matchByKey` a request with no key produced an empty correlation id, which every other keyless request
+  * also produced. They shared one slot in the correlation table, so a reply resolved whichever request happened to occupy it:
+  * one virtual user was credited with another's answer while the real owner timed out.
+  *
+  * No broker here on purpose. The guard runs before the reply channel is acquired and before the record reaches the producer,
+  * so the interesting assertions are that the outcome is reported at all and that the sender is never called — both of which
+  * are deterministic and need nothing running. The end-to-end behaviour against a real broker is `KeylessCorrelationSpec`.
+  */
+class KafkaRequestReplyActionSpec extends munit.FunSuite {
+
+  private final class StubClock(now: Long) extends Clock {
+    override def nowMillis: Long = now
+  }
+
+  private final class RecordingAction(val name: String) extends Action {
+    val lastSession: AtomicReference[Session]    = new AtomicReference[Session]()
+    override def !(session: Session): Unit       = execute(session)
+    override def execute(session: Session): Unit = lastSession.set(session)
+  }
+
+  /** Records whether the record ever reached the producer. The whole point of failing early is that it must not. */
+  private final class RecordingSender extends KafkaSender {
+    val sends: AtomicInteger = new AtomicInteger(0)
+
+    override def send(protocolMessage: KafkaProtocolMessage)(
+        onSuccess: RecordMetadata => Unit,
+        onFailure: Throwable => Unit,
+    ): Unit = { sends.incrementAndGet(); () }
+
+    override def close(): Unit = ()
+  }
+
+  private def attributes: KafkaAttributes[Array[Byte], Array[Byte]] =
+    KafkaAttributes[Array[Byte], Array[Byte]](
+      requestName = _ => "request-reply".success,
+      producerTopic = None,
+      consumerTopic = None,
+      key = None,
+      value = _ => Array.emptyByteArray.success,
+      headers = None,
+      keySerde = None,
+      valueSerde = Serdes.ByteArray(),
+      checks = Nil,
+    )
+
+  /** Points at a port nothing listens on: the pool must be present for the request-reply path to be taken at all, but this
+    * guard returns before the pool is touched, so it never has to work.
+    */
+  private def deadConsumerSettings: Map[String, AnyRef] = Map(
+    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG        -> "localhost:0",
+    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
+  )
+
+  private def withAction(
+      matcher: org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaMatcher,
+  )(
+      body: (KafkaRequestReplyAction[Array[Byte], Array[Byte]], RecordingSender, RecordingStatsEngine, RecordingAction) => Unit,
+  ): Unit = {
+    val actorSystem = new ActorSystem()
+    val statsEngine = new RecordingStatsEngine
+    val clock       = new StubClock(1_000L)
+    val sender      = new RecordingSender
+    val next        = new RecordingAction("next")
+    try {
+      val pool           = new KafkaMessageTrackerPool(deadConsumerSettings, actorSystem, statsEngine, clock)
+      val protocol       = KafkaProtocol(
+        producerProperties = Map.empty,
+        consumerProperties = deadConsumerSettings,
+        timeout = 5.seconds,
+        messageMatcher = matcher,
+      )
+      val coreComponents =
+        new CoreComponents(actorSystem, null, null, None, statsEngine, clock, null, GatlingConfiguration.loadForTest())
+      val action         = new KafkaRequestReplyAction[Array[Byte], Array[Byte]](
+        KafkaComponents(coreComponents, protocol, Some(pool), sender),
+        attributes,
+        coreComponents,
+        next,
+        None,
+      )
+      body(action, sender, statsEngine, next)
+    } finally actorSystem.close()
+  }
+
+  private def keylessMessage: KafkaProtocolMessage =
+    KafkaProtocolMessage(
+      key = null,
+      value = "body".getBytes,
+      producerTopic = "request-topic",
+      consumerTopic = "reply-topic",
+    )
+
+  test("a request with no correlation id is failed at issue time rather than sent") {
+    withAction(KafkaKeyMatcher) { (action, sender, statsEngine, next) =>
+      action.sendKafkaMessage("request-reply", keylessMessage, Session("scenario", 1L, null))
+
+      val responses = statsEngine.responses.get()
+      assertEquals(responses.size, 1, "a request that cannot be correlated must still get an outcome")
+      assertEquals(responses.head.status, (KO: Status))
+      assertEquals(
+        responses.head.requestName,
+        "request-reply",
+        "and it must be reported against the request, not swallowed",
+      )
+      assertEquals(
+        sender.sends.get(),
+        0,
+        "it must not reach the producer: a request whose reply could never be matched must not be put on the wire",
+      )
+      assert(next.lastSession.get() != null, "the virtual user must be advanced rather than left hanging")
+      assert(next.lastSession.get().isFailed, "and advanced as failed")
+    }
+  }
+
+  test("the failure names the matcher and the remedy") {
+    withAction(KafkaKeyMatcher) { (action, _, statsEngine, _) =>
+      action.sendKafkaMessage("request-reply", keylessMessage, Session("scenario", 1L, null))
+
+      val message = statsEngine.responses.get().head.message.getOrElse("")
+      assert(message.contains("KafkaKeyMatcher"), s"unexpected message: $message")
+      assert(message.contains("matchByValue"), s"unexpected message: $message")
+      // Not the reused-id wording: the scenario never reused anything, it supplied nothing.
+      assert(!message.contains("reused"), s"unexpected message: $message")
+    }
+  }
+
+  test("a keyless request is not rejected when the matcher correlates on something it carries") {
+    // The guard must key off what the matcher yields, not off the key: a keyless request under
+    // matchByValue has a perfectly good correlation id.
+    //
+    // This asserts only that the request is NOT rejected, which is all this rig can see. Acquisition is
+    // asynchronous and the pool points at a dead port, so the send can never complete here and
+    // `sender.sends` stays 0 whatever the action does — asserting on it would test the rig, not the
+    // code. That the request is actually published is covered end-to-end by KeylessCorrelationSpec's
+    // "concurrent keyless requests still correlate when the matcher uses a field they carry".
+    withAction(KafkaValueMatcher) { (action, _, statsEngine, _) =>
+      action.sendKafkaMessage("request-reply", keylessMessage, Session("scenario", 1L, null))
+
+      assertEquals(
+        statsEngine.responses.get().count(_.message.exists(_.contains("supplies no value"))),
+        0,
+        "a request whose value the matcher can correlate on must not be rejected for having no key",
+      )
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparerSpec.scala
@@ -1,0 +1,91 @@
+package org.galaxio.gatling.kafka.checks
+
+import io.gatling.commons.validation.{Failure, Success, Validation}
+import io.gatling.core.config.GatlingConfiguration
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+
+/** Issue #168 — a reply whose payload is absent must produce a clean failure, not an exception.
+  *
+  * `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` read `msg.value.length` unguarded. `msg.value` is copied
+  * verbatim from `consumerRecord.value()`, which is `null` for a tombstone and for any null-valued reply — normal traffic on a
+  * compacted topic. The resulting NPE escapes `Check.check` into the tracker's `try`/`finally`, which has no `catch`, so the
+  * virtual user is never continued: no success, no failure, no next request. It simply stops.
+  *
+  * Two of the five preparers in the same object already get this right, wrapping the identical work in `safely(...)`, which is
+  * the strongest evidence the other three are an oversight rather than a decision.
+  *
+  * Absent is not empty. An empty payload is a value and keeps its existing behaviour — `bodyString.is("")` must pass on an
+  * empty reply and fail on a tombstone, because "the service sent nothing" and "the service sent an empty string" are different
+  * findings.
+  */
+class KafkaMessagePreparerSpec extends munit.FunSuite {
+
+  private val config      = GatlingConfiguration.loadForTest()
+  private val jsonParsers = io.gatling.core.Predef.defaultJsonParsers
+
+  private def message(value: Array[Byte]): KafkaProtocolMessage =
+    KafkaProtocolMessage(
+      key = "k".getBytes,
+      value = value,
+      producerTopic = "in",
+      consumerTopic = "out",
+    )
+
+  private def failureOf[T](v: Validation[T]): String = v match {
+    case Failure(message) => message
+    case Success(value)   => fail(s"expected a failure, got a success: $value")
+  }
+
+  private def succeeds[T](v: Validation[T]): T = v match {
+    case Success(value)   => value
+    case Failure(message) => fail(s"expected a success, got a failure: $message")
+  }
+
+  // --- absent payload: every preparer must fail, and say why -------------------------------------
+
+  test("stringBodyPreparer fails on an absent payload instead of throwing") {
+    val message1 = failureOf(KafkaMessagePreparer.stringBodyPreparer(config)(message(null)))
+    assert(message1.toLowerCase.contains("no payload"), s"unexpected message: $message1")
+  }
+
+  test("bytesBodyPreparer fails on an absent payload instead of throwing") {
+    val message1 = failureOf(KafkaMessagePreparer.bytesBodyPreparer(message(null)))
+    assert(message1.toLowerCase.contains("no payload"), s"unexpected message: $message1")
+  }
+
+  test("jsonPathPreparer fails on an absent payload instead of throwing") {
+    val message1 = failureOf(KafkaMessagePreparer.jsonPathPreparer(jsonParsers, config)(message(null)))
+    assert(message1.toLowerCase.contains("no payload"), s"unexpected message: $message1")
+  }
+
+  test("xmlPreparer fails on an absent payload instead of throwing") {
+    // Already guarded by `safely`, so this passes before the fix too. It is here to pin that all five
+    // agree: a reply must not succeed under one check type and strand the user under another.
+    val message1 = failureOf(KafkaMessagePreparer.xmlPreparer(config)(message(null)))
+    assert(message1.nonEmpty)
+  }
+
+  // --- empty payload: unchanged, and must stay distinct from absent -------------------------------
+
+  test("an empty payload is a value, not an absent one") {
+    assertEquals(succeeds(KafkaMessagePreparer.stringBodyPreparer(config)(message(Array.emptyByteArray))), "")
+    assertEquals(
+      succeeds(KafkaMessagePreparer.bytesBodyPreparer(message(Array.emptyByteArray))).length,
+      0,
+    )
+  }
+
+  test("a present payload is still parsed") {
+    assertEquals(succeeds(KafkaMessagePreparer.stringBodyPreparer(config)(message("hello".getBytes))), "hello")
+    assertEquals(
+      new String(succeeds(KafkaMessagePreparer.bytesBodyPreparer(message("hello".getBytes)))),
+      "hello",
+    )
+    assertEquals(
+      succeeds(KafkaMessagePreparer.jsonPathPreparer(jsonParsers, config)(message("""{"m":"v"}""".getBytes)))
+        .get("m")
+        .asText(),
+      "v",
+    )
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumerSpec.scala
@@ -156,10 +156,19 @@ class DynamicKafkaConsumerSpec extends munit.FunSuite {
   }
 
   test("a topic requested long after startup is still accepted") {
-    val failures = new CopyOnWriteArrayList[Exception]()
-    val consumer = newConsumerReporting(failures.add(_))
+    val consumer = newConsumer()
 
-    runningConsumer(consumer) {
+    try {
+      // What #143 broke was a *timed* initialization window: it expired, and every reply topic requested
+      // afterwards was refused for the rest of the run. So the property is "elapsed time alone never
+      // refuses a request", and elapsed time is all this needs to reproduce it.
+      //
+      // Deliberately without a running poll loop. This used to start one against `localhost:0` and then
+      // assert on `readiness` right after requesting — but by then the loop is awake and driving a
+      // subscribe against an unreachable broker, so it can fail that subscription asynchronously and
+      // legitimately. The assertion was racing it, and under the CPU contention of a full `sbt test` the
+      // loop won: the test failed for a reason that has nothing to do with lateness. The idle loop's own
+      // behaviour is covered by "a consumer running with nothing requested never fails" above.
       Thread.sleep(1_000)
 
       val readiness = consumer.requestTopicSubscription("late-topic")
@@ -168,8 +177,13 @@ class DynamicKafkaConsumerSpec extends munit.FunSuite {
         !readiness.isCompletedExceptionally,
         "a topic requested long after startup must not be refused",
       )
-      assertEquals(failures.size(), 0, "accepting a late topic must not report a failure")
-    }
+      assertEquals(failureRef(consumer).get(), null, "and must not latch a consumer failure")
+      assertEquals(
+        subscriptionQueue(consumer).size,
+        1,
+        "the late topic must be queued for the consumer to pick up, not dropped",
+      )
+    } finally consumer.close()
   }
 
   test("a blank reply topic fails only that request, not the consumer") {

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
@@ -2,13 +2,16 @@ package org.galaxio.gatling.kafka.client
 
 import io.gatling.commons.stats.{KO, OK, Status}
 import io.gatling.commons.util.Clock
+import io.gatling.commons.validation.Validation
+import io.gatling.core.check.{Check, CheckResult}
 import io.gatling.core.action.Action
 import io.gatling.core.actor.{Actor, ActorSystem}
-import io.gatling.core.session.Session
+import io.gatling.core.session.{Expression, Session}
 import io.gatling.core.stats.RecordingStatsEngine
 import org.galaxio.gatling.kafka.client.KafkaMessageTracker.{ConsumerFailure, MessageConsumed, MessagePublished, SendFailed}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.KafkaCheck
 
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
@@ -302,6 +305,48 @@ class KafkaMessageTrackerSpec extends munit.FunSuite {
       responses.head.message.exists(_.contains("no match id")),
       s"the single outcome must be the refusal, not a match: ${responses.head.message}",
     )
+  }
+
+  // Issue #168, second layer. Fixing the preparers stops the tombstone NPE, but the guarantee worth
+  // having is "no check can strand a virtual user" — which has to hold for check types this plugin does
+  // not own. Before the catch, an exception out of Check.check left the record already removed from
+  // sentMessages (so no timeout scan could fail it) and `next ! session` unreached: the user stopped
+  // with nothing in the report.
+  test("a check that throws is reported as a failure instead of stranding the virtual user") {
+    val statsEngine = new RecordingStatsEngine
+    val next        = new RecordingAction("next")
+    val released    = new AtomicInteger(0)
+    val tracker     =
+      new KafkaMessageTracker[Array[Byte], Array[Byte]]("tracker", statsEngine, new StubClock(9_000L), KafkaKeyMatcher, None)
+    val behavior    = tracker.init()
+
+    val exploding: KafkaCheck = new KafkaCheck {
+      override def check(
+          response: KafkaProtocolMessage,
+          session: Session,
+          preparedCache: java.util.Map[Any, Any],
+      ): Validation[CheckResult] = throw new RuntimeException("check blew up")
+
+      override def checkIf(condition: Expression[Boolean]): Check[KafkaProtocolMessage]                                    = this
+      override def checkIf(condition: (KafkaProtocolMessage, Session) => Validation[Boolean]): Check[KafkaProtocolMessage] =
+        this
+    }
+
+    behavior(
+      published(next, replyTimeout = 0L, requestStart = 1_000L)
+        .copy(checks = List(exploding), onComplete = () => { released.incrementAndGet(); () }),
+    )
+    behavior(replyFor("match-race"))
+
+    val responses = statsEngine.responses.get()
+    assertEquals(responses.size, 1, "a throwing check must still produce an outcome")
+    assertEquals(responses.head.status, (KO: Status))
+    assert(
+      responses.head.message.exists(_.contains("check blew up")),
+      s"the failure must carry the cause: ${responses.head.message}",
+    )
+    assert(next.lastSession.get() != null, "and the virtual user must be advanced, not left hanging")
+    assertEquals(released.get(), 1, "the channel reference must still be released exactly once")
   }
 
   test("a registration with no match id is refused rather than stored") {

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
@@ -268,6 +268,70 @@ class KafkaMessageTrackerSpec extends munit.FunSuite {
       requestName = "request-reply",
     )
 
+  // Issue #167. `matchKeyFor` used to fold a null match id into `Array.emptyByteArray`, so "this request
+  // has no identity" and "this request's identity is empty" became the same map key. Every keyless
+  // request-reply therefore shared one slot, and a reply carrying an empty key resolved whichever request
+  // happened to be occupying it.
+  test("an absent match id and an empty one are different requests") {
+    val statsEngine = new RecordingStatsEngine
+    val next        = new RecordingAction("next")
+    val tracker     =
+      new KafkaMessageTracker[Array[Byte], Array[Byte]]("tracker", statsEngine, new StubClock(9_000L), KafkaKeyMatcher, None)
+    val behavior    = tracker.init()
+
+    behavior(published(next, replyTimeout = 0L, requestStart = 1_000L).copy(matchId = null))
+    // A real reply from a keyless round trip: Kafka distinguishes an absent key from an empty one, and so
+    // must the correlation table. This reply belongs to some other request, not to the one above.
+    behavior(
+      MessageConsumed(
+        received = 5_000L,
+        message = KafkaProtocolMessage(
+          key = Array.emptyByteArray,
+          value = "reply".getBytes(StandardCharsets.UTF_8),
+          producerTopic = "reply-topic",
+          consumerTopic = "reply-topic",
+        ),
+      ),
+    )
+
+    // Exactly one outcome, and it is the refusal — not a match. Before the fix `matchKeyFor` folded null
+    // onto the empty array, so this reply resolved the registration and reported it a second time.
+    val responses = statsEngine.responses.get()
+    assertEquals(responses.size, 1, "a reply whose match id is empty must not resolve a request registered with none")
+    assert(
+      responses.head.message.exists(_.contains("no match id")),
+      s"the single outcome must be the refusal, not a match: ${responses.head.message}",
+    )
+  }
+
+  test("a registration with no match id is refused rather than stored") {
+    val statsEngine = new RecordingStatsEngine
+    val next        = new RecordingAction("next")
+    val tracker     =
+      new KafkaMessageTracker[Array[Byte], Array[Byte]]("tracker", statsEngine, new StubClock(9_000L), KafkaKeyMatcher, None)
+    val behavior    = tracker.init()
+
+    // The sending side rejects these before they get here, so this is the symmetric guard to the one
+    // MessageConsumed already has. It matters because the table cannot hold a null safely:
+    // `Arrays.equals(null, null)` is true, so two of them would alias each other and re-create issue #167
+    // one key over — with a displacement message telling a user who supplied no key to make their key
+    // distinct.
+    behavior(published(next, replyTimeout = 0L, requestStart = 1_000L).copy(matchId = null))
+    behavior(published(next, replyTimeout = 0L, requestStart = 2_000L).copy(matchId = null, token = 2L))
+
+    val responses = statsEngine.responses.get()
+    assertEquals(responses.size, 2, "each refused registration must still be reported, not dropped")
+    assert(
+      responses.forall(_.message.exists(_.contains("no match id"))),
+      s"unexpected messages: ${responses.flatMap(_.message)}",
+    )
+    assert(
+      responses.forall(!_.message.exists(_.contains("reused"))),
+      "a request that supplied no id must not be told it reused one",
+    )
+    assert(next.lastSession.get() != null, "the virtual user must be advanced rather than left hanging")
+  }
+
   test("a reply is reported as soon as it arrives") {
     val statsEngine = new RecordingStatsEngine
     val next        = new RecordingAction("next")

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/BasicSimulation.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/BasicSimulation.scala
@@ -27,7 +27,7 @@ class BasicSimulation extends Simulation {
   def getHeader(headerKey: String): KafkaProtocolMessage => Array[Byte] =
     _.headers
       .flatMap(hs => Option(hs.lastHeader(headerKey)).map(_.value()))
-      .getOrElse(Array.emptyByteArray)
+      .orNull
 
   def kafkaProtocolC: KafkaProtocol = kafka
     .producerSettings(

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaConcurrencyLoadTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaConcurrencyLoadTest.scala
@@ -21,7 +21,12 @@ import scala.concurrent.duration.DurationInt
   * responder, so — unlike KafkaGatlingTest's `scnRRwo` — no scenario here is designed to fail; the residual failures the
   * assertion still tolerates are tracked defects, see `KnownReplyLossBudgetPercent`.
   *
-  * Not wired into CI; run manually against the docker-compose.kafka.yml stack: sbt "Gatling / testOnly
+  * Runs in CI alongside the other simulations (see the "Test (Gatling targeted)" step in ci.yml). It is the only *sustained*
+  * concurrent request-reply coverage: 30 virtual users held for 100 s with a zero reply-loss budget. `KafkaGatlingTest`'s
+  * keyless scenarios (issue #167) inject a handful of concurrent users, which is enough to observe cross-attribution but not to
+  * hold load.
+  *
+  * To run it alone against the docker-compose.kafka.yml stack: sbt "Gatling / testOnly
   * org.galaxio.gatling.kafka.examples.KafkaConcurrencyLoadTest"
   */
 class KafkaConcurrencyLoadTest extends Simulation with StrictLogging {
@@ -161,6 +166,12 @@ class KafkaConcurrencyLoadTest extends Simulation with StrictLogging {
   ).protocols(protocol)
     .assertions(
       global.failedRequests.count.lte(KnownReplyLossBudget),
+      // A zero-failure budget alone cannot establish sustained zero-loss load: a regression that strands every virtual
+      // user logs no responses at all, so `failedRequests.count` is 0, `0 <= 0` holds, maxDuration ends the run and the
+      // gate goes green having proved nothing. Now that this simulation is mandatory CI coverage it has to assert that
+      // work actually completed. The floor is deliberately far below the ~7,500 requests the profile produces — it is a
+      // did-anything-run check, not a throughput assertion, so runner speed cannot make it flap.
+      global.successfulRequests.count.gte(concurrency * 10),
     )
     .maxDuration(3.minutes)
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -20,6 +20,7 @@ import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
 import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, TimeUnit}
 import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
 
 class KafkaGatlingTest extends Simulation with StrictLogging {
 
@@ -35,6 +36,10 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
   private val echoRoutes: Map[String, String] = Map(
     "myTopic1" -> "test.t1",
     "myTopic2" -> "test.t2",
+    // Serves the keyless request-reply scenario (issue #167). Its own route rather than a shared one:
+    // it runs several virtual users at once, and sharing a reply topic with a single-user scenario would
+    // make a cross-attribution failure look like that scenario's problem instead.
+    "myTopic5" -> "test.t5",
   )
 
   /** Header carrying when the responder answered. Round-trip metadata has to ride here rather than in the key or the value:
@@ -44,6 +49,13 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
   private val RespondedAtHeader = "x-responded-at"
 
   private val probeMarker = "_probe"
+
+  /** Concurrent users for the keyless scenarios (issue #167). More than one is the whole point on the value side — a reply
+    * reaching the wrong virtual user is unobservable with a single user in flight — and it keeps the key-side expected failure
+    * count from being satisfiable by one lucky request.
+    */
+  private val KeylessValueUsers = 5
+  private val KeylessKeyUsers   = 3
 
   // Stands in for the service under test. Before this existed the request-reply scenarios were "answered"
   // by sibling fire-and-forget scenarios that happened to publish a matching key or value at a fixed
@@ -196,6 +208,22 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     .timeout(5.seconds)
     .matchByValue
 
+  /** String serializers plus value matching, for the keyless scenario (issue #167). String rather than bytes so the payload can
+    * come from a feeder through EL, which `KafkaAction.serializeValue` only applies to `String` values.
+    */
+  val kafkaProtocolRRKeylessValue: KafkaProtocol = kafka
+    .producerSettings(
+      ProducerConfig.ACKS_CONFIG                   -> "1",
+      ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> "localhost:9093",
+      ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> "org.apache.kafka.common.serialization.StringSerializer",
+      ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> "org.apache.kafka.common.serialization.StringSerializer",
+    )
+    .consumeSettings(
+      "bootstrap.servers" -> "localhost:9093",
+    )
+    .timeout(10.seconds)
+    .matchByValue
+
   // The reply timeout doubles as the acquisition timeout, so it has to outlast establishing the reply
   // channel. At the previous 1 second this scenario failed with "Timed out waiting for consumer
   // assignment to topic 'test.t2'" — a KO for the right count but the wrong reason, and a timing-dependent
@@ -318,6 +346,50 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
         .send[Array[Byte], Array[Byte]]("testWO".getBytes(), "tstBytesWO".getBytes()),
     )
 
+  // Issue #167. `Option(null)` is `None`, so a null key expression is how the DSL expresses "this request
+  // carries no key" — the same idiom `scnwokey` already uses for produce-only.
+  //
+  // These two are the only scenarios here that exercise `KafkaAction`'s key handling itself, which is
+  // where the empty-array substitution lived. KeylessCorrelationSpec builds its KafkaProtocolMessage
+  // directly and so bypasses exactly the code under test.
+
+  /** Distinct payload per virtual user. A feeder rather than an EL expression on the value: EL is only applied when the value
+    * type is `String` (see `KafkaAction.serializeValue`), so a templated `Array[Byte]` would be sent with its placeholder
+    * unresolved — identical for every user, which would make value correlation collide for a reason that has nothing to do with
+    * what is under test.
+    */
+  private val keylessPayloads: Feeder[String] =
+    Iterator.from(1).map(i => Map("payload" -> s"keyless-$i"))
+
+  /** Keyless, correlating on the value each request carries. Several users at once, each with a distinct payload: correlation
+    * has something real to work with, so every one must be answered. `atOnceUsers(1)` — which every other request-reply
+    * scenario here uses — could not show a reply reaching the wrong user even if one did.
+    */
+  val scnRRKeylessValue: ScenarioBuilder = scenario("RequestReply keyless by value")
+    .feed(keylessPayloads)
+    .exec(
+      kafka("Request Reply Keyless Value").requestReply
+        .requestTopic("myTopic5")
+        .replyTopic("test.t5")
+        .send[String, String](null, "#{payload}"),
+    )
+
+  /** Keyless under the default key matching: there is nothing to correlate a reply on, so each request must be failed at issue
+    * time rather than sent. Before the fix these all registered under one shared empty id, and a reply resolved whichever
+    * request happened to hold it.
+    *
+    * The failure *count* here is a smoke check, not the gate: a half-reverted fix that published these requests would produce
+    * the same count via displacement plus one timeout. That the requests never reach the broker is asserted in
+    * `KeylessCorrelationSpec`, which can observe the request topic directly.
+    */
+  val scnRRKeylessKey: ScenarioBuilder = scenario("RequestReply keyless by key")
+    .exec(
+      kafka("Request Reply Keyless Key").requestReply
+        .requestTopic("myTopic5")
+        .replyTopic("test.t5")
+        .send[String, String](null, "no-key-to-match-on"),
+    )
+
   setUp(
     scnRR.inject(atOnceUsers(1)).protocols(kafkaProtocolRRString),
     scn.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConf),
@@ -326,16 +398,27 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     scnAvro4s.inject(atOnceUsers(1)).protocols(kafkaAvro4sConf),
     scnRRwo.inject(atOnceUsers(1)).protocols(kafkaProtocolRRBytes2),
     scnwokey.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConfwoKey),
+    scnRRKeylessValue.inject(atOnceUsers(KeylessValueUsers)).protocols(kafkaProtocolRRKeylessValue),
+    scnRRKeylessKey.inject(atOnceUsers(KeylessKeyUsers)).protocols(kafkaProtocolRRString),
   ).assertions(
-    // Exactly one failure is expected, and it is by design: scnRRwo ("RequestReply w/o answer") sends to
-    // myTopic4, which the echo responder does not consume, so it always KOs on its reply timeout.
+    // Two sources of expected failure, and they are expected for opposite reasons:
     //
-    // `is(1)` rather than `lte(1)`: the previous bound passed when the by-design timeout silently stopped
+    //   - scnRRwo ("RequestReply w/o answer") sends to myTopic4, which the echo responder does not
+    //     consume, so it always KOs on its reply timeout. That is the reply-timeout coverage.
+    //   - scnRRKeylessKey supplies no key under key matching, so there is nothing to correlate a reply
+    //     on and every one of its requests is failed at issue time without being sent (issue #167).
+    //
+    // `is(n)` rather than `lte(n)`: the previous bound passed when the by-design timeout silently stopped
     // failing, so a broken reply-timeout would have dropped the count to 0 and still gone green. Pinning
-    // the count and naming the request that must fail closes the gate in both directions — a second,
-    // real failure fails the run, and so does the expected one starting to pass.
-    global.failedRequests.count.is(1),
+    // the count and naming each request that must fail closes the gate in both directions — a new, real
+    // failure fails the run, and so does an expected one starting to pass.
+    global.failedRequests.count.is(1 + KeylessKeyUsers),
     details("Request Reply Bytes wo").failedRequests.count.is(1),
+    details("Request Reply Keyless Key").failedRequests.count.is(KeylessKeyUsers),
+    // The other half of #167: keyless requests that *can* be correlated must all succeed, concurrently.
+    // Pinned as a success count rather than a failure count of zero, so a scenario that silently stops
+    // running at all fails the run instead of passing it.
+    details("Request Reply Keyless Value").successfulRequests.count.is(KeylessValueUsers),
   ).maxDuration(120.seconds)
 
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -40,7 +40,16 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     // it runs several virtual users at once, and sharing a reply topic with a single-user scenario would
     // make a cross-attribution failure look like that scenario's problem instead.
     "myTopic5" -> "test.t5",
+    // Answered with a *tombstone* rather than an echo — see the responder below (issue #168).
+    "myTopic6" -> "test.t6",
   )
+
+  /** Request topics the responder answers with a null value instead of echoing.
+    *
+    * A tombstone is ordinary traffic on a compacted topic, and it used to take the virtual user down with it: the body check
+    * NPE'd inside the tracker, which had no catch, so the user was never continued — no success, no failure, no next request.
+    */
+  private val tombstoneRoutes: Set[String] = Set("myTopic6")
 
   /** Header carrying when the responder answered. Round-trip metadata has to ride here rather than in the key or the value:
     * `scnRR` matches by key and checks `jsonPath` on the value, `scnRR2` matches by value and checks `bodyBytes`. Any rewrite
@@ -56,6 +65,9 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     */
   private val KeylessValueUsers = 5
   private val KeylessKeyUsers   = 3
+
+  /** Virtual users answered with a tombstone (issue #168). Each contributes one expected KO and one follow-up success. */
+  private val TombstoneUsers = 2
 
   // Stands in for the service under test. Before this existed the request-reply scenarios were "answered"
   // by sibling fire-and-forget scenarios that happened to publish a matching key or value at a fixed
@@ -96,8 +108,12 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
       echoRoutes.get(record.topic()).foreach { replyTopic =>
         val headers = new RecordHeaders()
         headers.add(RespondedAtHeader, System.currentTimeMillis().toString.getBytes)
+        // The probe has to be echoed intact or `awaitResponderReady` never completes for this route, so
+        // only non-probe records get the tombstone treatment.
+        val isProbe = record.value() != null && new String(record.value()) == probeMarker
+        val value   = if (tombstoneRoutes.contains(record.topic()) && !isProbe) null else record.value()
         responderSender.send(
-          KafkaProtocolMessage(record.key(), record.value(), replyTopic, replyTopic, Some(headers)),
+          KafkaProtocolMessage(record.key(), value, replyTopic, replyTopic, Some(headers)),
         )(
           _ => { echoedRoutes.add(record.topic()); () },
           // Never silent: a responder that stops echoing looks exactly like the plugin losing replies,
@@ -382,6 +398,34 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     * the same count via displacement plus one timeout. That the requests never reach the broker is asserted in
     * `KeylessCorrelationSpec`, which can observe the request topic directly.
     */
+  /** Issue #168. The reply is a tombstone, so the body check has nothing to check against.
+    *
+    * Two requests, and the second is the point. A stranded virtual user produces *no* KO at all, so a failure-count assertion
+    * on its own goes green on exactly the run this scenario exists to catch. "Tombstone Follow Up" only executes if the user
+    * survived the first request, which is what turns a hang into a visible, countable difference.
+    */
+  val scnRRTombstone: ScenarioBuilder = scenario("RequestReply tombstone reply")
+    // A distinct key per user, from a feeder rather than an EL reference to `userId`: `userId` is not a
+    // session attribute, so `#{userId}` fails to resolve and the request dies at build time — reported
+    // as a crash with no request stats at all, which makes the scenario silently assert nothing. The
+    // keys must differ because matchByKey would otherwise displace one request with the other.
+    .feed(Iterator.from(1).map(i => Map("tombKey" -> s"tomb-$i")): Feeder[String])
+    .exec(
+      kafka("Request Reply Tombstone").requestReply
+        .requestTopic("myTopic6")
+        .replyTopic("test.t6")
+        .send[String, String]("#{tombKey}", "body")
+        // `is("body")`, not a value that never matches: a check failing on *every* reply cannot tell a tombstone from a
+        // normal echo, so the scenario would stay green with tombstoneRoutes empty or the route lookup broken. This one
+        // succeeds on an echo and can only KO when the payload is absent.
+        .check(bodyString.is("body")),
+    )
+    .exec(
+      kafka("Tombstone Follow Up")
+        .topic("myTopic3")
+        .send[String]("survived"),
+    )
+
   val scnRRKeylessKey: ScenarioBuilder = scenario("RequestReply keyless by key")
     .exec(
       kafka("Request Reply Keyless Key").requestReply
@@ -400,6 +444,7 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     scnwokey.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConfwoKey),
     scnRRKeylessValue.inject(atOnceUsers(KeylessValueUsers)).protocols(kafkaProtocolRRKeylessValue),
     scnRRKeylessKey.inject(atOnceUsers(KeylessKeyUsers)).protocols(kafkaProtocolRRString),
+    scnRRTombstone.inject(atOnceUsers(TombstoneUsers)).protocols(kafkaProtocolRRString),
   ).assertions(
     // Two sources of expected failure, and they are expected for opposite reasons:
     //
@@ -412,13 +457,18 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     // failing, so a broken reply-timeout would have dropped the count to 0 and still gone green. Pinning
     // the count and naming each request that must fail closes the gate in both directions — a new, real
     // failure fails the run, and so does an expected one starting to pass.
-    global.failedRequests.count.is(1 + KeylessKeyUsers),
+    global.failedRequests.count.is(1 + KeylessKeyUsers + TombstoneUsers),
     details("Request Reply Bytes wo").failedRequests.count.is(1),
     details("Request Reply Keyless Key").failedRequests.count.is(KeylessKeyUsers),
     // The other half of #167: keyless requests that *can* be correlated must all succeed, concurrently.
     // Pinned as a success count rather than a failure count of zero, so a scenario that silently stops
     // running at all fails the run instead of passing it.
     details("Request Reply Keyless Value").successfulRequests.count.is(KeylessValueUsers),
+    // Issue #168, and the pair is the assertion. The KO count alone would be satisfied by a run in which
+    // the users hung — a stranded user reports nothing — so the follow-up success count is what proves
+    // they were continued rather than lost.
+    details("Request Reply Tombstone").failedRequests.count.is(TombstoneUsers),
+    details("Tombstone Follow Up").successfulRequests.count.is(TombstoneUsers),
   ).maxDuration(120.seconds)
 
 }

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -221,7 +221,7 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     .consumeSettings(
       "bootstrap.servers" -> "localhost:9093",
     )
-    .timeout(5.seconds)
+    .timeout(15.seconds)
     .matchByValue
 
   /** String serializers plus value matching, for the keyless scenario (issue #167). String rather than bytes so the payload can
@@ -255,7 +255,7 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     .consumeSettings(
       "bootstrap.servers" -> "localhost:9093",
     )
-    .timeout(5.seconds)
+    .timeout(15.seconds)
     .matchByValue
 
   val kafkaAvro4sConf: KafkaProtocol = kafka

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/ReadmeExamplesCompileOnly.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/ReadmeExamplesCompileOnly.scala
@@ -38,7 +38,7 @@ object ReadmeExamplesCompileOnly {
   def correlationIdFromHeader(headerName: String): KafkaProtocolMessage => Array[Byte] =
     _.headers
       .flatMap(headers => Option(headers.lastHeader(headerName)).map(_.value()))
-      .getOrElse(Array.emptyByteArray)
+      .orNull
 
   val matchByMessageProtocol: KafkaProtocol =
     requestReplyProtocolBuilder.matchByMessage(correlationIdFromHeader("correlation-id"))

--- a/src/test/scala/org/galaxio/gatling/kafka/integration/KeylessCorrelationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/KeylessCorrelationSpec.scala
@@ -1,0 +1,382 @@
+package org.galaxio.gatling.kafka.integration
+
+import com.dimafeng.testcontainers.ConfluentKafkaContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import com.typesafe.scalalogging.StrictLogging
+import io.gatling.commons.stats.{OK, Status}
+import io.gatling.commons.util.Clock
+import io.gatling.commons.validation._
+import io.gatling.core.CoreComponents
+import io.gatling.core.action.Action
+import io.gatling.core.actor.ActorSystem
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.session.Session
+import io.gatling.core.stats.{LoggedResponse, RecordingStatsEngine}
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, Serdes}
+import org.galaxio.gatling.kafka.actions.{KafkaRequestAction, KafkaRequestReplyAction}
+import org.galaxio.gatling.kafka.client.{DynamicKafkaConsumer, KafkaMessageTrackerPool, KafkaSender}
+import org.galaxio.gatling.kafka.protocol.KafkaProtocol.{KafkaKeyMatcher, KafkaMatcher, KafkaValueMatcher}
+import org.galaxio.gatling.kafka.protocol.{KafkaComponents, KafkaProtocol}
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.request.builder.KafkaAttributes
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, TimeUnit}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.jdk.CollectionConverters._
+
+/** Issue #167 — a request-reply that carries no key must not share a correlation slot with every other keyless request.
+  *
+  * `KafkaAction` used to substitute `Array.emptyByteArray` for an absent key, and the tracker folded a null match id into that
+  * same empty array. Every keyless request-reply therefore registered under one key in a plain `HashMap`: the second request
+  * displaced the first, and the first reply to arrive resolved whichever request currently occupied the slot. One virtual user
+  * was marked OK on someone else's reply while the real owner timed out.
+  *
+  * Two tests, and they are not the same kind of check:
+  *
+  *   - `keyless under key matching` is the regression gate. Before the fix these requests were registered and sent; now there
+  *     is nothing to correlate them on, so each is failed at issue time and none reaches the broker.
+  *   - `keyless under value matching` is a guard on the fix rather than a gate. It passed before the fix too, because the
+  *     matcher never looked at the key. It is here so that carrying the key as `null` cannot silently break correlation that
+  *     already worked — which is the obvious way to get this fix wrong.
+  */
+class KeylessCorrelationSpec extends munit.FunSuite with TestContainerForAll with StrictLogging {
+
+  override val containerDef: ConfluentKafkaContainer.Def = ConfluentKafkaContainer.Def()
+
+  override def munitTimeout: scala.concurrent.duration.Duration = 5.minutes
+
+  /** Generous on purpose: nothing here should time out, so a timeout means a lost or misrouted reply. */
+  private val ReplyTimeout: FiniteDuration = 30.seconds
+
+  private val Requests = 24
+
+  private def producerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ProducerConfig.ACKS_CONFIG                   -> "1",
+    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> bootstrap,
+    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> classOf[ByteArraySerializer].getName,
+    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[ByteArraySerializer].getName,
+  )
+
+  private def consumerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG        -> bootstrap,
+    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "earliest",
+  )
+
+  private def createTopics(bootstrap: String, names: String*): Unit = {
+    val admin = AdminClient.create(
+      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrap).asJava,
+    )
+    try admin.createTopics(names.map(new NewTopic(_, 1, 1.toShort)).asJava).all().get(30, TimeUnit.SECONDS)
+    finally admin.close()
+  }
+
+  private final class SystemClock extends Clock {
+    override def nowMillis: Long = System.currentTimeMillis()
+  }
+
+  /** Records *which* virtual users were advanced, not just how many.
+    *
+    * A bare counter cannot see the defect this suite exists for. A correlation table that resolved every reply against the
+    * wrong pending request still advances the right number of users — 24 completions, 24 OK, zero timeouts — and only the
+    * identities are wrong. Keeping the ids is what makes cross-attribution observable.
+    */
+  private final class CountingAction extends Action {
+    private val users = ConcurrentHashMap.newKeySet[Long]()
+    private val count = new AtomicInteger(0)
+
+    override def name: String                    = "counting-next"
+    override def !(session: Session): Unit       = execute(session)
+    override def execute(session: Session): Unit = { users.add(session.userId); count.incrementAndGet(); () }
+
+    def completed: Int           = count.get()
+    def distinctUsers: Set[Long] = users.asScala.toSet
+  }
+
+  private def attributes: KafkaAttributes[Array[Byte], Array[Byte]] =
+    KafkaAttributes[Array[Byte], Array[Byte]](
+      requestName = _ => "request-reply".success,
+      producerTopic = None,
+      consumerTopic = None,
+      key = None,
+      value = _ => Array.emptyByteArray.success,
+      headers = None,
+      keySerde = None,
+      valueSerde = Serdes.ByteArray(),
+      checks = Nil,
+    )
+
+  /** Runs `body` with a request-reply action wired to a real broker, plus an echo responder on `requestTopic` that mirrors
+    * every record onto `replyTopic`. `received` counts what the responder saw, which is how "nothing reached the broker" is
+    * asserted.
+    */
+  private def withRig(bootstrap: String, requestTopic: String, replyTopic: String, matcher: KafkaMatcher)(
+      body: (KafkaRequestReplyAction[Array[Byte], Array[Byte]], RecordingStatsEngine, CountingAction, AtomicInteger) => Unit,
+  ): Unit = {
+    createTopics(bootstrap, requestTopic, replyTopic)
+
+    val actorSystem = new ActorSystem()
+    val statsEngine = new RecordingStatsEngine
+    val clock       = new SystemClock
+    val sender      = KafkaSender(producerSettings(bootstrap))
+    val next        = new CountingAction
+    val received    = new AtomicInteger(0)
+
+    val echoSender      = KafkaSender(producerSettings(bootstrap))
+    val echoReady       = new CountDownLatch(1)
+    val responder       = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+      consumerSettings(bootstrap) + (ConsumerConfig.GROUP_ID_CONFIG -> s"$requestTopic-responder"),
+      Set(requestTopic),
+      record => {
+        received.incrementAndGet()
+        echoReady.countDown()
+        echoSender.send(KafkaProtocolMessage(record.key(), record.value(), replyTopic, replyTopic))(
+          _ => (),
+          error => logger.error("[keyless responder] failed to echo", error),
+        )
+      },
+      error => logger.error("[keyless responder] consumer failed", error),
+    )
+    val responderThread = new Thread(responder, s"$requestTopic-responder")
+    responderThread.setDaemon(true)
+    responderThread.start()
+
+    try {
+      val pool           = new KafkaMessageTrackerPool(consumerSettings(bootstrap), actorSystem, statsEngine, clock)
+      val protocol       = KafkaProtocol(
+        producerProperties = producerSettings(bootstrap),
+        consumerProperties = consumerSettings(bootstrap),
+        timeout = ReplyTimeout,
+        messageMatcher = matcher,
+      )
+      val coreComponents =
+        new CoreComponents(actorSystem, null, null, None, statsEngine, clock, null, GatlingConfiguration.loadForTest())
+      val action         = new KafkaRequestReplyAction[Array[Byte], Array[Byte]](
+        KafkaComponents(coreComponents, protocol, Some(pool), sender),
+        attributes,
+        coreComponents,
+        next,
+        None,
+      )
+
+      // Warm the responder so a skipped first echo is never mistaken for a correlation failure. The probe
+      // carries a key, so it is unaffected by what is under test.
+      val warmup = KafkaProtocolMessage("warmup".getBytes, "warmup".getBytes, requestTopic, replyTopic)
+      val sent   = new CountDownLatch(1)
+      sender.send(warmup)(_ => sent.countDown(), _ => sent.countDown())
+      assert(sent.await(30, TimeUnit.SECONDS), "warmup request was never delivered")
+      assert(echoReady.await(60, TimeUnit.SECONDS), "responder never received anything")
+      received.set(0)
+
+      body(action, statsEngine, next, received)
+    } finally {
+      responder.close()
+      echoSender.close()
+      sender.close()
+      actorSystem.close()
+    }
+  }
+
+  private def awaitResponses(
+      statsEngine: RecordingStatsEngine,
+      expected: Int,
+      within: FiniteDuration,
+  ): Vector[LoggedResponse] = {
+    val deadline = System.currentTimeMillis() + within.toMillis
+    while (statsEngine.responses.get().size < expected && System.currentTimeMillis() < deadline)
+      Thread.sleep(100)
+    statsEngine.responses.get()
+  }
+
+  test("concurrent keyless requests under key matching are each failed at issue time, and none is sent") {
+    withContainers { kafka =>
+      withRig(kafka.bootstrapServers, "keyless-key-request", "keyless-key-reply", KafkaKeyMatcher) {
+        (action, statsEngine, next, received) =>
+          // Issued from several threads at once: the defect needed two keyless requests in flight
+          // together, since the second is what displaced the first.
+          val threads = (1 to Requests).map { i =>
+            val t = new Thread(() =>
+              action.sendKafkaMessage(
+                "request-reply",
+                KafkaProtocolMessage(null, s"body-$i".getBytes, "keyless-key-request", "keyless-key-reply"),
+                Session("scenario", i.toLong, null),
+              ),
+            )
+            t.setDaemon(true)
+            t
+          }
+          threads.foreach(_.start())
+          threads.foreach(_.join(30000))
+
+          val responses = awaitResponses(statsEngine, Requests, 60.seconds)
+          assertEquals(responses.size, Requests, "every request must reach a terminal outcome")
+
+          val uncorrelatable = responses.count(_.message.exists(_.contains("supplies no value")))
+          assertEquals(
+            uncorrelatable,
+            Requests,
+            "every keyless request under key matching must be failed for having nothing to correlate on; " +
+              s"instead: ${responses.flatMap(_.message).distinct.mkString(" | ")}",
+          )
+          assertEquals(
+            responses.count(_.status == (OK: Status)),
+            0,
+            "none may be reported as a success: before the fix a reply resolved whichever request held the shared slot",
+          )
+          // Settle first. Every one of these KOs is reported synchronously inside sendKafkaMessage, so
+          // without a wait `received` is sampled milliseconds after the last thread died — before a
+          // produce round trip plus the responder's poll cycle could have shown anything. That would let
+          // a "report the failure but send it anyway" regression pass.
+          Thread.sleep(5000)
+          assertEquals(
+            received.get(),
+            0,
+            "and none may reach the broker: a request whose reply could never be matched must not be published",
+          )
+          assertEquals(next.completed, Requests, "every virtual user must be advanced exactly once")
+      }
+    }
+  }
+
+  test("concurrent keyless requests still correlate when the matcher uses a field they carry") {
+    withContainers { kafka =>
+      withRig(kafka.bootstrapServers, "keyless-value-request", "keyless-value-reply", KafkaValueMatcher) {
+        (action, statsEngine, next, received) =>
+          val threads = (1 to Requests).map { i =>
+            val t = new Thread(() =>
+              action.sendKafkaMessage(
+                "request-reply",
+                KafkaProtocolMessage(null, s"body-$i".getBytes, "keyless-value-request", "keyless-value-reply"),
+                Session("scenario", i.toLong, null),
+              ),
+            )
+            t.setDaemon(true)
+            t
+          }
+          threads.foreach(_.start())
+          threads.foreach(_.join(30000))
+
+          val responses = awaitResponses(statsEngine, Requests, ReplyTimeout + 60.seconds)
+          assertEquals(responses.size, Requests, s"only ${responses.size} of $Requests requests reported an outcome")
+
+          val timedOut = responses.filter(_.message.exists(_.startsWith("Reply timeout")))
+          assertEquals(
+            timedOut.size,
+            0,
+            s"${timedOut.size} of $Requests replies were lost: the responder answered every request, so a timeout " +
+              "here means the reply was not matched to the request that earned it",
+          )
+          assert(
+            responses.forall(_.status == (OK: Status)),
+            s"unexpected failures: ${responses.filterNot(_.status == (OK: Status)).flatMap(_.message).distinct.mkString(" | ")}",
+          )
+          assertEquals(received.get(), Requests, "every request must have reached the broker")
+          assertEquals(next.completed, Requests, "every virtual user must be advanced exactly once")
+          assertEquals(
+            next.distinctUsers,
+            (1L to Requests.toLong).toSet,
+            "each of the distinct virtual users must be advanced: a correlation table that resolved every reply " +
+              "against the wrong request would still advance the right *number* of users",
+          )
+      }
+    }
+  }
+
+  /** Issue #167, the produce side. A request that supplies no key must reach the broker with `key == null`, not with an empty
+    * byte array.
+    *
+    * The distinction is not cosmetic. An empty key is a *present* key: Kafka hashes it, and `murmur2` of an empty input is a
+    * constant, so every keyless record landed on one partition for the whole run. A null key is absent, which is what lets
+    * Kafka apply its keyless strategy at all — and what a log-compacted topic rejects, which is why the Migration Guide has to
+    * mention it.
+    *
+    * Deliberately NOT asserted here: which partitions the records land on. Distribution is Kafka's decision and it changed in
+    * 3.3 (the built-in partitioner now batches keyless records stickily rather than round-robin), so asserting spread would
+    * test Kafka and depend on batch size and timing. What the plugin controls is the key on the wire.
+    *
+    * Driven through `sendRequest`, not `sendKafkaMessage`: the substitution lived in `KafkaAction.resolveToProtocolMessage`,
+    * which only the former runs. Handing a pre-built `KafkaProtocolMessage` to the latter would bypass the code under test.
+    */
+  test("a request that supplies no key is published with no key") {
+    withContainers { kafka =>
+      val bootstrap = kafka.bootstrapServers
+      val topic     = "keyless-produce"
+      createTopics(bootstrap, topic)
+
+      val actorSystem = new ActorSystem()
+      val statsEngine = new RecordingStatsEngine
+      val sender      = KafkaSender(producerSettings(bootstrap))
+      val next        = new CountingAction
+      try {
+        val protocol       = KafkaProtocol(
+          producerProperties = producerSettings(bootstrap),
+          consumerProperties = consumerSettings(bootstrap),
+          timeout = ReplyTimeout,
+          messageMatcher = KafkaKeyMatcher,
+        )
+        val coreComponents = new CoreComponents(
+          actorSystem,
+          null,
+          null,
+          None,
+          statsEngine,
+          new SystemClock,
+          null,
+          GatlingConfiguration.loadForTest(),
+        )
+        // key = None is what the DSL produces for `send[K, V](null, payload)`, since `Option(null)` is `None`.
+        val keyless        = attributes.copy(producerTopic = Some(_ => topic.success))
+        val action         = new KafkaRequestAction[Array[Byte], Array[Byte]](
+          KafkaComponents(coreComponents, protocol, None, sender),
+          keyless,
+          coreComponents,
+          next,
+          None,
+        )
+
+        (1 to Requests).foreach(i => action.sendRequest(Session("scenario", i.toLong, null)))
+
+        val deadline = System.currentTimeMillis() + 60000
+        while (statsEngine.responses.get().size < Requests && System.currentTimeMillis() < deadline)
+          Thread.sleep(100)
+        assertEquals(statsEngine.responses.get().size, Requests, "every send must be reported")
+
+        val keys = readKeys(bootstrap, topic, Requests)
+        assertEquals(keys.size, Requests, s"expected to read back $Requests records, got ${keys.size}")
+        assertEquals(
+          keys.count(_ != null),
+          0,
+          "a request with no key must be published with a null key: an empty byte array is a present key, it hashes to a " +
+            "constant, and a compacted topic rejects the record outright",
+        )
+      } finally {
+        sender.close()
+        actorSystem.close()
+      }
+    }
+  }
+
+  /** Reads exactly `expected` records from the start of a freshly created topic, failing rather than returning a short list.
+    *
+    * Bounded by count, not only by a deadline: a read that fell short and returned what it had would let an "all keys absent"
+    * assertion pass having inspected one record.
+    */
+  private def readKeys(bootstrap: String, topic: String, expected: Int): List[Array[Byte]] = {
+    val consumer = new org.apache.kafka.clients.consumer.KafkaConsumer[Array[Byte], Array[Byte]](
+      (consumerSettings(bootstrap) + (ConsumerConfig.GROUP_ID_CONFIG -> s"$topic-key-reader")).asJava,
+    )
+    try {
+      consumer.subscribe(List(topic).asJava)
+      val collected = scala.collection.mutable.ListBuffer.empty[Array[Byte]]
+      val deadline  = System.currentTimeMillis() + 60000
+      while (collected.size < expected && System.currentTimeMillis() < deadline)
+        consumer.poll(java.time.Duration.ofMillis(500)).forEach(r => collected += r.key())
+      collected.toList
+    } finally consumer.close()
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala
@@ -1,0 +1,166 @@
+package org.galaxio.gatling.kafka.integration
+
+import com.dimafeng.testcontainers.ConfluentKafkaContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
+import org.galaxio.gatling.kafka.client.{DynamicKafkaConsumer, KafkaSender}
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
+
+/** Issue #193 — a reply channel must not report itself ready until it can actually receive.
+  *
+  * Readiness used to complete as soon as the topic appeared in `consumer.assignment()`. Assignment precedes fetch-position
+  * resolution, and the plugin defaults `auto.offset.reset` to `latest`, so a record produced in that window is skipped: the
+  * position resolves to the log end *after* it. The request then fails on its reply timeout, which reads in the report exactly
+  * like a system under test that never answered.
+  *
+  * ==Why this measures an interval instead of racing one==
+  *
+  * The obvious test — publish one marker the instant readiness completes, assert it arrives — races the poll thread and can
+  * pass by luck. Repeating it N times narrows the luck but never removes it, and a check that can pass by luck is not a gate.
+  *
+  * So this measures the gap rather than trying to land inside it. A producer emits a continuously numbered stream, started
+  * before the subscription is requested and never paused:
+  *
+  *   - `S` = the sequence number the producer had reached when readiness completed. That is the "now" in the contract
+  *     "everything published from now on will be seen".
+  *   - `F` = the sequence number of the first record actually delivered.
+  *
+  * `F <= S` *is* that contract, stated directly. Before the fix the position resolves after readiness, so `F` lands past
+  * everything produced in between and the difference is measurable — tens of records over milliseconds, not a knife edge. After
+  * the fix the position is resolved before the future completes, so `F <= S` on every run.
+  *
+  * On failure the gap `F - S` is reported: that is the number of replies a real run would have silently skipped.
+  */
+class PositionedReadinessSpec extends munit.FunSuite with TestContainerForAll with StrictLogging {
+
+  override val containerDef: ConfluentKafkaContainer.Def = ConfluentKafkaContainer.Def()
+
+  override def munitTimeout: scala.concurrent.duration.Duration = 5.minutes
+
+  private val Topic = "positioned-readiness"
+
+  /** Gap between records. Small enough that the assignment-to-position window spans many of them — with one record per second
+    * the window would fit between two and the defect would be invisible — and large enough not to saturate the broker.
+    */
+  private val ProduceIntervalMillis = 2L
+
+  /** Let the stream get going before requesting the subscription, so `latest` has somewhere to land: on an empty topic offset 0
+    * is both the start and the end, and a skipped record cannot be told from a delivered one.
+    */
+  private val WarmUpRecords = 50
+
+  private def producerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ProducerConfig.ACKS_CONFIG                   -> "1",
+    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> bootstrap,
+    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> classOf[ByteArraySerializer].getName,
+    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[ByteArraySerializer].getName,
+  )
+
+  /** `latest` is the plugin's own default (`KafkaProtocolBuilder.withDefaultAutoReset`), and it is what makes the window
+    * observable — with `earliest` a skipped record would be read anyway and the defect would hide.
+    */
+  private def consumerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG        -> bootstrap,
+    ConsumerConfig.GROUP_ID_CONFIG                 -> s"$Topic-reader",
+    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "latest",
+    // Without this the client default (true) commits offsets under a fixed group id, and a second run — or a reused
+    // container — would resolve from the commit rather than from `latest`, quietly removing the very premise this spec
+    // rests on and passing against a broken fix.
+    ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG       -> "false",
+  )
+
+  private def createTopic(bootstrap: String): Unit = {
+    val admin = AdminClient.create(
+      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrap).asJava,
+    )
+    try admin.createTopics(List(new NewTopic(Topic, 1, 1.toShort)).asJava).all().get(30, TimeUnit.SECONDS)
+    finally admin.close()
+  }
+
+  test("a reply published the moment a channel reports ready is received") {
+    withContainers { kafka =>
+      val bootstrap = kafka.bootstrapServers
+      createTopic(bootstrap)
+
+      val sender    = KafkaSender(producerSettings(bootstrap))
+      val produced  = new AtomicLong(0L)
+      val streaming = new AtomicBoolean(true)
+
+      // Numbered, continuous, and never paused for the measurement. A stream that stopped while readiness
+      // resolved would collapse S and F together and make the assertion vacuous.
+      val producerThread = new Thread(
+        () =>
+          while (streaming.get) {
+            val n = produced.incrementAndGet()
+            sender.send(KafkaProtocolMessage(null, n.toString.getBytes, Topic, Topic))(
+              _ => (),
+              error => logger.error("[positioned-readiness] produce failed", error),
+            )
+            Thread.sleep(ProduceIntervalMillis)
+          },
+        "positioned-readiness-producer",
+      )
+      producerThread.setDaemon(true)
+      producerThread.start()
+
+      val firstDelivered = new AtomicLong(-1L)
+      val delivered      = new AtomicInteger(0)
+      val consumer       = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+        consumerSettings(bootstrap),
+        Set.empty,
+        record => {
+          delivered.incrementAndGet()
+          firstDelivered.compareAndSet(-1L, new String(record.value()).toLong)
+        },
+        error => logger.error("[positioned-readiness] consumer failed", error),
+      )
+      val consumerThread = new Thread(consumer, "positioned-readiness-consumer")
+      consumerThread.setDaemon(true)
+      consumerThread.start()
+
+      try {
+        while (produced.get() < WarmUpRecords) Thread.sleep(10)
+
+        val readiness = consumer.requestTopicSubscription(Topic)
+        readiness.get(60, TimeUnit.SECONDS)
+
+        // "Now", in the units the contract is written in. Sampled the instant readiness completed.
+        val s = produced.get()
+
+        // Let the stream run on so there is something after S to deliver.
+        val deadline = System.currentTimeMillis() + 30000
+        while (delivered.get() == 0 && System.currentTimeMillis() < deadline) Thread.sleep(20)
+
+        val f = firstDelivered.get()
+        assert(f >= 0, s"nothing was delivered within 30 s of readiness completing (producer reached ${produced.get()})")
+        // `s + 1`, not `s`. `produced` is incremented before `sender.send`, and the send is asynchronous, so `S` counts
+        // records handed to the producer while the consumer positions at the *appended* log end. When nothing happens to be
+        // in flight at resolution time the correct implementation legitimately delivers `S + 1` first, and asserting `f <= s`
+        // would fail a working fix over a one-record accounting artefact. Anything beyond that is a real skip.
+        assert(
+          f <= s + 1,
+          s"the channel reported ready at record $s but the first record it delivered was $f: ${f - s - 1} records " +
+            "published after readiness were skipped. Readiness completed on assignment alone, before the fetch " +
+            "position was resolved, and `auto.offset.reset=latest` then positioned the consumer past them (issue #193)",
+        )
+      } finally {
+        streaming.set(false)
+        producerThread.join(5000)
+        consumer.close()
+        consumerThread.join(10000)
+        sender.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #167
Closes #168
Closes #193

Completes milestone **v1.2.0 Reply correlation correctness**. Its own summary is the shape of the problem: *results are silently wrong — replies attributed to the wrong virtual user, stalled users, and false timeouts against a system that answered.* One issue (#170) landed earlier; these are the remaining three.

Five commits, spec first, then one per issue:

| Commit | |
|---|---|
| `ba02ba7` | `docs(speckit)` — spec/plan/tasks |
| `a2f9645` | `fix(actions)` — #167 |
| `38d0599` | `fix(checks)` — #168 |
| `64513fc` | `feat(client)` — #193 |
| `7ad071c` | `docs(speckit)` — task state + the #193 reproduction |

**Reviewing by commit is much easier than by diff**: the three fixes are +2962, +290 and +254 lines, and of the first, 1888 lines are the spec artifacts. Actual production change across all three is **~95 lines**.

---

## #167 — a reply could be credited to the wrong virtual user

A request with no key was published with an empty byte array in place of one, and the tracker folded a `null` match id into that same empty array. Every keyless request-reply registered under **one** key: the second displaced the first, and a reply resolved whichever request occupied the slot.

The same substitution put a *present* key on the wire. `murmur2` of an empty input is constant, so every keyless record landed on one partition for the whole run — and a log-compacted topic, which requires a key, accepted records it should have rejected.

- `KafkaAction`: carry an absent key as `null`. `KafkaProtocolMessage.key` was already nullable on the consume side, so no signature moves.
- `KafkaMessageTracker`: drop the null→empty fold, and **refuse to register a null match id**. Removing the fold only stops null and empty colliding — `Arrays.equals(null, null)` is `true`, so it does not make the table injective. The invariant is enforced at both edges instead.
- `KafkaRequestReplyAction`: when the matcher yields no id, fail at issue time and do not publish. The remedy in the message is chosen from what that matcher reads — telling a `matchByValue` user to "use matchByValue" was worse than saying nothing.

## #168 — a tombstone reply took the virtual user down with it

Three preparers read `msg.value.length` unguarded. The NPE escaped `Check.check` into a `try`/`finally` with no `catch`; the record was already out of `sentMessages`, so no timeout scan could complete it, and `next ! session` was never reached.

**The user simply stopped.** No success, no failure, no next request — the run looked *cleaner* than it was while shedding load.

Two layers: all five preparers now short-circuit an absent payload to a named failure, and `completeMatched` gains a catch so **no check can strand a user**, including check types this plugin does not own. An empty payload stays a value: `bodyString.is("")` passes on an empty reply and fails on a tombstone.

## #193 — a channel reported ready before it could receive

Readiness completed when the topic appeared in `consumer.assignment()`. Assignment precedes fetch-position resolution, and the default is `auto.offset.reset=latest`, so a reply produced in that window was skipped and its request failed on the reply timeout.

`completeAssignedReadiness` now resolves `consumer.position` for every assigned partition before completing that topic's futures. Failure is scoped to the topic and deliberately does **not** reach `markConsumerFailed` — latching that refuses every subscription for the rest of the run, which is the terminal state #143 exists to prevent. `WakeupException`/`InterruptException` propagate untouched; swallowing them would break `close()`.

`group.initial.rebalance.delay.ms=0` is removed from both broker definitions.

---

## Verification

Every check was demonstrated failing against pre-change code, not assumed:

| Check | Before |
|---|---|
| tracker: absent vs empty match id | the reply resolved a request registered with none |
| action: KO at issue time | no outcome reported at all |
| `KeylessCorrelationSpec` | 0 of 24 rejected, all sent, 33 s of reply timeouts |
| `KafkaGatlingTest` keyless | 60 of 60 records carried a key |
| `KafkaMessagePreparerSpec` | three NPEs — `xmlPreparer` passed, it was the working example |
| `KafkaGatlingTest` tombstone | **neither** the request **nor** its follow-up appeared in the statistics |
| `PositionedReadinessSpec` | ready at record 107, first delivered 110 — **3 records skipped** |

That last line is the **first direct reproduction of #193**. Research §R4 in the spec established that removing the broker workaround could not demonstrate it — the setting moves *when* assignment happens, never the width of the assignment-to-position window — and §R9 recorded only one unexplained observation. `PositionedReadinessSpec` measures the gap instead of racing into it: a numbered stream runs throughout, `S` is where the producer was when readiness completed, `F` is the first record delivered, and `F <= S` is the readiness contract stated directly.

Full suite green **on a broker at Kafka's 3000 default**: 76 tests, all six `KafkaGatlingTest` assertions, `ExampleSmokeValidation`, and `KafkaConcurrencyLoadTest` at zero reply loss.

## Behaviour changes (Migration Guide in `README.md`)

Nothing stops compiling — no DSL, facade or protocol-setting signature moves. Three behavioural changes, two of which can turn a passing scenario red:

1. **Keyless request-reply under `matchByKey` now fails.** Those runs were reporting incorrect results.
2. **Keyless records reach the broker with no key** — which a **log-compacted topic rejects outright**. 100% OK → 100% KO for such a scenario.
3. **A tombstone reply now KOs** instead of stalling the user. Expect new KOs, and expect the run to finish with the users it started with.

Also documented: an immediate rejection reports a near-zero response time, which *lowers* percentiles on a run that rejects everything — assert on `failedRequests`/`successfulRequests` to catch that.

## Reviewer notes

- **`KAFKA_CREATE_TOPICS` and `topic-init` are separate broker definitions.** CI does not use `docker-compose.kafka.yml`; a topic added to one is not created in the other. Both now say so.
- `KafkaConcurrencyLoadTest` is wired into CI — 30 concurrent users at a zero reply-loss budget. It was already written and passing; it just never ran.
- The wire-level key assertion lives in an integration spec, not the simulation's `after` block: Gatling invokes `after` before building its `RunResult`, so throwing there suppresses every `.assertions` result.
- `DynamicKafkaConsumerSpec`'s late-topic test is made deterministic — it raced the consumer thread it started against an unreachable broker, and the added Testcontainers coverage made that race start losing.
- **Version**: the `feat` commit is what lifts this to `1.2.0`; the two `fix` commits alone would derive a patch and contradict the Migration Guide.

## Known, deliberately not addressed here

- Test scaffolding (`producerSettings`, `attributes`, `SystemClock`, `CountingAction`) is duplicated across integration specs and this adds to it. Extracting a shared helper touches five files unrelated to this milestone.
- `KafkaRequestReplyActionSpec` stubs `KafkaSender`, which Constitution Principle II permits only for units with no Kafka interaction. The test covers the branch where no interaction happens, but the deviation belongs in the plan's Complexity Tracking rather than passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)