### PR TITLE
fix(checks): fail cleanly on replies with no payload (#168)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,10 @@ jobs:
           KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
           # Must stay in step with docker-compose.kafka.yml's topic-init: this is a separate broker
           # definition, so a topic added there is NOT created here. myTopic5/test.t5 serve the keyless
-          # request-reply scenarios (#167); load.request/load.reply are KafkaConcurrencyLoadTest's, which
-          # previously relied on broker auto-create.
-          KAFKA_CREATE_TOPICS: "myTopic1:1:1, test.t1:1:1, myTopic2:1:1, test.t2:1:1, myTopic3:1:1, test.t3:1:1, myTopic4:1:1, myTopic5:1:1, test.t5:1:1, load.request:1:1, load.reply:1:1"
+          # request-reply scenarios (#167), myTopic6/test.t6 the tombstone one (#168), and
+          # load.request/load.reply are KafkaConcurrencyLoadTest's, which previously relied on
+          # broker auto-create.
+          KAFKA_CREATE_TOPICS: "myTopic1:1:1, test.t1:1:1, myTopic2:1:1, test.t2:1:1, myTopic3:1:1, test.t3:1:1, myTopic4:1:1, myTopic5:1:1, test.t5:1:1, myTopic6:1:1, test.t6:1:1, load.request:1:1, load.reply:1:1"
         ports:
           - '9092:9092'
           - '9093:9093'

--- a/README.md
+++ b/README.md
@@ -467,9 +467,8 @@ Use this section as release-based upgrade notes. Start from the version you are 
 
 ### Upgrading to `1.2.0`
 
-No changes to the DSL, the `javaapi` facade or protocol settings — nothing you have written stops compiling. There is one
-change at the record level, and two behavioural changes follow from it: a message with no key is now published with **no key**
-rather than with an empty one. Read both sections below before upgrading; the second can turn a passing scenario red.
+No changes to the DSL, the `javaapi` facade or protocol settings — nothing you have written stops compiling. Three
+behavioural changes, and two of them can turn a passing scenario red, so read the sections below before upgrading.
 
 #### A request-reply with no key is now failed instead of mismatched
 
@@ -500,6 +499,25 @@ val protocol = kafka
 ```
 
 Request-reply that already sets a key, or that uses `matchByValue` / `matchByMessage`, is unaffected.
+
+#### A reply with no payload now fails the request instead of losing the virtual user
+
+A reply can arrive with no payload at all — a tombstone on a compacted topic, or an acknowledgement carrying no body. Applying
+a content check to one (`bodyString`, `substring`, `bodyBytes`, `jsonPath`, `jmesPath`) used to throw inside the reply-handling
+path, which had nothing to catch it. The virtual user was **never continued**: no success, no failure, no next request. It
+simply stopped, and the run's user count silently diverged from the load the profile was applying.
+
+Such a check now reports the request as a failure naming the absent payload, and the virtual user carries on.
+
+- **Expect new KOs on any target that answers with tombstones.** Those requests were previously unreported — the run looked
+  cleaner than it was, while quietly shedding load.
+- **Expect the run to finish with the number of users it started with.** If your achieved throughput used to drift below the
+  configured rate for no visible reason, this is a candidate cause.
+- An **empty** payload is unchanged: it is a value, not an absence. `bodyString.is("")` still passes on an empty reply and now
+  fails on a tombstone — "the service sent nothing" and "the service sent an empty string" are different findings.
+
+Independently of the checks above, **no check can strand a virtual user any more**: one that throws for any reason is reported
+as a failure and the user continues.
 
 #### A message with no key is now published with no key
 

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -67,6 +67,8 @@ services:
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic4 --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic5 --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic test.t5 --partitions 1 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic myTopic6 --partitions 1 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic test.t6 --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic load.request --partitions 1 --replication-factor 1 &&
       kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic load.reply --partitions 1 --replication-factor 1
       "

--- a/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala
@@ -25,13 +25,39 @@ object KafkaMessagePreparer {
       .map(header => Try(Charset.forName(new String(header.value(), StandardCharsets.UTF_8))).toValidation)
       .getOrElse(cfg.core.charset.success)
 
+  /** Reported when a check is applied to a reply that carries no payload at all.
+    *
+    * Distinct from an empty payload on purpose. An empty value is something the system under test sent; `null` is the absence
+    * of a value — a tombstone, which is ordinary traffic on a compacted topic. Collapsing the two would let `bodyString.is("")`
+    * pass on a record that says "this key is deleted", which is a different finding from "the service replied with an empty
+    * string" (issue #168).
+    */
+  private val NoPayload = "the reply carries no payload, so there is nothing to check against"
+
+  private val ErrorMapper = "Could not parse response into a DOM Document: " + _
+
+  /** Absent payload short-circuits to a failure; everything else keeps its existing behaviour.
+    *
+    * The `msg.value.length` reads below all NPE on a tombstone, and that exception escapes `Check.check` into the tracker,
+    * whose `try`/`finally` has no `catch` — so the virtual user is never continued and simply stops, with nothing in the report
+    * (issue #168).
+    */
+  private def withPayload[T](msg: KafkaProtocolMessage)(f: => Validation[T]): Validation[T] =
+    if (msg.value == null) NoPayload.failure else f
+
   def stringBodyPreparer(configuration: GatlingConfiguration): KafkaMessagePreparer[String] =
     msg =>
-      messageCharset(configuration, msg)
-        .map(cs => if (msg.value.length > 0) new String(msg.value, cs) else "")
+      withPayload(msg) {
+        safely(ErrorMapper) {
+          messageCharset(configuration, msg)
+            .map(cs => if (msg.value.length > 0) new String(msg.value, cs) else "")
+        }
+      }
 
   val bytesBodyPreparer: KafkaMessagePreparer[Array[Byte]] = msg =>
-    (if (msg.value.length > 0) msg.value else Array.emptyByteArray).success
+    withPayload(msg) {
+      (if (msg.value.length > 0) msg.value else Array.emptyByteArray).success
+    }
 
   private val CharsParsingThreshold = 200 * 1000
 
@@ -40,24 +66,33 @@ object KafkaMessagePreparer {
       configuration: GatlingConfiguration,
   ): Preparer[KafkaProtocolMessage, JsonNode] =
     msg =>
-      messageCharset(configuration, msg)
-        .flatMap(bodyCharset =>
-          if (msg.value.length > CharsParsingThreshold)
-            jsonParsers.safeParse(new ByteArrayInputStream(msg.value))
-          else
-            jsonParsers.safeParse(new String(msg.value, bodyCharset)),
-        )
+      withPayload(msg) {
+        safely(ErrorMapper) {
+          messageCharset(configuration, msg)
+            .flatMap(bodyCharset =>
+              if (msg.value.length > CharsParsingThreshold)
+                jsonParsers.safeParse(new ByteArrayInputStream(msg.value))
+              else
+                jsonParsers.safeParse(new String(msg.value, bodyCharset)),
+            )
+        }
+      }
 
-  private val ErrorMapper = "Could not parse response into a DOM Document: " + _
-
+  // These two never threw — `safely` already caught it — but they reported the absent payload as a
+  // parse error, which sends the reader looking at their document instead of at the reply. Same guard,
+  // so all five preparers give one answer to one condition (FR-009).
   def xmlPreparer(configuration: GatlingConfiguration): KafkaMessagePreparer[XdmNode] =
     msg =>
-      safely(ErrorMapper) {
-        messageCharset(configuration, msg).map(cs => XmlParsers.parse(new ByteArrayInputStream(msg.value), cs))
+      withPayload(msg) {
+        safely(ErrorMapper) {
+          messageCharset(configuration, msg).map(cs => XmlParsers.parse(new ByteArrayInputStream(msg.value), cs))
+        }
       }
 
   def avroPreparer[T <: GenericRecord: Serde](config: GatlingConfiguration, topic: String): KafkaMessagePreparer[T] = msg =>
-    safely(ErrorMapper) {
-      messageCharset(config, msg).map(_ => implicitly[Serde[T]].deserializer().deserialize(topic, msg.value))
+    withPayload(msg) {
+      safely(ErrorMapper) {
+        messageCharset(config, msg).map(_ => implicitly[Serde[T]].deserializer().deserialize(topic, msg.value))
+      }
     }
 }

--- a/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala
@@ -14,6 +14,7 @@ import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 import org.galaxio.gatling.kafka.{KafkaCheck, KafkaLogging}
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 import scala.concurrent.duration.DurationInt
 
 object KafkaMessageTracker {
@@ -158,7 +159,17 @@ class KafkaMessageTracker[K, V](
       })
     }
 
-  /** Reports a matched reply, whether or not the acknowledgement has landed yet. The caller has already removed the record. */
+  /** Reports a matched reply, whether or not the acknowledgement has landed yet. The caller has already removed the record.
+    *
+    * The `catch` is the backstop for issue #168, and it is deliberately broad. A check that throws used to escape here into a
+    * `try`/`finally` with nothing to catch it: the record had already been removed from `sentMessages`, so no timeout scan
+    * could ever fail it either, and `next ! session` was never reached. The virtual user simply stopped — no success, no
+    * failure, no continuation, and nothing in the report to say a user had gone missing.
+    *
+    * The preparers no longer throw on a tombstone, which is what actually triggered it. This stays because the guarantee worth
+    * having is not "these five checks are safe" but "no check can strand a virtual user", and that has to hold for check types
+    * this plugin does not own.
+    */
   private def completeMatched(
       published: MessagePublished,
       receivedTimestamp: Long,
@@ -174,7 +185,20 @@ class KafkaMessageTracker[K, V](
         published.next,
         published.requestName,
       )
-    finally published.onComplete()
+    catch {
+      case NonFatal(e) =>
+        logger.error(s"Check execution failed for ${published.requestName}; reporting it as a failure", e)
+        executeNext(
+          published.session.markAsFailed,
+          published.sentTimestamp,
+          receivedTimestamp,
+          KO,
+          published.next,
+          published.requestName,
+          message.responseCode,
+          Some(s"Check execution failed: ${Option(e.getMessage).getOrElse(e.getClass.getSimpleName)}"),
+        )
+    } finally published.onComplete()
 
   override def init(): Behavior[TrackerMessage] = {
     // The request is registered here, before it is handed to the producer, so a reply cannot be looked

--- a/src/test/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparerSpec.scala
@@ -1,0 +1,91 @@
+package org.galaxio.gatling.kafka.checks
+
+import io.gatling.commons.validation.{Failure, Success, Validation}
+import io.gatling.core.config.GatlingConfiguration
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+
+/** Issue #168 — a reply whose payload is absent must produce a clean failure, not an exception.
+  *
+  * `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` read `msg.value.length` unguarded. `msg.value` is copied
+  * verbatim from `consumerRecord.value()`, which is `null` for a tombstone and for any null-valued reply — normal traffic on a
+  * compacted topic. The resulting NPE escapes `Check.check` into the tracker's `try`/`finally`, which has no `catch`, so the
+  * virtual user is never continued: no success, no failure, no next request. It simply stops.
+  *
+  * Two of the five preparers in the same object already get this right, wrapping the identical work in `safely(...)`, which is
+  * the strongest evidence the other three are an oversight rather than a decision.
+  *
+  * Absent is not empty. An empty payload is a value and keeps its existing behaviour — `bodyString.is("")` must pass on an
+  * empty reply and fail on a tombstone, because "the service sent nothing" and "the service sent an empty string" are different
+  * findings.
+  */
+class KafkaMessagePreparerSpec extends munit.FunSuite {
+
+  private val config      = GatlingConfiguration.loadForTest()
+  private val jsonParsers = io.gatling.core.Predef.defaultJsonParsers
+
+  private def message(value: Array[Byte]): KafkaProtocolMessage =
+    KafkaProtocolMessage(
+      key = "k".getBytes,
+      value = value,
+      producerTopic = "in",
+      consumerTopic = "out",
+    )
+
+  private def failureOf[T](v: Validation[T]): String = v match {
+    case Failure(message) => message
+    case Success(value)   => fail(s"expected a failure, got a success: $value")
+  }
+
+  private def succeeds[T](v: Validation[T]): T = v match {
+    case Success(value)   => value
+    case Failure(message) => fail(s"expected a success, got a failure: $message")
+  }
+
+  // --- absent payload: every preparer must fail, and say why -------------------------------------
+
+  test("stringBodyPreparer fails on an absent payload instead of throwing") {
+    val message1 = failureOf(KafkaMessagePreparer.stringBodyPreparer(config)(message(null)))
+    assert(message1.toLowerCase.contains("no payload"), s"unexpected message: $message1")
+  }
+
+  test("bytesBodyPreparer fails on an absent payload instead of throwing") {
+    val message1 = failureOf(KafkaMessagePreparer.bytesBodyPreparer(message(null)))
+    assert(message1.toLowerCase.contains("no payload"), s"unexpected message: $message1")
+  }
+
+  test("jsonPathPreparer fails on an absent payload instead of throwing") {
+    val message1 = failureOf(KafkaMessagePreparer.jsonPathPreparer(jsonParsers, config)(message(null)))
+    assert(message1.toLowerCase.contains("no payload"), s"unexpected message: $message1")
+  }
+
+  test("xmlPreparer fails on an absent payload instead of throwing") {
+    // Already guarded by `safely`, so this passes before the fix too. It is here to pin that all five
+    // agree: a reply must not succeed under one check type and strand the user under another.
+    val message1 = failureOf(KafkaMessagePreparer.xmlPreparer(config)(message(null)))
+    assert(message1.nonEmpty)
+  }
+
+  // --- empty payload: unchanged, and must stay distinct from absent -------------------------------
+
+  test("an empty payload is a value, not an absent one") {
+    assertEquals(succeeds(KafkaMessagePreparer.stringBodyPreparer(config)(message(Array.emptyByteArray))), "")
+    assertEquals(
+      succeeds(KafkaMessagePreparer.bytesBodyPreparer(message(Array.emptyByteArray))).length,
+      0,
+    )
+  }
+
+  test("a present payload is still parsed") {
+    assertEquals(succeeds(KafkaMessagePreparer.stringBodyPreparer(config)(message("hello".getBytes))), "hello")
+    assertEquals(
+      new String(succeeds(KafkaMessagePreparer.bytesBodyPreparer(message("hello".getBytes)))),
+      "hello",
+    )
+    assertEquals(
+      succeeds(KafkaMessagePreparer.jsonPathPreparer(jsonParsers, config)(message("""{"m":"v"}""".getBytes)))
+        .get("m")
+        .asText(),
+      "v",
+    )
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala
@@ -2,13 +2,16 @@ package org.galaxio.gatling.kafka.client
 
 import io.gatling.commons.stats.{KO, OK, Status}
 import io.gatling.commons.util.Clock
+import io.gatling.commons.validation.Validation
+import io.gatling.core.check.{Check, CheckResult}
 import io.gatling.core.action.Action
 import io.gatling.core.actor.{Actor, ActorSystem}
-import io.gatling.core.session.Session
+import io.gatling.core.session.{Expression, Session}
 import io.gatling.core.stats.RecordingStatsEngine
 import org.galaxio.gatling.kafka.client.KafkaMessageTracker.{ConsumerFailure, MessageConsumed, MessagePublished, SendFailed}
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol.KafkaKeyMatcher
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+import org.galaxio.gatling.kafka.KafkaCheck
 
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
@@ -302,6 +305,48 @@ class KafkaMessageTrackerSpec extends munit.FunSuite {
       responses.head.message.exists(_.contains("no match id")),
       s"the single outcome must be the refusal, not a match: ${responses.head.message}",
     )
+  }
+
+  // Issue #168, second layer. Fixing the preparers stops the tombstone NPE, but the guarantee worth
+  // having is "no check can strand a virtual user" — which has to hold for check types this plugin does
+  // not own. Before the catch, an exception out of Check.check left the record already removed from
+  // sentMessages (so no timeout scan could fail it) and `next ! session` unreached: the user stopped
+  // with nothing in the report.
+  test("a check that throws is reported as a failure instead of stranding the virtual user") {
+    val statsEngine = new RecordingStatsEngine
+    val next        = new RecordingAction("next")
+    val released    = new AtomicInteger(0)
+    val tracker     =
+      new KafkaMessageTracker[Array[Byte], Array[Byte]]("tracker", statsEngine, new StubClock(9_000L), KafkaKeyMatcher, None)
+    val behavior    = tracker.init()
+
+    val exploding: KafkaCheck = new KafkaCheck {
+      override def check(
+          response: KafkaProtocolMessage,
+          session: Session,
+          preparedCache: java.util.Map[Any, Any],
+      ): Validation[CheckResult] = throw new RuntimeException("check blew up")
+
+      override def checkIf(condition: Expression[Boolean]): Check[KafkaProtocolMessage]                                    = this
+      override def checkIf(condition: (KafkaProtocolMessage, Session) => Validation[Boolean]): Check[KafkaProtocolMessage] =
+        this
+    }
+
+    behavior(
+      published(next, replyTimeout = 0L, requestStart = 1_000L)
+        .copy(checks = List(exploding), onComplete = () => { released.incrementAndGet(); () }),
+    )
+    behavior(replyFor("match-race"))
+
+    val responses = statsEngine.responses.get()
+    assertEquals(responses.size, 1, "a throwing check must still produce an outcome")
+    assertEquals(responses.head.status, (KO: Status))
+    assert(
+      responses.head.message.exists(_.contains("check blew up")),
+      s"the failure must carry the cause: ${responses.head.message}",
+    )
+    assert(next.lastSession.get() != null, "and the virtual user must be advanced, not left hanging")
+    assertEquals(released.get(), 1, "the channel reference must still be released exactly once")
   }
 
   test("a registration with no match id is refused rather than stored") {

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala
@@ -40,7 +40,16 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     // it runs several virtual users at once, and sharing a reply topic with a single-user scenario would
     // make a cross-attribution failure look like that scenario's problem instead.
     "myTopic5" -> "test.t5",
+    // Answered with a *tombstone* rather than an echo — see the responder below (issue #168).
+    "myTopic6" -> "test.t6",
   )
+
+  /** Request topics the responder answers with a null value instead of echoing.
+    *
+    * A tombstone is ordinary traffic on a compacted topic, and it used to take the virtual user down with it: the body check
+    * NPE'd inside the tracker, which had no catch, so the user was never continued — no success, no failure, no next request.
+    */
+  private val tombstoneRoutes: Set[String] = Set("myTopic6")
 
   /** Header carrying when the responder answered. Round-trip metadata has to ride here rather than in the key or the value:
     * `scnRR` matches by key and checks `jsonPath` on the value, `scnRR2` matches by value and checks `bodyBytes`. Any rewrite
@@ -56,6 +65,9 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     */
   private val KeylessValueUsers = 5
   private val KeylessKeyUsers   = 3
+
+  /** Virtual users answered with a tombstone (issue #168). Each contributes one expected KO and one follow-up success. */
+  private val TombstoneUsers = 2
 
   // Stands in for the service under test. Before this existed the request-reply scenarios were "answered"
   // by sibling fire-and-forget scenarios that happened to publish a matching key or value at a fixed
@@ -96,8 +108,12 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
       echoRoutes.get(record.topic()).foreach { replyTopic =>
         val headers = new RecordHeaders()
         headers.add(RespondedAtHeader, System.currentTimeMillis().toString.getBytes)
+        // The probe has to be echoed intact or `awaitResponderReady` never completes for this route, so
+        // only non-probe records get the tombstone treatment.
+        val isProbe = record.value() != null && new String(record.value()) == probeMarker
+        val value   = if (tombstoneRoutes.contains(record.topic()) && !isProbe) null else record.value()
         responderSender.send(
-          KafkaProtocolMessage(record.key(), record.value(), replyTopic, replyTopic, Some(headers)),
+          KafkaProtocolMessage(record.key(), value, replyTopic, replyTopic, Some(headers)),
         )(
           _ => { echoedRoutes.add(record.topic()); () },
           // Never silent: a responder that stops echoing looks exactly like the plugin losing replies,
@@ -382,6 +398,31 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     * the same count via displacement plus one timeout. That the requests never reach the broker is asserted in
     * `KeylessCorrelationSpec`, which can observe the request topic directly.
     */
+  /** Issue #168. The reply is a tombstone, so the body check has nothing to check against.
+    *
+    * Two requests, and the second is the point. A stranded virtual user produces *no* KO at all, so a failure-count assertion
+    * on its own goes green on exactly the run this scenario exists to catch. "Tombstone Follow Up" only executes if the user
+    * survived the first request, which is what turns a hang into a visible, countable difference.
+    */
+  val scnRRTombstone: ScenarioBuilder = scenario("RequestReply tombstone reply")
+    // A distinct key per user, from a feeder rather than an EL reference to `userId`: `userId` is not a
+    // session attribute, so `#{userId}` fails to resolve and the request dies at build time — reported
+    // as a crash with no request stats at all, which makes the scenario silently assert nothing. The
+    // keys must differ because matchByKey would otherwise displace one request with the other.
+    .feed(Iterator.from(1).map(i => Map("tombKey" -> s"tomb-$i")): Feeder[String])
+    .exec(
+      kafka("Request Reply Tombstone").requestReply
+        .requestTopic("myTopic6")
+        .replyTopic("test.t6")
+        .send[String, String]("#{tombKey}", "body")
+        .check(bodyString.is("never-matches")),
+    )
+    .exec(
+      kafka("Tombstone Follow Up")
+        .topic("myTopic3")
+        .send[String]("survived"),
+    )
+
   val scnRRKeylessKey: ScenarioBuilder = scenario("RequestReply keyless by key")
     .exec(
       kafka("Request Reply Keyless Key").requestReply
@@ -400,6 +441,7 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     scnwokey.inject(nothingFor(1), atOnceUsers(1)).protocols(kafkaConfwoKey),
     scnRRKeylessValue.inject(atOnceUsers(KeylessValueUsers)).protocols(kafkaProtocolRRKeylessValue),
     scnRRKeylessKey.inject(atOnceUsers(KeylessKeyUsers)).protocols(kafkaProtocolRRString),
+    scnRRTombstone.inject(atOnceUsers(TombstoneUsers)).protocols(kafkaProtocolRRString),
   ).assertions(
     // Two sources of expected failure, and they are expected for opposite reasons:
     //
@@ -412,13 +454,18 @@ class KafkaGatlingTest extends Simulation with StrictLogging {
     // failing, so a broken reply-timeout would have dropped the count to 0 and still gone green. Pinning
     // the count and naming each request that must fail closes the gate in both directions — a new, real
     // failure fails the run, and so does an expected one starting to pass.
-    global.failedRequests.count.is(1 + KeylessKeyUsers),
+    global.failedRequests.count.is(1 + KeylessKeyUsers + TombstoneUsers),
     details("Request Reply Bytes wo").failedRequests.count.is(1),
     details("Request Reply Keyless Key").failedRequests.count.is(KeylessKeyUsers),
     // The other half of #167: keyless requests that *can* be correlated must all succeed, concurrently.
     // Pinned as a success count rather than a failure count of zero, so a scenario that silently stops
     // running at all fails the run instead of passing it.
     details("Request Reply Keyless Value").successfulRequests.count.is(KeylessValueUsers),
+    // Issue #168, and the pair is the assertion. The KO count alone would be satisfied by a run in which
+    // the users hung — a stranded user reports nothing — so the follow-up success count is what proves
+    // they were continued rather than lost.
+    details("Request Reply Tombstone").failedRequests.count.is(TombstoneUsers),
+    details("Tombstone Follow Up").successfulRequests.count.is(TombstoneUsers),
   ).maxDuration(120.seconds)
 
 }


### PR DESCRIPTION
Closes #168

> **Stacked on [#219](https://github.com/galax-io/gatling-kafka-plugin/pull/219)** (`#167`). Review that one first; the diff here is only the last commit.

## What was wrong

A reply can carry no payload at all — a tombstone on a compacted topic, or an acknowledgement with no body. `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` read `msg.value.length` unguarded, and `msg.value` is copied verbatim from `consumerRecord.value()`, so any content check against such a reply threw an NPE.

That exception escaped `Check.check` into the tracker's `try`/`finally`, which had **no `catch`**. By then the record had already been removed from `sentMessages`, so no timeout scan could complete it either, and `next ! session` was never reached.

**The virtual user simply stopped.** No success, no failure, no next request. The run looked *cleaner* than it was while quietly shedding load, and nothing in the report said a user had gone missing.

Two of the five preparers in the same object already wrapped the identical work in `safely(...)`, which is what identifies the other three as an oversight rather than a decision.

## What changed

Two layers, and the second is not redundant.

**Preparers** — an absent payload short-circuits to a `Validation` failure naming the cause, via a shared `withPayload` guard. All five now use it, including `xmlPreparer` and `avroPreparer`: those never threw, but reported the absence as a *document parse error*, sending the reader to inspect their own XML. One condition, one answer.

**Tracker** — `completeMatched` gains a `catch` that reports a KO carrying the cause and continues the user. The preparers no longer throw, but the guarantee worth having is not "these five checks are safe", it is **"no check can strand a virtual user"** — and that has to hold for check types this plugin does not own.

An empty payload is unchanged: it is a value, not an absence. `bodyString.is("")` still passes on an empty reply and now fails on a tombstone, because "the service sent nothing" and "the service sent an empty string" are different findings.

## Verification

Each demonstrated failing against the pre-change code:

| Check | Before the fix |
|---|---|
| `KafkaMessagePreparerSpec` | three NPEs, `Cannot read the array length because … value() is null`. `xmlPreparer` passed — it was the working example |
| `KafkaMessageTrackerSpec` | a throwing check produced no KO, no continuation, and no channel release |
| `KafkaGatlingTest` | **neither** `Request Reply Tombstone` **nor** its follow-up appeared in the statistics — both users vanished mid-scenario |

The responder now answers `myTopic6` with a tombstone. The scenario issues a **second** request afterwards, and that pair is the assertion: a stranded user produces no KO at all, so a failure-count assertion on its own goes green on exactly the run this scenario exists to catch. Global failures went 4 → 6 with the fix.

## Reviewer notes

- `myTopic6`/`test.t6` added to **both** broker definitions — CI builds its broker from its own service block, not from `docker-compose.kafka.yml`.
- Migration Guide gains a section for this: expect new KOs against any target that answers with tombstones, and expect the run to finish with the number of users it started with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)