### PR TITLE
feat(client): complete reply readiness only once positioned (#193)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,11 @@ jobs:
           KAFKA_INTER_BROKER_LISTENER_NAME: BROKER
           KAFKA_BROKER_ID: "1"
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-          # Mirrors docker-compose.kafka.yml. Kept at 0 to keep the simulations quick, but no longer
-          # required: KafkaGatlingTest's replies now come from a real echo responder (#196) and its
-          # reply channel is established before the request is sent (#191), so an immediate reply is
-          # received whatever the delay. Verified green over three runs with Kafka's 3000 default.
-          # This is the only setting the two stacks agree on — broker and Schema Registry generations
-          # still differ; consolidating them is issue #192.
-          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
+          # group.initial.rebalance.delay.ms is deliberately left at Kafka's default, matching
+          # docker-compose.kafka.yml. It was pinned to 0 while reply-channel readiness completed on
+          # assignment alone (issue #193); with the fetch position now resolved before readiness
+          # completes, CI runs on the same setting a real target system would.
+          #
           # Must stay in step with docker-compose.kafka.yml's topic-init: this is a separate broker
           # definition, so a topic added there is NOT created here. myTopic5/test.t5 serve the keyless
           # request-reply scenarios (#167), myTopic6/test.t6 the tombstone one (#168), and

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -22,16 +22,16 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      # Kafka's 3s default delays the first assignment of every new consumer group. Kept at 0 to keep
-      # the simulations quick; Testcontainers' Kafka module does the same.
+      # group.initial.rebalance.delay.ms is deliberately left at Kafka's 3000 default.
       #
-      # KafkaGatlingTest no longer *depends* on it. It used to: its request-reply scenarios were
-      # answered by sibling scenarios publishing at a fixed delay, and with the default the first
-      # assignment landed after those publishes, so the replies were skipped. Since #196 gave the
-      # simulation a real echo responder and #191 made the reply channel exist before the request is
-      # sent, an immediate reply is always received. Verified by running the simulation three times
-      # against this broker with the value at Kafka's 3000 default: green each time.
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      # It used to be pinned to 0 here and in ci.yml. That started as a speed tweak, but it also sat on
+      # top of issue #193: a reply channel reported ready on assignment alone, before its fetch position
+      # was resolved, so a reply produced in that window was skipped under auto.offset.reset=latest. The
+      # setting changes when assignment happens, not the width of that window, so it never fixed the gap
+      # — it just made the simulations quick enough to rarely notice.
+      #
+      # Now that readiness resolves the fetch position first, nothing depends on the delay, and running
+      # at the broker default is what a real target system will do.
     ports:
       - "9092:9092"
       - "9093:9093"

--- a/specs/004-reply-correlation-correctness/tasks.md
+++ b/specs/004-reply-correlation-correctness/tasks.md
@@ -151,19 +151,19 @@ of its scenario.
 
 ### Tests for User Story 2 (MANDATORY — write first, confirm they FAIL) ⚠️
 
-- [ ] T016 [P] [US2] New unit spec `KafkaMessagePreparerSpec` covering all five preparers against absent, empty and present payloads — absent yields a `Validation` failure naming the cause, empty keeps today's behaviour (`""` / empty bytes, success), present parses — in `src/test/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparerSpec.scala` (VR-5 – VR-7)
-- [ ] T017 [P] [US2] Unit test that a check which throws still produces a terminal KO and still continues the virtual user, in `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala` (VR-8)
-- [ ] T018 [US2] Run `sbt "testOnly org.galaxio.gatling.kafka.checks.KafkaMessagePreparerSpec org.galaxio.gatling.kafka.client.KafkaMessageTrackerSpec"` against unmodified code and record that T016 fails with an NPE and T017 fails with no continuation
+- [X] T016 [P] [US2] New unit spec `KafkaMessagePreparerSpec` covering all five preparers against absent, empty and present payloads — absent yields a `Validation` failure naming the cause, empty keeps today's behaviour (`""` / empty bytes, success), present parses — in `src/test/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparerSpec.scala` (VR-5 – VR-7)
+- [X] T017 [P] [US2] Unit test that a check which throws still produces a terminal KO and still continues the virtual user, in `src/test/scala/org/galaxio/gatling/kafka/client/KafkaMessageTrackerSpec.scala` (VR-8)
+- [X] T018 [US2] Red-before demonstrated: three NPEs, `Cannot read the array length because ... KafkaProtocolMessage.value() is null`, from stringBodyPreparer/bytesBodyPreparer/jsonPathPreparer. xmlPreparer passed — it was already wrapped in `safely`, which is the evidence the other three were an oversight. After the fix: 19/19 across both specs.
 
 ### Implementation for User Story 2
 
-- [ ] T019 [US2] Null-guard `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` behind `safely(...)`, matching the existing shape of `xmlPreparer`/`avroPreparer` in the same file, in `src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala` (research §R6)
-- [ ] T020 [US2] Add a `catch` to the `try`/`finally` in `completeMatched` that reports KO and continues the virtual user, in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` (VR-8; **same file as T009 — sequence after Phase 3**)
+- [X] T019 [US2] Null-guard `stringBodyPreparer`, `bytesBodyPreparer` and `jsonPathPreparer` behind `safely(...)`, matching the existing shape of `xmlPreparer`/`avroPreparer` in the same file, in `src/main/scala/org/galaxio/gatling/kafka/checks/KafkaMessagePreparer.scala` (research §R6)
+- [X] T020 [US2] Add a `catch` to the `try`/`finally` in `completeMatched` that reports KO and continues the virtual user, in `src/main/scala/org/galaxio/gatling/kafka/client/KafkaMessageTracker.scala` (VR-8; **same file as T009 — sequence after Phase 3**)
 
 ### Simulation-level verification for User Story 2 (FR-021)
 
-- [ ] T021 [US2] Add a request-reply scenario answered with an absent payload and carrying a reply-content check, asserting **both** the exact KO count and that a request executed after it in the same scenario also ran — a stalled user produces no failure, so a failure count alone goes green on a hung run — in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`
-- [ ] T022 [US2] Add a Migration Guide entry for contract C3 — an absent reply payload now KOs instead of stalling the user, and `bodyString.is("")` does not pass on a tombstone — in `README.md`
+- [X] T021 [US2] Add a request-reply scenario answered with an absent payload and carrying a reply-content check, asserting **both** the exact KO count and that a request executed after it in the same scenario also ran — a stalled user produces no failure, so a failure count alone goes green on a hung run — in `src/test/scala/org/galaxio/gatling/kafka/examples/KafkaGatlingTest.scala`
+- [X] T022 [US2] Add a Migration Guide entry for contract C3 — an absent reply payload now KOs instead of stalling the user, and `bodyString.is("")` does not pass on a tombstone — in `README.md`
 
 **Checkpoint**: US1 and US2 both independently functional.
 
@@ -180,14 +180,14 @@ first record delivered. One run, decisive in both directions.
 
 ### Tests for User Story 3 (MANDATORY — write first, confirm they FAIL) ⚠️
 
-- [ ] T023 [US3] New Testcontainers spec `PositionedReadinessSpec` — fresh topic and consumer group with `auto.offset.reset=latest`, a continuous numbered producer stream started **before** the subscription request, capture `S` when readiness completes and `F` from the first delivered record, assert `F <= S` and report `F - S` on failure — in `src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala` (research §R5)
-- [ ] T024 [US3] Run `sbt "testOnly org.galaxio.gatling.kafka.integration.PositionedReadinessSpec"` against unmodified code and record `F > S` with the observed gap size; if it passes pre-change the stream was idle at readiness, so fix `src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala` before concluding the defect is absent
+- [X] T023 [US3] New Testcontainers spec `PositionedReadinessSpec` — fresh topic and consumer group with `auto.offset.reset=latest`, a continuous numbered producer stream started **before** the subscription request, capture `S` when readiness completes and `F` from the first delivered record, assert `F <= S` and report `F - S` on failure — in `src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala` (research §R5)
+- [X] T024 [US3] Red-before demonstrated, and it is the first direct reproduction of #193: "the channel reported ready at record 107 but the first record it delivered was 110: 3 records published after readiness were skipped". Research §R4 had established that removing the broker workaround could not demonstrate the defect, and §R9 recorded only one unexplained observation; this measures it.
 
 ### Implementation for User Story 3
 
-- [ ] T025 [US3] In `completeAssignedReadiness`, resolve `consumer.position(tp, timeout)` for every assigned partition of a topic awaiting readiness **before** completing that topic's futures, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (research §R3, VR-9)
-- [ ] T026 [US3] On position timeout or failure, complete **only that topic's** readiness futures exceptionally and do not call `markConsumerFailed`, which would poison the pool for the rest of the run — the #143 terminal state — in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-10)
-- [ ] T027 [US3] Confirm both call sites remain poll-thread-only (`onPartitionsAssigned` and the tail of `updateSubscription()`) and update `completeAssignedReadiness`'s scaladoc to state that readiness now means positioned rather than merely assigned, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-11)
+- [X] T025 [US3] In `completeAssignedReadiness`, resolve `consumer.position(tp, timeout)` for every assigned partition of a topic awaiting readiness **before** completing that topic's futures, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (research §R3, VR-9)
+- [X] T026 [US3] On position timeout or failure, complete **only that topic's** readiness futures exceptionally and do not call `markConsumerFailed`, which would poison the pool for the rest of the run — the #143 terminal state — in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-10)
+- [X] T027 [US3] Confirm both call sites remain poll-thread-only (`onPartitionsAssigned` and the tail of `updateSubscription()`) and update `completeAssignedReadiness`'s scaladoc to state that readiness now means positioned rather than merely assigned, in `src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala` (VR-11)
 
 ### Broker-definition cleanup for User Story 3 (FR-022)
 
@@ -195,9 +195,9 @@ first record delivered. One run, decisive in both directions.
 > `docker-compose.kafka.yml:25-33` records that the simulations were already verified green at Kafka's
 > 3000 default. It is hygiene, not the gate. The gate is T023.
 
-- [ ] T028 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` and its explanatory comment from `docker-compose.kafka.yml`
-- [ ] T029 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` from `.github/workflows/ci.yml`
-- [ ] T030 [US3] Re-run the Compose-stack simulation suite per [quickstart.md](./quickstart.md) step 3 with the setting gone and confirm green (SC-010)
+- [X] T028 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` and its explanatory comment from `docker-compose.kafka.yml`
+- [X] T029 [US3] Remove `KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS` from `.github/workflows/ci.yml`
+- [X] T030 [US3] Re-run the Compose-stack simulation suite per [quickstart.md](./quickstart.md) step 3 with the setting gone and confirm green (SC-010)
 
 **Checkpoint**: US1, US2 and US3 all independently functional.
 
@@ -231,12 +231,12 @@ landed — every partition receives messages.
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T036 Run `sbt scalafmtAll scalafmtSbt`, then confirm `sbt scalafmtCheckAll scalafmtSbtCheck compile test` is green at the repository root
-- [ ] T037 Run `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` — the Principle I gate; a failure here is an API break to reconsider, not a check to relax (SC-008)
-- [ ] T038 Run the full CI Gatling line including `KafkaConcurrencyLoadTest` per [quickstart.md](./quickstart.md) step 3
-- [ ] T039 Walk the red-before/green-after table in [quickstart.md](./quickstart.md) and confirm all four stories are demonstrated in both directions (SC-009)
-- [ ] T040 Verify the Migration Guide section of `README.md` covers contracts C1, C3 and C4 with remediation for each (FR-017)
-- [ ] T041 Split the work into the three semantic commits in [Commit & Issue Mapping](#commit--issue-mapping-principle-v), each green on its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [X] T036 Run `sbt scalafmtAll scalafmtSbt`, then confirm `sbt scalafmtCheckAll scalafmtSbtCheck compile test` is green at the repository root
+- [X] T037 Run `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` — the Principle I gate; a failure here is an API break to reconsider, not a check to relax (SC-008)
+- [X] T038 Run the full CI Gatling line including `KafkaConcurrencyLoadTest` per [quickstart.md](./quickstart.md) step 3
+- [X] T039 Walk the red-before/green-after table in [quickstart.md](./quickstart.md) and confirm all four stories are demonstrated in both directions (SC-009)
+- [X] T040 Verify the Migration Guide section of `README.md` covers contracts C1, C3 and C4 with remediation for each (FR-017)
+- [X] T041 Split the work into the three semantic commits in [Commit & Issue Mapping](#commit--issue-mapping-principle-v), each green on its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
 - [ ] T042 Open one PR per issue, each assigned to milestone `v1.2.0 Reply correlation correctness` with `Closes #NNN`, and verify each with `scripts/check-linkage.sh --pr <N>`
 
 ---

--- a/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/client/DynamicKafkaConsumer.scala
@@ -3,7 +3,7 @@ package org.galaxio.gatling.kafka.client
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.kafka.clients.consumer.{ConsumerRebalanceListener, ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.WakeupException
+import org.apache.kafka.common.errors.{InterruptException, WakeupException}
 
 import java.time.Duration
 import java.util
@@ -13,6 +13,7 @@ import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, ConcurrentLin
 import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 object DynamicKafkaConsumer {
 
@@ -34,6 +35,15 @@ object DynamicKafkaConsumer {
     * nothing depends on it — an idle consumer should cost nothing.
     */
   private val idleBackoffMillis: Long = 1000L
+
+  /** How long the poll thread will wait for one partition's fetch position before giving up on that topic.
+    *
+    * Bounded because this runs on the single thread that timestamps every reply for every topic on this consumer: an unbounded
+    * `position` against an unreachable coordinator would stall the whole run, not just the topic being resolved. Generous
+    * enough for a `ListOffsets` round trip on a loaded broker, short enough that a genuinely stuck one surfaces as a failed
+    * reply channel rather than a hung simulation.
+    */
+  private val positionTimeout: Duration = Duration.ofSeconds(10)
 
   private[client] val consumerFailedMessage = "Kafka consumer failed; dynamic consumer can no longer be used"
   private[client] val consumerClosedMessage = "Kafka consumer is closed; topic subscription will not complete"
@@ -126,17 +136,61 @@ final class DynamicKafkaConsumer[K, V] private (
     awaitingAssignment.clear()
   }
 
-  /** Completes readiness for every topic the consumer currently holds partitions for. Runs on the consumer thread only, since
-    * it reads the consumer's assignment.
+  /** Completes readiness for every topic the consumer holds partitions for *and* has a fetch position on. Runs on the consumer
+    * thread only, since it reads the consumer's assignment and resolves positions.
+    *
+    * Assignment alone is not enough. It precedes fetch-position resolution, and the plugin defaults `auto.offset.reset` to
+    * `latest`, so a reply produced between the two is skipped: the position resolves to the log end *after* that record, the
+    * request never sees its answer, and it fails on the reply timeout — indistinguishable from a system under test that never
+    * replied (issue #193).
+    *
+    * Resolving the position here closes that window. `consumer.position` performs the `ListOffsets` round trip that would
+    * otherwise have happened on the next poll, so once a topic's futures complete, everything published from that moment on is
+    * at or after the position the consumer will fetch from.
     */
   private def completeAssignedReadiness(): Unit =
     if (!awaitingAssignment.isEmpty) {
-      consumer.assignment().asScala.map(_.topic()).toSet.foreach { (topic: String) =>
-        val pending = awaitingAssignment.remove(topic)
-        if (pending != null) {
-          pending.forEach(_.complete(null))
+      val assigned = consumer.assignment().asScala.toSet
+      assigned.map(_.topic()).foreach { (topic: String) =>
+        if (awaitingAssignment.containsKey(topic)) {
+          val failure = resolvePositions(assigned.filter(_.topic() == topic))
+          val pending = awaitingAssignment.remove(topic)
+          if (pending != null) {
+            failure match {
+              case None        => pending.forEach(_.complete(null))
+              case Some(cause) => pending.forEach(_.completeExceptionally(cause))
+            }
+          }
         }
       }
+    }
+
+  /** Resolves the fetch position for every partition of one awaited topic, returning the failure rather than throwing.
+    *
+    * Failure is scoped to the topic on purpose. Routing it through `markConsumerFailed` would latch `consumerFailure` and
+    * refuse every present and future subscription for the rest of the run — the terminal state issue #143 exists to prevent —
+    * over what may be one slow `ListOffsets` for one reply topic. The virtual users waiting on *this* topic fail; everything
+    * else on the consumer carries on.
+    *
+    * `WakeupException` and `InterruptException` are shutdown signals, not position failures, so they are left to propagate to
+    * the run loop that knows how to interpret them.
+    */
+  private def resolvePositions(partitions: Set[TopicPartition]): Option[Throwable] =
+    try {
+      partitions.foreach(tp => consumer.position(tp, DynamicKafkaConsumer.positionTimeout))
+      None
+    } catch {
+      case e: WakeupException    => throw e
+      case e: InterruptException => throw e
+      case NonFatal(e)           =>
+        logger.error(s"Could not resolve a fetch position for $partitions; failing readiness for that topic only", e)
+        Some(
+          new IllegalStateException(
+            s"Reply channel is subscribed to $partitions but its fetch position could not be resolved, " +
+              "so a reply published now could be skipped; failing this topic rather than reporting it ready",
+            e,
+          ),
+        )
     }
 
   private def markConsumerFailed(exception: Exception): Unit = {

--- a/src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala
@@ -1,0 +1,158 @@
+package org.galaxio.gatling.kafka.integration
+
+import com.dimafeng.testcontainers.ConfluentKafkaContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer}
+import org.galaxio.gatling.kafka.client.{DynamicKafkaConsumer, KafkaSender}
+import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
+
+/** Issue #193 — a reply channel must not report itself ready until it can actually receive.
+  *
+  * Readiness used to complete as soon as the topic appeared in `consumer.assignment()`. Assignment precedes fetch-position
+  * resolution, and the plugin defaults `auto.offset.reset` to `latest`, so a record produced in that window is skipped: the
+  * position resolves to the log end *after* it. The request then fails on its reply timeout, which reads in the report exactly
+  * like a system under test that never answered.
+  *
+  * ==Why this measures an interval instead of racing one==
+  *
+  * The obvious test — publish one marker the instant readiness completes, assert it arrives — races the poll thread and can
+  * pass by luck. Repeating it N times narrows the luck but never removes it, and a check that can pass by luck is not a gate.
+  *
+  * So this measures the gap rather than trying to land inside it. A producer emits a continuously numbered stream, started
+  * before the subscription is requested and never paused:
+  *
+  *   - `S` = the sequence number the producer had reached when readiness completed. That is the "now" in the contract
+  *     "everything published from now on will be seen".
+  *   - `F` = the sequence number of the first record actually delivered.
+  *
+  * `F <= S` *is* that contract, stated directly. Before the fix the position resolves after readiness, so `F` lands past
+  * everything produced in between and the difference is measurable — tens of records over milliseconds, not a knife edge. After
+  * the fix the position is resolved before the future completes, so `F <= S` on every run.
+  *
+  * On failure the gap `F - S` is reported: that is the number of replies a real run would have silently skipped.
+  */
+class PositionedReadinessSpec extends munit.FunSuite with TestContainerForAll with StrictLogging {
+
+  override val containerDef: ConfluentKafkaContainer.Def = ConfluentKafkaContainer.Def()
+
+  override def munitTimeout: scala.concurrent.duration.Duration = 5.minutes
+
+  private val Topic = "positioned-readiness"
+
+  /** Gap between records. Small enough that the assignment-to-position window spans many of them — with one record per second
+    * the window would fit between two and the defect would be invisible — and large enough not to saturate the broker.
+    */
+  private val ProduceIntervalMillis = 2L
+
+  /** Let the stream get going before requesting the subscription, so `latest` has somewhere to land: on an empty topic offset 0
+    * is both the start and the end, and a skipped record cannot be told from a delivered one.
+    */
+  private val WarmUpRecords = 50
+
+  private def producerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ProducerConfig.ACKS_CONFIG                   -> "1",
+    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG      -> bootstrap,
+    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG   -> classOf[ByteArraySerializer].getName,
+    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[ByteArraySerializer].getName,
+  )
+
+  /** `latest` is the plugin's own default (`KafkaProtocolBuilder.withDefaultAutoReset`), and it is what makes the window
+    * observable — with `earliest` a skipped record would be read anyway and the defect would hide.
+    */
+  private def consumerSettings(bootstrap: String): Map[String, AnyRef] = Map(
+    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG        -> bootstrap,
+    ConsumerConfig.GROUP_ID_CONFIG                 -> s"$Topic-reader",
+    ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG   -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> classOf[ByteArrayDeserializer].getName,
+    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG        -> "latest",
+  )
+
+  private def createTopic(bootstrap: String): Unit = {
+    val admin = AdminClient.create(
+      Map[String, AnyRef](AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrap).asJava,
+    )
+    try admin.createTopics(List(new NewTopic(Topic, 1, 1.toShort)).asJava).all().get(30, TimeUnit.SECONDS)
+    finally admin.close()
+  }
+
+  test("a reply published the moment a channel reports ready is received") {
+    withContainers { kafka =>
+      val bootstrap = kafka.bootstrapServers
+      createTopic(bootstrap)
+
+      val sender    = KafkaSender(producerSettings(bootstrap))
+      val produced  = new AtomicLong(0L)
+      val streaming = new AtomicBoolean(true)
+
+      // Numbered, continuous, and never paused for the measurement. A stream that stopped while readiness
+      // resolved would collapse S and F together and make the assertion vacuous.
+      val producerThread = new Thread(
+        () =>
+          while (streaming.get) {
+            val n = produced.incrementAndGet()
+            sender.send(KafkaProtocolMessage(null, n.toString.getBytes, Topic, Topic))(
+              _ => (),
+              error => logger.error("[positioned-readiness] produce failed", error),
+            )
+            Thread.sleep(ProduceIntervalMillis)
+          },
+        "positioned-readiness-producer",
+      )
+      producerThread.setDaemon(true)
+      producerThread.start()
+
+      val firstDelivered = new AtomicLong(-1L)
+      val delivered      = new AtomicInteger(0)
+      val consumer       = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
+        consumerSettings(bootstrap),
+        Set.empty,
+        record => {
+          delivered.incrementAndGet()
+          firstDelivered.compareAndSet(-1L, new String(record.value()).toLong)
+        },
+        error => logger.error("[positioned-readiness] consumer failed", error),
+      )
+      val consumerThread = new Thread(consumer, "positioned-readiness-consumer")
+      consumerThread.setDaemon(true)
+      consumerThread.start()
+
+      try {
+        while (produced.get() < WarmUpRecords) Thread.sleep(10)
+
+        val readiness = consumer.requestTopicSubscription(Topic)
+        readiness.get(60, TimeUnit.SECONDS)
+
+        // "Now", in the units the contract is written in. Sampled the instant readiness completed.
+        val s = produced.get()
+
+        // Let the stream run on so there is something after S to deliver.
+        val deadline = System.currentTimeMillis() + 30000
+        while (delivered.get() == 0 && System.currentTimeMillis() < deadline) Thread.sleep(20)
+
+        val f = firstDelivered.get()
+        assert(f >= 0, s"nothing was delivered within 30 s of readiness completing (producer reached ${produced.get()})")
+        assert(
+          f <= s,
+          s"the channel reported ready at record $s but the first record it delivered was $f: ${f - s} records " +
+            "published after readiness were skipped. Readiness completed on assignment alone, before the fetch " +
+            "position was resolved, and `auto.offset.reset=latest` then positioned the consumer past them (issue #193)",
+        )
+      } finally {
+        streaming.set(false)
+        producerThread.join(5000)
+        consumer.close()
+        consumerThread.join(10000)
+        sender.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #193

> **Stacked on [#220](https://github.com/galax-io/gatling-kafka-plugin/pull/220)** (`#168`), which is stacked on [#219](https://github.com/galax-io/gatling-kafka-plugin/pull/219) (`#167`). Review those first; the diff here is the last two commits.
>
> This is the last open issue in milestone **v1.2.0 Reply correlation correctness**.

## What was wrong

A reply channel reported itself ready as soon as its topic appeared in `consumer.assignment()`. Assignment **precedes** fetch-position resolution, and the plugin defaults `auto.offset.reset` to `latest`, so a reply produced in that window was skipped: the position resolved to the log end *after* it.

The request then failed on its reply timeout — which reads in a report exactly like a system under test that never answered.

## What changed

`completeAssignedReadiness` now resolves `consumer.position` for every assigned partition of an awaited topic **before** completing that topic's futures. That performs the `ListOffsets` round trip which would otherwise have happened on the next poll, so once readiness completes, everything published from that moment on is at or after the position the consumer will fetch from.

Three details that are easy to get wrong:

- **Failure is scoped to the topic.** A position timeout fails only the futures waiting on it and deliberately does **not** reach `markConsumerFailed` — latching that refuses every present and future subscription for the rest of the run, which is the terminal state #143 exists to prevent, over one slow `ListOffsets` for one reply topic.
- **`WakeupException` and `InterruptException` propagate untouched.** They are shutdown signals; swallowing them as "position failures" would break `close()`.
- **The call is bounded at 10 s.** It runs on the single thread that timestamps every reply for every topic on the consumer, so an unbounded wait stalls the whole run rather than one channel.

`group.initial.rebalance.delay.ms=0` is removed from both broker definitions. CI now runs on the setting a real target system will have.

## Verification — and this is the part worth reading

The obvious test is to publish one marker the instant readiness completes and assert it arrives. That **races the poll thread and can pass by luck**, and repeating it N times narrows the luck without removing it. A check that can pass by luck is not a gate.

So `PositionedReadinessSpec` measures the gap instead of trying to land inside it. A continuously numbered producer stream runs throughout:

- `S` = the sequence the producer had reached when readiness completed — the "now" in *"everything published from now on will be seen"*
- `F` = the first record actually delivered

`F <= S` **is** that contract, stated directly. Against the pre-change code:

```
the channel reported ready at record 107 but the first record it delivered
was 110: 3 records published after readiness were skipped
```

Three records is three replies a real run would have received and discarded, and three requests reported as timeouts against a system that answered.

**This is the first direct reproduction of #193.** Research §R4 in the spec had established that removing the broker workaround could *not* demonstrate it — the setting moves *when* assignment happens, never the width of the assignment-to-position window — and §R9 recorded only a single unexplained observation with the caveat that n=1 proves nothing. Both still stand; this measures what neither could.

The full suite, all three simulations included, is green against a broker at Kafka's 3000 default.

## Milestone

With this merged, all four issues in `v1.2.0` are closed (#170 landed earlier), and `scripts/check-linkage.sh --for-tag v1.2.0` should resolve. Note the version: `feat` here is what lifts the release to **1.2.0** — the two `fix` commits alone would derive a patch, which would contradict the Migration Guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)