### PR TITLE
v1.3.0: make the plugin resolvable from Maven Central

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/004-reply-correlation-correctness"
+  "feature_directory": "specs/005-classpath-dependency-shedding"
 }

--- a/README.md
+++ b/README.md
@@ -29,12 +29,21 @@ Kafka protocol plugin for [Gatling](https://gatling.io/) load testing framework.
 
 ## Compatibility
 
-| Branch / Line | Gatling | Scala | Java |
-|---|---|---|---|
-| `main` / `1.0.x` | 3.13.5 | 2.13.16 | 17+ |
-| 0.22.x | 3.13.x | 2.13 | 17+ |
-| 0.21.x | 3.12.x | 2.13 | 17+ |
-| 0.20.3 | 3.11.5 | 2.13 | 17+ |
+| Branch / Line | Gatling | Scala | Java | Kafka client |
+|---|---|---|---|---|
+| `main` / `1.3.x` | 3.13.5 | 2.13.18 | 17+ | Apache 3.9.x |
+| `1.1.x` – `1.2.x` | 3.13.5 | 2.13.18 | 17+ | Confluent 7.9.x-ce |
+| `1.0.x` | 3.13.5 | 2.13.16 | 17+ | Confluent 7.9.x-ccs |
+| 0.22.x | 3.13.x | 2.13 | 17+ | Confluent 7.x |
+| 0.21.x | 3.12.x | 2.13 | 17+ | Confluent 7.x |
+| 0.20.3 | 3.11.5 | 2.13 | 17+ | Confluent 7.x |
+
+> **Kafka client:** from `1.3.0` the plugin depends on the Apache release of `kafka-clients`
+> (`org.apache.kafka:kafka-clients:3.9.x`) rather than Confluent's `-ce` rebuild of the same upstream
+> code. Confluent Platform 7.9.x is built from Apache Kafka 3.9.x, so this is the same code under a
+> different version scheme — but the Confluent rebuild is published only to `packages.confluent.io`,
+> which made the plugin unresolvable for anyone building against Maven Central. Broker compatibility is
+> unchanged.
 
 > **Version guidance:** if you are on Gatling `3.11.5`, use plugin `0.20.3`. The `1.0.x` / `main` line targets Gatling `3.13.x`.
 >
@@ -66,6 +75,81 @@ gatling("org.galaxio:gatling-kafka-plugin_2.13:<version>")
   <scope>test</scope>
 </dependency>
 ```
+
+Everything above resolves from Maven Central. No additional repository is required for plain
+serialization — which covers producing, request-reply, checks, and consume-only tracking.
+
+### Optional: Avro via Confluent Schema Registry
+
+Schema-Registry-backed Avro needs two artifacts that Confluent publishes only to its own repository —
+they are not on Maven Central, so the plugin declares them as `provided` and you add them yourself.
+This mirrors how `avro4s` has always worked here. **Skip this section entirely if you do not use
+Schema Registry**; nothing else in the plugin needs it.
+
+```scala
+resolvers += "Confluent" at "https://packages.confluent.io/maven/"
+
+libraryDependencies ++= Seq(
+  "io.confluent" % "kafka-avro-serializer"    % "7.9.9" % Test,
+  "io.confluent" % "kafka-streams-avro-serde" % "7.9.9" % Test,
+).map(_.exclude("org.apache.kafka", "kafka-clients"))
+```
+
+```kotlin
+repositories {
+    maven("https://packages.confluent.io/maven/")
+}
+
+dependencies {
+    gatling("io.confluent:kafka-avro-serializer:7.9.9") {
+        exclude(group = "org.apache.kafka", module = "kafka-clients")
+    }
+    gatling("io.confluent:kafka-streams-avro-serde:7.9.9") {
+        exclude(group = "org.apache.kafka", module = "kafka-clients")
+    }
+}
+```
+
+```xml
+<repositories>
+  <repository>
+    <id>confluent</id>
+    <url>https://packages.confluent.io/maven/</url>
+  </repository>
+</repositories>
+
+<dependencies>
+  <dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>kafka-avro-serializer</artifactId>
+    <version>7.9.9</version>
+    <scope>test</scope>
+    <exclusions>
+      <exclusion><groupId>org.apache.kafka</groupId><artifactId>kafka-clients</artifactId></exclusion>
+    </exclusions>
+  </dependency>
+  <dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>kafka-streams-avro-serde</artifactId>
+    <version>7.9.9</version>
+    <scope>test</scope>
+    <exclusions>
+      <exclusion><groupId>org.apache.kafka</groupId><artifactId>kafka-clients</artifactId></exclusion>
+    </exclusions>
+  </dependency>
+</dependencies>
+```
+
+**The `kafka-clients` exclusion is not optional — keep it.** These artifacts pull
+`io.confluent:kafka-schema-registry-client`, which depends on Confluent's own rebuild of the Kafka
+client (`kafka-clients:7.9.x-ccs`). sbt and Gradle both resolve conflicts by taking the highest
+version, so that rebuild wins over the Apache `3.9.x` this plugin declares and your load test silently
+runs a different client from the one the plugin is built and tested against. Excluding it leaves the
+plugin's own Apache client in place. Maven resolves nearest-wins and is not affected, but the exclusion
+is harmless there and keeps the three snippets equivalent.
+
+Your simulation code needs no change: `org.galaxio.gatling.kafka.Predef._` exposes the Avro serdes
+exactly as before. See [Schema Registry Integration](#schema-registry-integration) for usage.
 
 If you are installing this while upgrading an older test suite, read the [Migration Guide](#migration-guide) before copying examples from `main`.
 
@@ -415,11 +499,21 @@ scenario("Avro4s")
 
 ### Schema Registry Integration
 
+> **Requires two extra dependencies.** From `1.3.0` the Confluent Schema Registry artifacts are
+> `provided` rather than inherited, because they are not published to Maven Central. Add them and the
+> Confluent resolver as shown in
+> [Installation → Optional: Avro via Confluent Schema Registry](#optional-avro-via-confluent-schema-registry)
+> before using anything in this section. Without them the code below still compiles, and fails at run
+> time with `NoClassDefFoundError: io/confluent/kafka/streams/serdes/avro/GenericAvroSerde`.
+
 For Schema Registry-backed Avro classes, provide an implicit `schemaRegUrl` or your own Kafka `Serde[T]`:
 
 ```scala
 implicit val schemaRegUrl: String = "http://localhost:8081"
 ```
+
+The same applies to `avroBody` checks and to the Java facade's `avro(...)` entry points, which are
+backed by the same Confluent serdes.
 
 ### Avro in Request-Reply
 
@@ -464,6 +558,47 @@ Use this section as release-based upgrade notes. Start from the version you are 
 | `0.20.3` | `1.0.x` | Move from Gatling `3.11.5` to `3.13.x`, update request-reply consumer settings, re-check examples against current README. |
 | `0.21.x` | `1.0.x` | Stay on Gatling `3.13.x`, review request-reply defaults and DSL surface. |
 | `0.20.x` or older | `1.0.x` | Treat as full doc refresh. Older consume-only or per-action matcher APIs are not present. |
+| `1.0.x` – `1.2.x` | `1.3.x` | Build-file only. Plain users: no change. Schema Registry Avro users: declare two artifacts and the Confluent resolver — see below. |
+
+### `1.2.x` → `1.3.x` — Confluent artifacts are no longer inherited
+
+**If you use plain serialization, avro4s, or anything other than Confluent Schema Registry: nothing
+to do.** Bump the version and carry on. You may also drop the Confluent resolver from your build if
+you added one — it is no longer needed.
+
+**Why this changed.** Up to `1.2.x` the plugin declared four dependencies that are published only to
+`packages.confluent.io`, while its released POM carries no repository list. A consumer building against
+Maven Central alone could not resolve the plugin at all. Two of the four (the Kafka client and Kafka
+Streams Scala) were Confluent rebuilds of Apache code and now use the Apache coordinates. The other two
+are genuinely Confluent-only and have become optional.
+
+**If you use Schema-Registry-backed Avro**, your build previously received these transitively. Declare
+them yourself, exactly as you already declare `avro4s`:
+
+```scala
+resolvers += "Confluent" at "https://packages.confluent.io/maven/"
+
+libraryDependencies ++= Seq(
+  "io.confluent" % "kafka-avro-serializer"    % "7.9.9" % Test,
+  "io.confluent" % "kafka-streams-avro-serde" % "7.9.9" % Test,
+).map(_.exclude("org.apache.kafka", "kafka-clients"))
+```
+
+Keep the `kafka-clients` exclusion — without it these artifacts pull Confluent's own rebuild of the
+Kafka client, which outranks the Apache one this plugin declares under sbt's and Gradle's
+highest-version-wins resolution. See
+[Installation](#optional-avro-via-confluent-schema-registry) for the Gradle and Maven forms and the
+full explanation.
+
+**No source change is required, in any scenario.** Imports, implicits, and every Scala and Java entry
+point are unchanged — `Predef` still supplies the Avro serdes.
+
+**How you find out if you forget them.** Not at build time: `provided` dependencies are simply absent
+from your classpath, so resolution and compilation both succeed. The serdes construct their Confluent
+delegate on first use, so the first Avro send or check fails with
+`NoClassDefFoundError: io/confluent/kafka/streams/serdes/avro/GenericAvroSerde` — in the middle of a
+run. If your suite uses Schema Registry Avro, add the dependencies before you upgrade rather than
+finding out from a load test.
 
 ### Upgrading to `1.2.0`
 

--- a/README.md
+++ b/README.md
@@ -600,6 +600,11 @@ delegate on first use, so the first Avro send or check fails with
 run. If your suite uses Schema Registry Avro, add the dependencies before you upgrade rather than
 finding out from a load test.
 
+**Also in this release**, `sessionWindowedSerde` and `consumedFromSerde` are deprecated. They are Kafka
+Streams helpers that this plugin never used; they will be removed in `2.0.0` along with the
+`kafka-streams-scala` dependency. If you genuinely build Streams topologies in your harness, depend on
+`org.apache.kafka:kafka-streams-scala_2.13` directly.
+
 ### Upgrading to `1.2.0`
 
 No changes to the DSL, the `javaapi` facade or protocol settings — nothing you have written stops compiling. Three

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(avro4s, avroCore, avroSerdes, avroSerializers),
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.20" % Test,
     libraryDependencies ++= testcontainers,
+    dependencyOverrides ++= kafkaOverrides,
     schemaRegistrySubjects ++= avroSchemas,
 //    schemaRegistryUrl := "http://test-schema-registry:8081",
     resolvers ++= Seq(
@@ -42,6 +43,170 @@ lazy val root = (project in file("."))
       "-language:postfixOps",
     ),
   )
+
+// ---------------------------------------------------------------------------------------------
+// Published-POM contract.
+//
+// A dependency a consumer inherits MUST be fetchable from Maven Central, because the published POM
+// deliberately carries no repository list (publish.sbt sets `pomIncludeRepository := { _ => false }`,
+// which is correct Sonatype hygiene). A coordinate a consumer can neither fetch nor be told where to
+// fetch from is unusable, and that is exactly what shipped: four inherited dependencies resolvable
+// only from packages.confluent.io.
+//
+// Nothing asserted this, so routine dependency updates kept the broken coordinates current and green
+// across several releases — they advanced 7.9.5-ce -> 7.9.9-ce while the defect sat untouched. Hence a
+// standing gate rather than a one-time correction to a version string. Assertions are written over the
+// coordinate *pattern*, never over specific versions, so the next bump cannot silence them.
+//
+// Contracts C1-C3 and C5 of specs/005-classpath-dependency-shedding/contracts/published-pom.md.
+// The deny-list is deliberately offline: a network probe would report a network outage as a pass.
+// ---------------------------------------------------------------------------------------------
+
+// group:artifact -> why a consumer inherits it. An inherited dependency missing from this map fails
+// C3. At most one entry may be justified by `deprecated:` (data-model DR-4) — that bound is what stops
+// "kept for a deprecation" from becoming a general-purpose excuse.
+val inheritedDependencyJustification: Map[String, String] = Map(
+  "org.scala-lang:scala-library"         -> "used-by: every Scala source",
+  "org.apache.kafka:kafka-clients"       -> "used-by: client/KafkaSender, client/DynamicKafkaConsumer, protocol settings",
+  "org.apache.kafka:kafka-streams-scala" -> "deprecated: held only by KafkaSerdesImplicits.sessionWindowedSerde and .consumedFromSerde; removed in 2.0.0",
+  "org.apache.avro:avro"                 -> "used-by: checks/AvroBodyCheckBuilder, avro4s serde derivation",
+)
+
+/** Why this coordinate cannot be fetched from Maven Central, or None if it can. */
+def vendorOnlyReason(group: String, version: String): Option[String] =
+  if (group == "io.confluent")
+    Some("io.confluent artifacts are published only to packages.confluent.io")
+  else if (group == "org.apache.kafka" && (version.endsWith("-ce") || version.endsWith("-ccs")))
+    Some(s"$version is a Confluent rebuild, published only to packages.confluent.io")
+  else None
+
+lazy val checkPublishedPom =
+  taskKey[Unit]("Assert the published POM declares only Maven Central-resolvable dependencies in scopes consumers inherit")
+
+checkPublishedPom := {
+  val log    = streams.value.log
+  val pom    = (root / makePom).value
+  val xml    = scala.xml.XML.loadFile(pom)
+  val report = (root / update).value
+
+  // sbt-scoverage adds its instrumentation artifacts as compile-scope dependencies while `coverage` is
+  // on, so the POM generated during a coverage run declares four org.scoverage entries that a released
+  // POM never carries. CI runs `sbt coverage ... test`, so without this the gate fails on artifacts
+  // that are not part of any publish. Every other contract still runs; only these are filtered.
+  val instrumented = (root / coverageEnabled).value
+
+  // Cross-published artifacts carry a Scala binary suffix in the POM (kafka-streams-scala_2.13) that
+  // the justification map should not have to repeat, or it would need editing on every Scala bump.
+  val scalaSuffix = "_" + scalaBinaryVersion.value
+
+  final case class Dep(group: String, artifact: String, version: String, scope: String) {
+    def ga: String         = s"$group:${artifact.stripSuffix(scalaSuffix)}"
+    def gav: String        = s"$group:$artifact:$version"
+    def inherited: Boolean = scope == "compile" || scope == "runtime"
+  }
+
+  val deps      = (xml \ "dependencies" \ "dependency").map { d =>
+    Dep(
+      (d \ "groupId").text.trim,
+      (d \ "artifactId").text.trim,
+      (d \ "version").text.trim,
+      Option((d \ "scope").text.trim).filter(_.nonEmpty).getOrElse("compile"),
+    )
+  }
+    .filterNot(d => instrumented && d.group == "org.scoverage")
+  val inherited = deps.filter(_.inherited)
+  val failures  = List.newBuilder[String]
+
+  // C1 - inherited scopes carry only Maven Central coordinates.
+  inherited.foreach { d =>
+    vendorOnlyReason(d.group, d.version).foreach { why =>
+      failures += s"C1 ${d.gav} is inherited (scope=${d.scope}) but $why"
+    }
+  }
+
+  // C2 - optional capabilities are not inherited.
+  inherited.foreach { d =>
+    if (d.group == "io.confluent" || d.group == "com.sksamuel.avro4s")
+      failures += s"C2 ${d.gav} serves an optional capability and must not be inherited"
+  }
+
+  // C3 - every inherited dependency is justified, at most one by a deprecation.
+  inherited.foreach { d =>
+    if (!inheritedDependencyJustification.contains(d.ga))
+      failures += s"C3 ${d.gav} is inherited with no recorded justification in inheritedDependencyJustification"
+  }
+  val heldByDeprecation =
+    inherited.map(_.ga).distinct.flatMap(inheritedDependencyJustification.get).count(_.startsWith("deprecated:"))
+  if (heldByDeprecation > 1)
+    failures += s"C3 $heldByDeprecation inherited dependencies are justified only by a deprecation; DR-4 permits at most 1"
+
+  // C5 - publication identity is unchanged.
+  def text(tag: String): String = (xml \ tag).text.trim
+  val expectedArtifactId        = s"gatling-kafka-plugin$scalaSuffix"
+  if (text("groupId") != "org.galaxio") failures += s"C5 groupId is '${text("groupId")}', expected 'org.galaxio'"
+  // Guards a rename of `name` or a flip of `crossPaths`, either of which would publish under a new
+  // coordinate — silently, and irrecoverably on Sonatype.
+  if (text("artifactId") != expectedArtifactId)
+    failures += s"C5 artifactId is '${text("artifactId")}', expected '$expectedArtifactId'"
+  if (text("packaging") != "jar") failures += s"C5 packaging is '${text("packaging")}', expected 'jar'"
+  if (text("url") != "https://github.com/galax-io/gatling-kafka-plugin") failures += s"C5 url is '${text("url")}'"
+  if ((xml \ "licenses" \ "license").isEmpty) failures += "C5 no license declared"
+  if ((xml \ "developers" \ "developer").isEmpty) failures += "C5 no developer declared"
+  if ((xml \ "scm").isEmpty) failures += "C5 no scm block declared"
+  if ((xml \ "organization").isEmpty) failures += "C5 no organization declared"
+  Seq("gatling-core", "gatling-core-java").foreach { a =>
+    deps.find(d => d.group == "io.gatling" && d.artifact == a) match {
+      case Some(d) if d.scope != "provided" => failures += s"C5 io.gatling:$a is scope=${d.scope}, expected provided"
+      case None                             => failures += s"C5 io.gatling:$a is missing from the POM"
+      case _                                => ()
+    }
+  }
+
+  // C1 (transitive) - the POM lists only what this build DECLARES, but a consumer inherits the whole
+  // closure. Checking declarations alone would miss a vendor-only coordinate arriving through a Central
+  // -published dependency, which is the same class of defect one level down. The Runtime configuration
+  // is the right graph to ask: it excludes Provided, so it is exactly what a consumer ends up with.
+  val inheritedClosure = report
+    .configuration(ConfigRef("runtime"))
+    .toSeq
+    .flatMap(_.modules)
+    .filterNot(_.evicted)
+    .map(_.module)
+    .filterNot(m => instrumented && m.organization == "org.scoverage")
+  inheritedClosure.foreach { m =>
+    vendorOnlyReason(m.organization, m.revision).foreach { why =>
+      failures += s"C1 ${m.organization}:${m.name}:${m.revision} is inherited transitively but $why"
+    }
+  }
+
+  val problems = failures.result()
+  if (problems.nonEmpty) {
+    problems.foreach(p => log.error(p))
+    sys.error(
+      s"${problems.size} published-POM contract violation(s) in ${pom.getName}. " +
+        "See specs/005-classpath-dependency-shedding/contracts/published-pom.md",
+    )
+  }
+  log.info(
+    s"checkPublishedPom: ${inherited.size} declared and ${inheritedClosure.size} transitively inherited dependencies, " +
+      "all Central-resolvable and justified",
+  )
+}
+
+// Run on every `sbt test`, not only in CI: this defect was introduced by a dependency bump, and a
+// dependency bump is exactly the change whose author will not think to run a bespoke check.
+Test / test := (Test / test).dependsOn(checkPublishedPom).value
+
+// And gate the tasks that actually produce the artifact. Relying on `test` running first is a property
+// of one workflow file, not of the build: `publishSigned` from a laptop, or a workflow edit that
+// parallelises the test and release steps, would otherwise publish an unchecked POM — and a Sonatype
+// release cannot be withdrawn.
+// `publishSigned` is what `ci-release` actually calls, so gating it is the point of this block; it
+// comes from sbt-pgp rather than sbt core, hence the qualified key.
+publish                                   := publish.dependsOn(checkPublishedPom).value
+publishLocal                              := publishLocal.dependsOn(checkPublishedPom).value
+publishM2                                 := publishM2.dependsOn(checkPublishedPom).value
+com.jsuereth.sbtpgp.PgpKeys.publishSigned := com.jsuereth.sbtpgp.PgpKeys.publishSigned.dependsOn(checkPublishedPom).value
 
 // Every spec under `integration/` starts its own single-node Kafka through Testcontainers, and sbt
 // runs suites in parallel by default — so the peak broker count is the suite count, not anything the

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,16 +46,17 @@ object Dependencies {
 
   lazy val avro4s: ModuleID = "com.sksamuel.avro4s" %% "avro4s-core" % Versions.avro4s % "provided"
 
-  lazy val avroCompiler: ModuleID = "org.apache.avro" % "avro-compiler" % Versions.avro
-  lazy val avroCore: ModuleID     = "org.apache.avro" % "avro"          % Versions.avro
+  lazy val avroCore: ModuleID        = "org.apache.avro" % "avro"                     % Versions.avro
   // `provided`, matching avro4s above: neither artifact is published to Maven Central, and the released
   // POM carries no resolver, so inheriting them makes the plugin unresolvable for anyone building
   // against Maven Central alone. Consumers who want Schema-Registry-backed Avro declare them together
   // with the Confluent resolver — see the Avro Support section of README.md.
-  lazy val avroSerdes: ModuleID   =
-    ("io.confluent"                                       % "kafka-streams-avro-serde" % Versions.kafkaAvroSerde)
-      .exclude("org.apache.kafka", "kafka-streams-scala") % "provided"
-  lazy val avroSerializers: ModuleID = "io.confluent" % "kafka-avro-serializer" % Versions.kafkaAvroSerde % "provided"
+  // The hand-managed `.exclude("org.apache.kafka", "kafka-streams-scala")` that used to sit here existed
+  // only to stop Confluent's rebuild of kafka-streams-scala colliding with the one declared above.
+  // `dependencyOverrides` now pins that coordinate for the whole build, so the exclusion had nothing
+  // left to prevent — verified with `sbt evicted`.
+  lazy val avroSerdes: ModuleID      = "io.confluent"    % "kafka-streams-avro-serde" % Versions.kafkaAvroSerde % "provided"
+  lazy val avroSerializers: ModuleID = "io.confluent"    % "kafka-avro-serializer"    % Versions.kafkaAvroSerde % "provided"
 
   lazy val testcontainers: Seq[ModuleID] = Seq(
     "com.dimafeng" %% "testcontainers-scala-munit" % Versions.testcontainers % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,13 @@ import sbt.*
 
 object Dependencies {
   private object Versions {
-    val kafka          = "7.9.9-ce"
+    // Apache release, not Confluent's `-ce`/`-ccs` rebuild: those are published only to
+    // packages.confluent.io, and the published POM cannot carry a resolver. Confluent Platform 7.9.x
+    // is built from Apache Kafka 3.9.x, so this is the equivalent line rather than an upgrade, and it
+    // matches the confluentinc/cp-kafka:7.9.5 brokers the test suites run against. The plugin uses
+    // only core client API (clients.consumer, clients.producer, common.header, common.serialization,
+    // TopicPartition, WakeupException), so nothing here depends on the vendor build.
+    val kafka          = "3.9.2"
     val gatling        = "3.13.5"
     val avro4s         = "4.1.2"
     val avro           = "1.12.1"
@@ -28,13 +34,28 @@ object Dependencies {
       .exclude("org.slf4j", "slf4j-api"),
   )
 
+  // The Confluent Avro artifacts drag in kafka-schema-registry-client, which depends on the
+  // vendor-rebuilt kafka-clients. Left alone, sbt picks the higher version and evicts the Apache one:
+  // the build would compile and test against 7.9.x-ccs while publishing a POM that declares 3.9.2, so
+  // a green suite would say nothing about the artifact consumers actually run. Pin what we ship.
+  lazy val kafkaOverrides: Seq[ModuleID] = Seq(
+    "org.apache.kafka"  % "kafka-clients"       % Versions.kafka,
+    "org.apache.kafka"  % "kafka-streams"       % Versions.kafka,
+    "org.apache.kafka" %% "kafka-streams-scala" % Versions.kafka,
+  )
+
   lazy val avro4s: ModuleID = "com.sksamuel.avro4s" %% "avro4s-core" % Versions.avro4s % "provided"
 
   lazy val avroCompiler: ModuleID = "org.apache.avro" % "avro-compiler" % Versions.avro
   lazy val avroCore: ModuleID     = "org.apache.avro" % "avro"          % Versions.avro
+  // `provided`, matching avro4s above: neither artifact is published to Maven Central, and the released
+  // POM carries no resolver, so inheriting them makes the plugin unresolvable for anyone building
+  // against Maven Central alone. Consumers who want Schema-Registry-backed Avro declare them together
+  // with the Confluent resolver — see the Avro Support section of README.md.
   lazy val avroSerdes: ModuleID   =
-    ("io.confluent" % "kafka-streams-avro-serde" % Versions.kafkaAvroSerde).exclude("org.apache.kafka", "kafka-streams-scala")
-  lazy val avroSerializers: ModuleID = "io.confluent" % "kafka-avro-serializer" % Versions.kafkaAvroSerde
+    ("io.confluent"                                       % "kafka-streams-avro-serde" % Versions.kafkaAvroSerde)
+      .exclude("org.apache.kafka", "kafka-streams-scala") % "provided"
+  lazy val avroSerializers: ModuleID = "io.confluent" % "kafka-avro-serializer" % Versions.kafkaAvroSerde % "provided"
 
   lazy val testcontainers: Seq[ModuleID] = Seq(
     "com.dimafeng" %% "testcontainers-scala-munit" % Versions.testcontainers % Test,

--- a/specs/005-classpath-dependency-shedding/checklists/requirements.md
+++ b/specs/005-classpath-dependency-shedding/checklists/requirements.md
@@ -1,0 +1,102 @@
+# Specification Quality Checklist: Classpath and Dependency Shedding
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+**Status: all items pass.** Validated over two iterations.
+
+### Iteration 1
+
+Three `[NEEDS CLARIFICATION]` markers were raised — at, not over, the allowed budget of three — each
+one a scope decision with no defensible default:
+
+- **FR-018** — Apache coordinates vs. non-inherited scope for the mandatory Kafka client dependency.
+- **FR-019** — the milestone calls for shedding the Kafka Streams artifact in this release, while
+  Constitution Principle I requires the two published implicits holding it to keep compiling for at
+  least one more minor, and they cannot compile without it. The milestone description and the ratified
+  constitution pointed in different directions.
+- **FR-020** — whether Avro consumers may be asked for a one-line additional import.
+
+All three were put to the maintainer at specification time rather than guessed.
+
+### Iteration 2
+
+All three resolved and recorded in the spec's Clarifications section (session 2026-08-09), with the
+rejected alternatives and the reason each was rejected. Downstream sections were reconciled with the
+answers rather than left contradicting them:
+
+- Story 4's title, independent test, and scenarios 1 and 5 now accommodate the one dependency
+  deliberately retained past its usefulness (Kafka Streams, held only by the deprecation window).
+- SC-007 states that exception explicitly instead of asserting an absolute zero it would fail.
+- Out of Scope now names artifact removal and entry-point removal as deferred, so the boundary between
+  this release and the next major is unambiguous.
+- Assumptions record the equivalence claim FR-018 rests on, flagged as a finding to raise if planning
+  disproves it rather than something to work around silently.
+
+### Interpretation notes on items marked complete
+
+- **Implementation details.** This feature's subject matter *is* packaging: artifact coordinates,
+  repositories, and what a consumer's build inherits are the user-observable facts, not implementation
+  choices. Coordinates and source paths appear only in the Problem section as verified evidence and in
+  Assumptions as verification records. The Functional Requirements state outcomes ("resolvable from the
+  default public repository", "a scope consumers do not inherit") and leave mechanism to planning.
+
+- **Non-technical stakeholders.** The stakeholder for this feature is the plugin's consumer — a
+  performance engineer running a build. Stories are written from that consumer's position ("can I
+  install it and get a first send working?"), which is the appropriate altitude here.
+
+- **Technology-agnostic success criteria.** SC-003 names sbt, Gradle, and Maven. These are the three
+  installation paths the project already documents and supports, so they are scope boundaries rather
+  than implementation choices.
+
+### Verification performed while writing the spec
+
+Claims in the Problem section were checked against live artifact repositories on 2026-08-09 rather than
+inferred from the build definition. The published `1.2.0` POM was fetched and read; each declared
+coordinate was probed on Maven Central and on the Confluent repository. This extended issue #185's
+finding: the two `org.apache.kafka` `-ce` coordinates are affected identically to the two `io.confluent`
+ones, so four inherited dependencies are unresolvable, not two. Issue #185 should be updated, or a
+companion issue opened, so the milestone's tracked scope matches what the fix must cover.
+
+**Correction applied after the first draft.** The maintainer pointed out that the declared Kafka version
+had moved on. The spec had been written against the branch point (`7.9.5-ce` / `7.9.8`); `main` was
+already at `7.9.9-ce` / `7.9.9`. The branch was fast-forwarded to `main` and every artifact updated to
+distinguish two version sets that had been conflated: what published `1.2.0` declares, and what the
+next release would declare. All seven vendor versions checked — `7.9.2-ccs`, `7.9.5-ce`, `7.9.5-ccs`,
+`7.9.8-ce`, `7.9.8-ccs`, `7.9.9-ce`, `7.9.9-ccs` — are absent from Maven Central, so no requirement or
+decision changed.
+
+The correction did surface a finding worth keeping: dependency automation had advanced all four broken
+coordinates during specification, and they stayed equally unresolvable. Nothing asserts the property,
+so each bump lands green. The same automation maintains a dependency declaration the build never
+applies. Both now appear in the spec as the argument for attaching a standing assertion to FR-001
+rather than only correcting the version strings, and every rule in the spec, data model, and contracts
+is stated over dependency *properties* so that the next bump cannot invalidate them.

--- a/specs/005-classpath-dependency-shedding/contracts/dsl-entry-points.md
+++ b/specs/005-classpath-dependency-shedding/contracts/dsl-entry-points.md
@@ -1,0 +1,142 @@
+# Contract: DSL Entry Points
+
+**Feature**: `005-classpath-dependency-shedding` | **Date**: 2026-08-09
+
+The Scala DSL and the Java facade are a published contract (Constitution Principle I). This feature
+changes no signature; it changes *what must be on the classpath* for each entry point to be reachable.
+That is still an observable change to the contract, so it is specified here.
+
+**Consumers of this contract**: Gatling simulations written in Scala, Java, and Kotlin against
+`org.galaxio.gatling.kafka`.
+
+---
+
+## E1 — The default import is vendor-free
+
+`import org.galaxio.gatling.kafka.Predef._` MUST be usable with only the inherited dependency set on
+the classpath.
+
+Concretely, with the `io.confluent` artifacts absent, all of the following MUST succeed:
+
+1. Compiling a simulation that imports `Predef._`.
+2. Initialising `Predef` at runtime.
+3. Executing a plain produce simulation.
+4. Executing a plain request-reply simulation with checks.
+
+**Why all four are listed separately**: the current defect passes (1) and fails (2). A contract that
+only said "compiles" would be satisfied by the broken state.
+
+**Mechanism**: no member reachable from `Predef` may name a vendor-only type in its *declared type*, and
+none may *construct* one during initialisation. The declared types are already compliant (`Serde[T]` and
+`GenericRecord` are both Central-published). The two eager `val`s delegate to the opt-in object instead
+of constructing, and become `lazy` so that delegating does not force that object to initialise. After
+this, no file reachable from `Predef` names a Confluent type — in a signature or in bytecode.
+
+**Test**: run (3) and (4) against a real broker with the Confluent artifacts removed from the runtime
+classpath. Fails today with `NoClassDefFoundError: io/confluent/kafka/streams/serdes/avro/GenericAvroSerde`
+raised from `Predef`'s initialiser.
+
+---
+
+## E2 — Schema Registry Avro has one documented entry point
+
+Schema-Registry-backed Avro support is reachable via:
+
+```scala
+import org.galaxio.gatling.kafka.confluent._
+```
+
+This object is the canonical home of `avroSerde` and `serdeClass[T]`. It mirrors the existing
+`org.galaxio.gatling.kafka.avro4s` object, which is the same idiom for the same reason — an optional
+capability whose dependency the consumer declares.
+
+**Naming rationale**: `confluent` matches the artifacts the consumer must add
+(`io.confluent:kafka-avro-serializer`, `io.confluent:kafka-streams-avro-serde`), so the import and the
+dependency reinforce each other in the migration guide. `avro` was rejected as ambiguous against both
+`avro4s` and plain Apache Avro, neither of which needs the opt-in.
+
+**Requirement**: everything reachable before this change stays reachable here, with identical behavior
+(FR-009). This object adds no capability and changes no semantics.
+
+---
+
+## E3 — Deprecated members keep compiling
+
+The following keep compiling in this release, each annotated with its replacement and its removal
+release:
+
+| Member | Replacement | Removed in |
+| --- | --- | --- |
+| `KafkaSerdesImplicits.avroSerde` | `org.galaxio.gatling.kafka.confluent.avroSerde` | 2.0.0 |
+| `KafkaSerdesImplicits.serdeClass[T]` | `org.galaxio.gatling.kafka.confluent.serdeClass[T]` | 2.0.0 |
+| `KafkaSerdesImplicits.sessionWindowedSerde[T]` | none — Kafka Streams is not part of this plugin | 2.0.0 |
+| `KafkaSerdesImplicits.consumedFromSerde[K,V]` | none — as above | 2.0.0 |
+
+**The last two name no replacement deliberately.** Constitution Principle I requires a replacement to be
+named where one exists; inventing one here would imply the plugin offers a Kafka Streams capability it
+does not. The annotation states that the plugin does not use them and that consumers writing Streams
+topologies should depend on Kafka Streams directly.
+
+**Deprecating `avroSerde` and `serdeClass` does not resurrect the coupling.** They remain on the trait
+reachable from `Predef`, but as lazy delegations to the opt-in object rather than as constructions, so
+E1 continues to hold. A consumer who ignores the deprecation and stays on the old member still needs the
+opt-in artifacts at runtime — the deprecation moves the *documentation*, and the artifacts are what
+actually gate the capability.
+
+**Cost of retaining them**: one keyword and one annotation per member. This is worth stating because it
+is what keeps the change source-compatible for Scala consumers; the only upgrade step for an Avro user
+is in their build file, not their code.
+
+**`-Xfatal-warnings` consequence**: every in-project use of these members moves to the opt-in import in
+the same change, or the build goes red. This is desirable — it makes the examples demonstrate the
+documented consumer path.
+
+---
+
+## E4 — The Java facade is usable without Schema Registry
+
+A Java or Kotlin simulation using plain serialization MUST compile and run with the Confluent artifacts
+absent.
+
+**Status: provisional, pending gate G2.** `javaapi/KafkaDsl.java` declares three `avro` overloads, two
+naming `SchemaRegistryClient` and one taking `Serializer`/`Deserializer`. The JVM resolves method
+descriptors lazily, so runtime is expected to be fine for a consumer who never calls the Schema Registry
+overloads. Compile-time behavior under overload resolution is **not established**: javac and kotlinc may
+require the parameter types of every candidate `avro` overload to be on the classpath.
+
+Two outcomes:
+
+- **G2 passes** — the `SchemaRegistryClient`-typed overloads and the `AvroExpressionBuilder` constructor
+  stay in place, deprecated, pointing at the opt-in Java entry point. Java source compatibility is
+  fully preserved.
+- **G2 fails** — they must move out of `KafkaDsl`, which is a Java-source break with no deprecation
+  window. That changes the release's compatibility story and must be raised with the maintainer before
+  implementation, not decided inside it.
+
+**Test**: compile a plain Java simulation and a plain Kotlin simulation against the published artifact
+with Confluent absent, exercising `avro(JExpression, Serializer, Deserializer)` so overload resolution
+is actually forced.
+
+---
+
+## E5 — Unchanged surface
+
+Explicitly out of scope and required to be byte-identical in behavior: the 15 primitive serde implicits,
+`kafka(...)` protocol and request builders, all check builders other than the Avro ones, request-reply
+correlation, tracker and consumer behavior, and every `org.galaxio.gatling.kafka.avro4s` member.
+
+**Test**: `ExampleSmokeValidation` constructs every README and example simulation; the existing unit,
+integration, and Gatling suites pass unchanged. No suite may be relaxed or disabled to accommodate this
+feature.
+
+---
+
+## Contract test summary
+
+| ID | Gate | Fails today | Needs broker |
+| --- | --- | --- | --- |
+| E1 | Default import usable without vendor artifacts | **yes**, at runtime | yes |
+| E2 | Opt-in entry point exists and is complete | **yes** (does not exist) | yes, for the Avro path |
+| E3 | Deprecated members compile, annotations correct | **yes** (not annotated) | no |
+| E4 | Java/Kotlin facade usable without Schema Registry | **unknown** — gate G2 | no |
+| E5 | Everything else unchanged | no | yes |

--- a/specs/005-classpath-dependency-shedding/contracts/published-pom.md
+++ b/specs/005-classpath-dependency-shedding/contracts/published-pom.md
@@ -1,0 +1,119 @@
+# Contract: Published Artifact Metadata
+
+**Feature**: `005-classpath-dependency-shedding` | **Date**: 2026-08-09
+
+The published POM is the plugin's contract with every consumer's build tool. It is the interface this
+feature repairs, so it is specified here as an interface rather than left as a side effect of the build
+definition.
+
+**Consumers of this contract**: sbt, Gradle, and Maven resolvers in downstream projects; the Sonatype
+release pipeline.
+
+---
+
+## C1 — Inherited scopes carry only Maven Central coordinates
+
+Every `<dependency>` whose `<scope>` is inherited by consumers (`compile` or `runtime`, including the
+implicit default) MUST be resolvable from `https://repo1.maven.org/maven2/` with no other repository
+configured.
+
+**Rationale**: the POM cannot carry a repository — `ThisBuild / pomIncludeRepository := { _ => false }`
+strips them, correctly, for a Sonatype release. A coordinate a consumer cannot fetch and cannot be told
+where to fetch from is unusable.
+
+**Assertion** (test, runs on every build):
+
+```text
+for each dependency in makePom output:
+  if scope in {compile, runtime, absent}:
+    assert group:artifact:version is fetchable from Maven Central
+```
+
+The check may be implemented offline against a deny-list of known vendor-only patterns
+(`io.confluent:*`, and any `org.apache.kafka:*` version bearing a `-ce` or `-ccs` suffix) so it does not
+depend on network access in CI. A network-backed variant is acceptable but must not be the only gate,
+because a network failure would then read as a pass.
+
+**Current state**: FAILS. Four dependencies violate this — on current `main`, `kafka-clients:7.9.9-ce`,
+`kafka-streams-scala_2.13:7.9.9-ce`, `kafka-streams-avro-serde:7.9.9`, `kafka-avro-serializer:7.9.9`;
+in published `1.2.0`, the same four at `7.9.5-ce` / `7.9.8`. This is the failing-first test required by
+Constitution Principle IV.
+
+**The assertion is written over the pattern, not the versions.** These coordinates advance regularly
+under dependency automation — they moved a full patch line during this feature's specification, staying
+equally unresolvable. A check pinned to specific version strings would go quiet on the next bump, which
+is the failure mode that let this defect ship in the first place.
+
+---
+
+## C2 — Optional capabilities are not inherited
+
+A dependency required only by an optional capability MUST be declared in a scope consumers do not
+inherit.
+
+Applies to: Confluent Avro serialization, Confluent Schema Registry, avro4s.
+
+**Assertion**: the inherited dependency set contains no `io.confluent` coordinate and no avro4s
+coordinate.
+
+**Note**: this is a stronger statement than C1 for these artifacts. C1 alone could in principle be
+satisfied by relocation; R1 established that no Central-published equivalent exists, so for these two
+the only compliant state is non-inheritance.
+
+---
+
+## C3 — Every inherited dependency is justified
+
+Each inherited dependency MUST map to either a plugin code path that uses it, or a recorded deprecation
+naming the release in which it goes away.
+
+**Assertion**: the count of inherited dependencies with neither is zero. At most one may be justified by
+deprecation in this release (data-model DR-4) — `kafka-streams-scala`, held by the two deprecated
+implicits.
+
+**Rationale**: FR-014 and SC-007. The bound of one is what stops "retained for a deprecation" from
+becoming a general-purpose excuse.
+
+---
+
+## C4 — Build and consumer classpaths agree
+
+The Kafka client version the plugin is compiled and tested against MUST equal the version a consumer
+resolves from the published POM.
+
+**Rationale**: opt-in dependencies remain on the plugin's *own* compile classpath, and R2 demonstrated
+this is not automatic — with the Apache coordinate declared, the build still resolved
+`kafka-clients:7.9.9-ccs` via `kafka-schema-registry-client`, silently. A build that compiles and tests
+against a different client than it ships against produces test results that do not describe the shipped
+artifact.
+
+**Assertion**: `sbt evicted` reports no version conflict for `org.apache.kafka:kafka-clients`. This is
+gate G1.
+
+---
+
+## C5 — Metadata that must stay unchanged
+
+This feature changes dependencies only. The following MUST be byte-identical to the previous release
+except for the version: `groupId`, `artifactId`, `packaging`, `licenses`, `scm`, `developers`,
+`organization`, `url`, and the `provided`/`test` status of the Gatling and testing artifacts.
+
+**Rationale**: guards against a build-file edit accidentally changing publication identity, which for a
+Sonatype release is unrecoverable.
+
+---
+
+## Contract test summary
+
+| ID | Gate | Fails today | Speed |
+| --- | --- | --- | --- |
+| C1 | Inherited ⟹ Central-resolvable | **yes**, 4 violations | fast, offline |
+| C2 | Optional ⟹ not inherited | **yes**, 2 violations | fast, offline |
+| C3 | Inherited ⟹ justified, ≤1 deprecation-held | **yes** | fast, offline |
+| C4 | Build client == shipped client | **yes** (R2) | fast |
+| C5 | Publication identity unchanged | no | fast, offline |
+
+C1–C3 and C5 are assertable from `makePom` output without a network or a broker, so they belong in the
+normal `sbt test` run. C4 reads `evicted`. None of them requires the scratch-project harness, which
+covers the complementary property — that a real build tool, not just the metadata, succeeds — and is
+specified in [quickstart.md](../quickstart.md).

--- a/specs/005-classpath-dependency-shedding/data-model.md
+++ b/specs/005-classpath-dependency-shedding/data-model.md
@@ -1,0 +1,142 @@
+# Phase 1 Data Model: Classpath and Dependency Shedding
+
+**Feature**: `005-classpath-dependency-shedding` | **Date**: 2026-08-09
+
+This feature has no runtime data model. Its "entities" are the classpath surfaces named in the spec's
+Key Entities section: what the published artifact declares, and what each declaration obliges of a
+consumer. Modelling them explicitly is what makes the acceptance criteria checkable — every rule below
+is something a test can assert.
+
+---
+
+## Entity: Dependency Declaration
+
+One entry in the published build definition.
+
+| Attribute | Values | Notes |
+| --- | --- | --- |
+| `coordinates` | group : artifact : version | The identity a consumer's build resolves |
+| `inheritance` | `inherited` \| `opt-in` \| `build-only` | Whether a consumer acquires it by declaring the plugin |
+| `origin` | `central` \| `vendor-only` | Where the artifact can actually be fetched from |
+| `justification` | `used-by` *code path* \| `retained-for` *deprecation* | Why it is declared at all |
+
+### Validation rules
+
+- **DR-1**: `inheritance = inherited` ⟹ `origin = central`. This is FR-001 and the whole of the S1
+  defect. Four declarations violate it today.
+- **DR-2**: `origin = vendor-only` ⟹ `inheritance ∈ {opt-in, build-only}`. The contrapositive of DR-1,
+  stated the way the fix is applied.
+- **DR-3**: Every declaration has a non-empty `justification`. A declaration justified by
+  `retained-for` must name the release in which the deprecation resolves.
+- **DR-4**: At most one declaration may carry `retained-for` in this release — the Kafka Streams
+  artifact. This is SC-007's "exactly one recorded exception", stated as an assertable bound rather
+  than a prose caveat.
+- **DR-5**: A declaration that the build never applies is not a declaration; it is dead text and is
+  removed (FR-015). The `avroCompiler` entry in `project/Dependencies.scala` is defined but never added
+  to `libraryDependencies` and falls here.
+
+### Transitions
+
+| Coordinate | Current on `main` | After (1.3.0) | Later (2.0.0) |
+| --- | --- | --- | --- |
+| `org.apache.kafka:kafka-clients` | inherited, vendor-only `7.9.9-ce` | inherited, central `3.9.2` | unchanged |
+| `org.apache.kafka:kafka-streams-scala` | inherited, vendor-only `7.9.9-ce` | inherited, central `3.9.2`, `retained-for` the deprecated implicits | **removed** |
+| `io.confluent:kafka-streams-avro-serde` | inherited, vendor-only `7.9.9` | **opt-in**, vendor-only | unchanged |
+| `io.confluent:kafka-avro-serializer` | inherited, vendor-only `7.9.9` | **opt-in**, vendor-only | unchanged |
+| `com.sksamuel.avro4s:avro4s-core` | opt-in, central | unchanged | unchanged |
+| `org.apache.avro:avro` | inherited, central | unchanged | unchanged |
+| `org.apache.avro:avro-compiler` | declared, never applied | **removed** | — |
+
+The `avro4s-core` row is the reference implementation of the target state: opt-in, documented, and
+already correct. It is included to make the point that this feature applies an existing pattern rather
+than inventing one.
+
+The version strings in the first column are a snapshot — dependency automation moves them regularly
+(the four vendor coordinates advanced from `7.9.5-ce`/`7.9.8` to `7.9.9-ce`/`7.9.9` during
+specification). Every rule above is stated over `inheritance` and `origin`, never over a version, so a
+bump changes this column and nothing else.
+
+---
+
+## Entity: DSL Entry Point
+
+One published Scala or Java member a simulation can reach.
+
+| Attribute | Values |
+| --- | --- |
+| `surface` | `plain` \| `avro-optin` |
+| `location` | `default-import` \| `optin-import` |
+| `coupling` | `none` \| `signature` \| `initialiser` |
+| `status` | `current` \| `deprecated(since, removed-in, replacement)` |
+
+### Validation rules
+
+- **EP-1**: `location = default-import` ⟹ `coupling ≠ signature` for any vendor-only type. A vendor type
+  in a signature is read by Scala implicit search for every consumer, so laziness cannot rescue it.
+  This is the rule that forces the Kafka Streams artifact to stay (R4).
+- **EP-2**: `location = default-import` ∧ `coupling = initialiser` ⟹ the initialiser is deferred and
+  isolated, so that loading and initialising the default entry point executes no vendor code. This is
+  FR-005, and the rule the two eager `val`s break today.
+- **EP-3**: Every `avro-optin` entry point is reachable from the opt-in import. Nothing is only
+  reachable from a deprecated location.
+- **EP-4**: `status = deprecated` ⟹ the member still compiles, and its annotation names both the
+  replacement and the removal release (Constitution Principle I).
+- **EP-5**: No entry point is removed in this release.
+
+### Current state and target
+
+| Entry point | Surface | Coupling today | Action |
+| --- | --- | --- | --- |
+| `KafkaSerdesImplicits.avroSerde` | avro-optin | initialiser, **eager** — breaks EP-2 | Defer + isolate; deprecate in place; canonical copy in the opt-in object |
+| `KafkaSerdesImplicits.serdeClass[T]` | avro-optin | initialiser, already deferred (`def`) | Deprecate in place; canonical copy in the opt-in object |
+| `KafkaSerdesImplicits.sessionWindowedSerde[T]` | plain (unused) | **signature** — permitted only because the artifact stays inherited | Deprecate; artifact retained under DR-4 |
+| `KafkaSerdesImplicits.consumedFromSerde[K,V]` | plain (unused) | **signature** — as above | Deprecate; artifact retained under DR-4 |
+| The 15 primitive serde implicits | plain | none | Unchanged |
+| `javaapi.checks.KafkaChecks.avroSerde` | avro-optin | initialiser, **eager** — breaks EP-2 | Defer + isolate |
+| `javaapi.KafkaDsl.avro(Object, SchemaRegistryClient)` | avro-optin | **signature** (Java) | Deprecate in place, pending gate G2 |
+| `javaapi.KafkaDsl.avro(JExpression, SchemaRegistryClient)` | avro-optin | **signature** (Java) | Deprecate in place, pending gate G2 |
+| `javaapi.KafkaDsl.avro(JExpression, Serializer, Deserializer)` | avro-optin | none | Unchanged — the overload G2 must prove still compiles |
+| `javaapi.KafkaDsl.avroBody(...)` | avro-optin | initialiser via `KafkaChecks.avroSerde` | Unchanged once EP-2 is satisfied — its signature is already Central-clean |
+| `javaapi.expressions.Builders.AvroExpressionBuilder(…, SchemaRegistryClient)` | avro-optin | **signature** (Java) | Deprecate in place, pending gate G2 |
+| `object avro4s` members | avro-optin (avro4s) | none | Unchanged — already correct |
+
+**Why Java signature coupling is treated differently from Scala.** EP-1 is a Scala rule because
+implicit search reads member signatures eagerly. The JVM resolves method descriptors lazily, so a Java
+signature naming an absent type is tolerable at runtime for a consumer who never calls it. Whether it
+is tolerable at *compile* time under overload resolution is gate G2, and the table above is provisional
+on it.
+
+---
+
+## Entity: Consumer Configuration
+
+What a consumer must have in place for a given capability. This is the entity the documentation
+describes and the scratch-project checks instantiate.
+
+| Capability | Repositories | Declarations | Imports |
+| --- | --- | --- | --- |
+| Plain serialization | Maven Central | the plugin | default DSL import |
+| Avro via avro4s | Maven Central | the plugin, `avro4s-core` | default + `avro4s` import |
+| Avro via Schema Registry | Maven Central **+ Confluent** | the plugin, the two `io.confluent` artifacts | default + **opt-in `confluent` import** |
+
+### Validation rules
+
+- **CC-1**: The plain row requires no repository beyond the default. This is SC-002, and it is the row
+  the scratch-project checks assert for all three build tools (FR-003).
+- **CC-2**: Each non-default row is fully stated in the installation documentation — exact coordinates
+  and exact repository URL, per build tool (FR-008). "Fully" means a consumer needs no source outside
+  the README.
+- **CC-3**: Moving between rows is additive. No row requires removing anything another row needs, so a
+  consumer can adopt Avro without unwinding a plain setup.
+- **CC-4**: The Schema Registry row's declarations pull the Kafka broker artifact transitively (R9);
+  the documented snippet shows the exclusion so opting into Avro does not silently add a broker to a
+  load-test classpath.
+
+### Upgrade transitions from 1.2.x
+
+| Consumer | Change required | Discoverable from |
+| --- | --- | --- |
+| Plain serialization | **none** | — (SC-006) |
+| Avro via avro4s | none | — |
+| Avro via Schema Registry, Central-only | was already broken; now works by following the documented row | Installation section |
+| Avro via Schema Registry, with a self-configured Confluent resolver | add two declarations; add one import | **Migration Guide** — this is the only population whose working setup changes, and the reason FR-011 is mandatory |

--- a/specs/005-classpath-dependency-shedding/plan.md
+++ b/specs/005-classpath-dependency-shedding/plan.md
@@ -1,0 +1,242 @@
+# Implementation Plan: Classpath and Dependency Shedding
+
+**Branch**: `005-classpath-dependency-shedding` | **Date**: 2026-08-09 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/005-classpath-dependency-shedding/spec.md`
+
+**Milestone**: [v1.3.0 Classpath and dependency shedding](https://github.com/galax-io/gatling-kafka-plugin/milestone/10)
+
+## Summary
+
+The published artifact declares four dependencies in a scope consumers inherit that do not exist on
+Maven Central, and its POM carries no repository from which to fetch them, so the documented
+installation path fails for every new consumer. The fix has two halves.
+
+**Relocate what can be relocated.** The Kafka client and Kafka Streams Scala artifacts are pinned to
+Confluent's vendor rebuild (`7.9.9-ce` on current `main`); the equivalent Apache releases are on Maven
+Central. Moving to Apache `3.9.2` — the newest 3.9.x on Central, the same upstream code Confluent
+Platform 7.9.x is built from, and the match for the `cp-kafka:7.9.5` brokers this project tests
+against — makes both resolvable with no functional change. Two compile spikes, one at the branch point
+and one against current `main`, confirmed source compatibility with zero warnings under
+`-Xfatal-warnings`. Both also revealed that the build silently resolves back to the Confluent client
+via a transitive path, so the version must be pinned before that result means anything.
+
+Note that the vendor coordinates moved (`7.9.5-ce`/`7.9.8` → `7.9.9-ce`/`7.9.9`) while this feature was
+being specified, with the defect untouched. Nothing asserts Central-resolvability, so routine
+dependency automation keeps the broken coordinates current and green — which is why the fix ships with
+a standing assertion rather than only a corrected version string.
+
+**Stop inheriting what cannot be relocated.** The two `io.confluent` Avro artifacts have no Maven
+Central equivalent at any version, so they must become opt-in. The obstacle is that the coupling is not
+confined to the Avro feature: `Predef` eagerly constructs a `GenericAvroSerde` at initialisation, so
+every simulation touches Confluent whether or not it uses Avro. The declared types in those members are
+already Confluent-free (`Serde[T]`, `GenericRecord` — both on Central); only the initialiser
+expressions are not. The Confluent constructions move to the opt-in object and the members left behind
+become lazy delegations to it — one keyword and one annotation each. That decouples the default DSL
+entry point while leaving every published signature in place, which is what lets the deprecation window
+required by Principle I coexist with the S1 fix in the same release.
+
+**On scope.** A simpler fix exists and was weighed: document the Confluent resolver in the README and
+change nothing else. It works, and it closes the S1 defect. It was rejected because it makes every
+consumer add a third-party repository to use a feature only some of them want — the plugin already
+treats `avro4s` as opt-in for exactly this reason, and these two artifacts are the inconsistency. The
+relocation of the Kafka client is not a workaround in either scenario: the plugin uses no vendor API, so
+the `-ce` pin is the accidental thing being removed.
+
+The unused Kafka Streams surface is deprecated rather than removed, and its artifact stays — its types
+appear in implicit *signatures*, so it cannot be shed while the implicits must keep compiling.
+
+## Technical Context
+
+**Language/Version**: Scala 2.13.18 on sbt 1.12.15; Java 17+ (Temurin in CI); Java facade sources
+compiled in the same module
+
+**Primary Dependencies**: Gatling 3.13.5 (`provided`); Apache Kafka clients — relocating from
+`org.apache.kafka:kafka-clients:7.9.9-ce` to Maven Central `3.9.2`; Confluent Avro serialization and
+Schema Registry client `7.9.9` — moving from inherited to opt-in; avro4s 4.1.2 and
+`org.apache.avro:avro` 1.12.1 (already correct). Versions are as of `main` at `4516572`; the plan is
+written against dependency *properties*, so a bump before implementation invalidates no decision
+
+**Storage**: N/A
+
+**Testing**: MUnit + ScalaTest unit specs; Testcontainers (`confluentinc/cp-kafka:7.9.5`) integration
+specs; Gatling simulations (`KafkaGatlingTest`, `KafkaJavaapiMethodsGatlingTest`) against the
+`docker-compose.kafka.yml` stack; `ExampleSmokeValidation` for README/example construction. This
+feature adds a classpath-isolation check and a published-POM assertion
+
+**Target Platform**: JVM library consumed by Gatling simulations via sbt, Gradle, and Maven
+
+**Project Type**: Single-module JVM library (Scala core plus a Java facade), published to Sonatype /
+Maven Central
+
+**Performance Goals**: N/A — this feature changes packaging, not runtime behavior. The existing suites
+are the regression guard that runtime behavior is unchanged
+
+**Constraints**: Published POM must declare only Maven Central-resolvable coordinates in inherited
+scopes; the default DSL entry point must neither reference nor initialise a Confluent type; every
+published Scala and Java signature must keep compiling for at least this minor release; the build must
+compile and test against the same client version consumers resolve
+
+**Scale/Scope**: 4 source files carry the Confluent coupling (`request/KafkaSerdesImplicits.scala`,
+`javaapi/checks/KafkaChecks.scala`, `javaapi/KafkaDsl.java`, `javaapi/expressions/Builders.java`), plus
+`project/Dependencies.scala`, `build.sbt`, `README.md`, and one example simulation. Two tracked issues
+([#185](https://github.com/galax-io/gatling-kafka-plugin/issues/185),
+[#214](https://github.com/galax-io/gatling-kafka-plugin/issues/214)) plus one companion issue this
+plan recommends opening
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+*Source: `.specify/memory/constitution.md` v1.0.0. Answer each gate; any NO must be justified in
+Complexity Tracking below or the plan does not proceed.*
+
+- [x] **I. Published API Compatibility**: **YES, this feature changes public API surface** — and the
+      obligations are met as follows. No Scala or Java *signature* changes: the declared types of the
+      affected members are already Confluent-free, so every published entry point keeps compiling.
+      Four members gain `@deprecated` annotations naming their replacement and their `1.3.0` removal
+      release, satisfying the one-minor deprecation window. A README Migration Guide entry is planned
+      (FR-011) covering the dependencies consumers must now declare and the one-line import change for
+      Schema Registry Avro users. The README compatibility table gains a Kafka client column (FR-013).
+      `ExampleSmokeValidation` stays green and its examples move to the documented opt-in import, so it
+      validates the consumer path rather than an internal shortcut. **One deviation is recorded in
+      Complexity Tracking**: consumers who had worked around the defect by configuring the Confluent
+      resolver themselves will need to declare two dependencies on upgrade. That is a build-level
+      break with no source-level counterpart, and it is why the migration entry is mandatory rather
+      than advisory.
+- [x] **II. Real Broker Over Mocks**: The feature changes the Kafka client version, which touches every
+      Kafka interaction, so the existing Testcontainers and Compose-stack suites are the regression
+      guard and must pass unchanged — no suite is relaxed, sampled, or disabled to accommodate the
+      change. The new classpath-isolation check (R7) runs real produce and request-reply simulations
+      against Testcontainers with the Confluent artifacts absent; the classpath is what varies, not the
+      broker. No mock is introduced anywhere.
+- [x] **III. Layer Separation & Single Wire Contract**: Untouched. `KafkaSender`,
+      `KafkaMessageTracker`, `KafkaMessageTrackerPool`, and `DynamicKafkaConsumer` are not modified.
+      `KafkaProtocolMessage` and `KafkaMatcher` are not extended or duplicated. The one new construct
+      is an opt-in entry point object that relocates existing serde members — it introduces no
+      abstraction, and it has a real caller (the moved examples and Java tests) from the first commit,
+      satisfying the no-speculative-abstraction rule.
+- [x] **IV. Test-First for Behavior Change**: Two failing-first tests, both of which fail against
+      today's code for the exact reason this feature exists. The published-POM assertion fails naming
+      all four unresolvable coordinates. The classpath-isolation check fails at `Predef` initialisation
+      with `NoClassDefFoundError: GenericAvroSerde`. Both are written before the corresponding change
+      and are not deferred to a later phase.
+- [x] **V. One Concern per Change, Always Green**: Spec artifacts commit first as
+      `docs(speckit): add 005-classpath-dependency-shedding spec/plan/tasks`, before any `fix`/`feat`.
+      Work decomposes to one semantic commit per issue — see Issue Decomposition below — each green on
+      its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`. The README and migration
+      documentation ride with the issue commit that makes them true, since a documented installation
+      path that does not yet work would be a false statement rather than a separable concern. Every PR
+      carries milestone 10 and a `Closes #NNN`.
+- [x] **Constraints**: No new dependency is added. The Kafka client relocation is a coordinate change
+      within the same upstream line, not a version upgrade, and it is the subject of the approved
+      FR-018 decision. This feature **restores** compliance with the standing constraint that "Avro4s
+      and Confluent Schema Registry support is `provided` scope and MUST remain optional: the plugin
+      MUST stay usable with plain serialization and no Schema Registry on the classpath" — which the
+      current build violates. No supported Gatling version changes.
+
+### Post-Phase 1 re-check
+
+Re-evaluated against the Phase 1 design in [contracts/](./contracts/) and
+[data-model.md](./data-model.md): **all gates still pass**, with two verification gates carried into
+implementation and one deviation recorded.
+
+- Gate I is the one that tightened. The design's ability to keep every signature in place rests on a
+  property verified for Scala (declared types are Confluent-free) but **not yet verified for Java**:
+  whether javac and kotlinc can compile a call to `KafkaDsl.avro(JExpression, Serializer, Deserializer)`
+  while two sibling overloads name a `SchemaRegistryClient` that is absent from the classpath. If that
+  fails, those two overloads cannot stay in place and Gate I is no longer satisfiable without either a
+  Java-source break or leaving Schema Registry inherited for Java consumers. This is a decision gate,
+  not an assumption — see Verification Gates.
+- Gate II tightened similarly: R2 showed the build resolves to the Confluent client despite declaring
+  the Apache one, so "the existing suites pass" is meaningless until the version pin lands. The pin is
+  ordered before the suites are treated as evidence.
+
+## Verification Gates
+
+Two findings are carried into implementation as gates that must be closed with evidence, not assumed.
+Neither is an open design question; both are claims that a spike could not settle.
+
+| Gate | Claim to establish | How | If it fails |
+| --- | --- | --- | --- |
+| **G1 — client pin** | The build compiles and tests against the same Kafka client version consumers resolve | Pin the client version, re-run `sbt "clean; compile; Test/compile; evicted"`, confirm no `kafka-clients` conflict is reported | Investigate whether the opt-in artifacts can be excluded from the plugin's own compile classpath; escalate before proceeding, since an unpinned build makes every downstream test result unattributable |
+| **G2 — Java overload resolution** | A Java or Kotlin consumer can compile against the facade with no Schema Registry artifact present | Compile a plain Java and a plain Kotlin simulation against the published artifact with Confluent absent, exercising the non-Schema-Registry `avro` overload | The `SchemaRegistryClient`-typed overloads must move to the opt-in Java class, which is a Java-source break. Raise with the maintainer before implementing — it may change the release's version number |
+
+## Issue Decomposition
+
+Constitution Principle V requires one tracked issue per semantic commit. Milestone 10 currently holds
+two issues, and the verified scope is wider than either records.
+
+| Commit | Issue | Scope |
+| --- | --- | --- |
+| `docs(speckit): add 005-classpath-dependency-shedding spec/plan/tasks` | — | Spec artifacts, landing first |
+| `fix(build): resolve every inherited dependency from Maven Central (#NEW)` | **companion issue to open** | Relocate the two `org.apache.kafka` artifacts to Apache coordinates; pin the client version (G1); POM assertion test |
+| `fix(build): make Confluent Avro support opt-in (#185)` | [#185](https://github.com/galax-io/gatling-kafka-plugin/issues/185) | Move the two `io.confluent` artifacts out of the inherited set; defer the eager initialisers; add the opt-in entry point; classpath-isolation test; README installation + migration entries |
+| `refactor(request): deprecate the unused Kafka Streams surface (#214)` | [#214](https://github.com/galax-io/gatling-kafka-plugin/issues/214) | Deprecate both implicits; remove the dead `avroCompiler` declaration and the unused example imports |
+
+**Action required before implementation**: open the companion issue for the Kafka client relocation and
+assign it to milestone 10, or extend #185's scope to cover it. #185 as written names only the two
+`io.confluent` artifacts; the fix must cover four, and Principle V does not permit smuggling
+unattributed scope into a commit that cites #185.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-classpath-dependency-shedding/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output (/speckit-plan command)
+├── data-model.md        # Phase 1 output (/speckit-plan command)
+├── quickstart.md        # Phase 1 output (/speckit-plan command)
+├── contracts/           # Phase 1 output (/speckit-plan command)
+│   ├── published-pom.md         # What the published artifact may declare
+│   └── dsl-entry-points.md      # What moves, what stays, what is deprecated
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (/speckit-specify output)
+└── tasks.md             # Phase 2 output (/speckit-tasks command - NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+project/
+└── Dependencies.scala                    # coordinate relocation, scope changes, dead declaration removal
+build.sbt                                 # dependency wiring, version pin (G1), POM assertion hook
+
+src/main/scala/org/galaxio/gatling/kafka/
+├── request/KafkaSerdesImplicits.scala    # defer eager Avro val; deprecate Avro + Streams members
+├── confluent.scala                       # NEW — opt-in Schema Registry Avro entry point
+├── avro4s.scala                          # unchanged — the precedent this mirrors
+├── KafkaDsl.scala                        # unchanged — mixes the (now Confluent-free) serdes trait
+└── Predef.scala                          # unchanged — must stop touching Confluent transitively
+
+src/main/java/org/galaxio/gatling/kafka/javaapi/
+├── checks/KafkaChecks.scala              # defer eager Avro val
+├── KafkaDsl.java                         # deprecate Schema Registry overloads (pending G2)
+└── expressions/Builders.java             # deprecate Schema Registry constructor (pending G2)
+
+src/test/scala/org/galaxio/gatling/kafka/
+├── build/PublishedPomSpec.scala          # NEW — inherited scopes carry only Central coordinates
+├── classpath/                            # NEW — plain simulations with Confluent absent
+└── examples/BasicSimulation.scala        # remove unused Kafka Streams imports
+
+README.md                                 # Installation (opt-in coordinates + resolver),
+                                          # Compatibility (Kafka client column), Migration Guide
+.github/workflows/ci.yml                  # scratch-project resolution job for sbt, Gradle, Maven
+```
+
+**Structure Decision**: Single module, unchanged. This feature adds one main source file
+(`confluent.scala`, deliberately a sibling of the existing `avro4s.scala` so the opt-in idiom is
+visibly one pattern rather than two) and two test areas. Everything else is an edit to a file that
+already exists. No new module, source root, or build project is introduced — the defect is in what the
+existing module declares, not in how it is organised.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| **Principle I** — consumers who had configured the Confluent resolver themselves must declare two dependencies on upgrade, a build-level break shipped in a minor release rather than a major | The two `io.confluent` artifacts have no Maven Central equivalent at any version (verified, R1), so there is no way to satisfy FR-001 while keeping them inherited. Keeping them inherited for a full deprecation cycle would leave the S1 defect shipping for another release; the plugin is currently unresolvable for any consumer following the documented installation path | *Deprecate for one minor, remove in 2.0* — rejected because the artifacts are the defect; retaining them retains the defect, and nothing is deprecated in the source (no signature changes), so there is no entry point to annotate. *Ship it as 2.0.0* — rejected by the maintainer at specification time as promoting a packaging fix to a major bump. The break is confined to build files, has a mechanical fix stated in the migration guide, and affects only consumers who had already worked around the defect with an undocumented resolver configuration |
+| **Principle V** — the README and migration documentation ride inside the issue commits rather than a separate docs PR | The documentation states the installation path. Landing "add these coordinates" before the code that requires them, or after it, means the repository asserts something untrue at one of the two commits | *Separate docs PR* — rejected because it guarantees an interval in which either the documented install is wrong or the shipped artifact is undocumented. The constitution's rule targets opportunistic docs bundled into feature work; documentation that is part of the contract being changed is the same concern, not a second one |

--- a/specs/005-classpath-dependency-shedding/plan.md
+++ b/specs/005-classpath-dependency-shedding/plan.md
@@ -162,6 +162,26 @@ Neither is an open design question; both are claims that a spike could not settl
 | **G1 — client pin** | The build compiles and tests against the same Kafka client version consumers resolve | Pin the client version, re-run `sbt "clean; compile; Test/compile; evicted"`, confirm no `kafka-clients` conflict is reported | Investigate whether the opt-in artifacts can be excluded from the plugin's own compile classpath; escalate before proceeding, since an unpinned build makes every downstream test result unattributable |
 | **G2 — Java overload resolution** | A Java or Kotlin consumer can compile against the facade with no Schema Registry artifact present | Compile a plain Java and a plain Kotlin simulation against the published artifact with Confluent absent, exercising the non-Schema-Registry `avro` overload | The `SchemaRegistryClient`-typed overloads must move to the opt-in Java class, which is a Java-source break. Raise with the maintainer before implementing — it may change the release's version number |
 
+### Outcomes (2026-08-09)
+
+**G1 — CLOSED.** `dependencyOverrides ++= kafkaOverrides` in `build.sbt` pins `kafka-clients`,
+`kafka-streams`, and `kafka-streams-scala` to the declared Apache version, defeating the eviction via
+`kafka-schema-registry-client`. `sbt "clean; compile; Test/compile; evicted"` exits 0 with zero
+`kafka-clients` conflicts; the only remaining conflict is the pre-existing, transitive-only
+`slf4j-api`. The overrides do not surface in the published POM, so Contract C5 is unaffected. The build
+now compiles and tests against the client it ships.
+
+**G2 — CLOSED FOR JAVA. Kotlin unverified.** `javac` compiled a probe calling
+`avro(JExpression, Serializer, Deserializer)` alongside plain protocol and request DSL usage, against
+the compile classpath with all seven `io.confluent` jars removed (95 of 102 entries) — exit 0, no
+diagnostics. Overload resolution does not force loading `SchemaRegistryClient`, so the two
+`SchemaRegistryClient`-typed overloads and the `AvroExpressionBuilder` constructor can stay in place,
+deprecated, and Java source compatibility is fully preserved. **The Kotlin half was not run**:
+`kotlinc` is not installed on this machine, and — separately — the build declares no Kotlin plugin, so
+the four simulations under `src/test/kotlin/` are compiled by no build step at all. Java's result is
+the load-bearing one, since the affected signatures are Java and Kotlin resolves the same descriptors,
+but this is recorded as unverified rather than assumed. Tracked as T045.
+
 ## Issue Decomposition
 
 Constitution Principle V requires one tracked issue per semantic commit. Milestone 10 currently holds

--- a/specs/005-classpath-dependency-shedding/quickstart.md
+++ b/specs/005-classpath-dependency-shedding/quickstart.md
@@ -1,0 +1,218 @@
+# Quickstart: Validating Classpath and Dependency Shedding
+
+**Feature**: `005-classpath-dependency-shedding` | **Date**: 2026-08-09
+
+How to prove this feature works, in the order the evidence should be gathered. Every step states what a
+pass looks like and what the current (pre-fix) result is, so a step that passes before the change is a
+broken test rather than good news.
+
+**Contracts referenced**: [published-pom.md](./contracts/published-pom.md) (C1–C5),
+[dsl-entry-points.md](./contracts/dsl-entry-points.md) (E1–E5).
+
+---
+
+## Prerequisites
+
+- JDK 17+ and sbt 1.12.15 (the repo pins this in `project/build.properties`)
+- Docker, for Testcontainers and the Compose stack
+- Gradle and Maven, for the cross-build-tool checks in Step 4
+- Network access to Maven Central; **deliberately no Confluent resolver** in the scratch projects
+
+```bash
+docker compose -f docker-compose.kafka.yml up -d
+```
+
+---
+
+## Step 0 — Baseline: confirm the defect still reproduces
+
+Do this before changing anything. If it does not reproduce, the premise has changed and the plan needs
+revisiting.
+
+```bash
+curl -s https://repo1.maven.org/maven2/org/galaxio/gatling-kafka-plugin_2.13/1.2.0/gatling-kafka-plugin_2.13-1.2.0.pom
+```
+
+**Expected**: four `<dependency>` entries with no `<scope>` (i.e. inherited) whose coordinates are
+`org.apache.kafka:kafka-clients:7.9.5-ce`, `org.apache.kafka:kafka-streams-scala_2.13:7.9.5-ce`,
+`io.confluent:kafka-streams-avro-serde:7.9.8`, `io.confluent:kafka-avro-serializer:7.9.8`; and no
+`<repositories>` element anywhere in the file.
+
+Then read the versions the *next* release would publish, which differ — dependency automation advances
+them regularly:
+
+```bash
+grep -E "val kafka|val kafkaAvroSerde" project/Dependencies.scala
+```
+
+**Expected at `main` = `4516572`**: `7.9.9-ce` and `7.9.9`. Confirm the currently declared vendor
+coordinate is not on Central, substituting whatever version the previous command printed:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/7.9.9-ce/kafka-clients-7.9.9-ce.pom
+```
+
+**Expected**: `404`. If a bump has landed since, re-run with the new version — the answer has been
+`404` for every `-ce` and `-ccs` version checked, and a `200` here would be a genuinely new finding
+worth stopping for.
+
+---
+
+## Step 1 — Gate G1: the build resolves the client it ships
+
+Run after the coordinate relocation and the version pin, before trusting any test result.
+
+```bash
+sbt -batch "clean; compile; Test/compile; evicted"
+```
+
+**Pass**: exit 0, and the `evicted` output reports **no** version conflict for
+`org.apache.kafka:kafka-clients`.
+
+**Current result**: exit 0 but `evicted` reports
+`org.apache.kafka:kafka-clients:7.9.9-ccs is selected over {3.9.2}` — the build compiles against the
+Confluent client while declaring the Apache one. Until this line is gone, every later step is testing
+an artifact that differs from the one consumers get, and Contract C4 is unmet.
+
+---
+
+## Step 2 — Contract C1–C3, C5: the published metadata
+
+```bash
+sbt "testOnly *PublishedPomSpec"
+```
+
+**Pass**: the inherited dependency set contains no `io.confluent` coordinate and no `org.apache.kafka`
+version bearing a `-ce` or `-ccs` suffix; every inherited dependency is justified; at most one is
+justified by a deprecation; publication identity is unchanged.
+
+**Current result**: fails, naming all four offending coordinates. This is the failing-first test for
+Constitution Principle IV — run it before the build change and keep the output.
+
+Inspect the generated POM directly when diagnosing:
+
+```bash
+sbt makePom
+```
+
+---
+
+## Step 3 — Contract E1: the default import works without Confluent
+
+The core acceptance check, and the one that distinguishes a real fix from a metadata-only one.
+
+```bash
+sbt "testOnly *ClasspathIsolation*"
+```
+
+**Pass**: with the `io.confluent` artifacts absent from the runtime classpath, a plain produce
+simulation and a plain request-reply simulation with checks both run to completion against a real
+broker, and `Predef` initialises without error.
+
+**Current result**: fails at `Predef` initialisation with
+`NoClassDefFoundError: io/confluent/kafka/streams/serdes/avro/GenericAvroSerde`.
+
+**Watch for a false pass**: if the harness leaves the Confluent artifacts on the classpath the test
+passes vacuously. Assert the absence — the check should fail loudly if `GenericAvroSerde` *is*
+loadable, so a misconfigured harness reports itself instead of reporting success.
+
+---
+
+## Step 4 — FR-003: a real consumer, on all three build tools
+
+Contracts C1–C3 test the metadata; this tests what a build tool actually does with it, which is where
+scope-handling differences between the tools surface.
+
+```bash
+sbt publishM2
+```
+
+Then, for each of sbt, Gradle, and Maven, build a scratch consumer project configured with **Maven
+Central and the local repository only — no Confluent resolver** — declaring nothing but the plugin, and
+containing the minimal produce simulation from the README.
+
+**Pass**: resolution succeeds, the simulation compiles, and it runs against the broker. For each tool,
+all three.
+
+**Current result**: resolution fails with unresolved dependencies for all three.
+
+**Why the local repository is allowed**: the version under test is not on Central. Its *transitive*
+dependencies still must come from Central alone, which is the property under test. Adding the Confluent
+resolver to any scratch project invalidates the check.
+
+---
+
+## Step 5 — Contract E2 and FR-009: the opt-in Avro path
+
+Repeat Step 4's sbt project, this time adding exactly what the README's Avro section says — the two
+`io.confluent` coordinates and the Confluent repository — and the opt-in import.
+
+**Pass**: an Avro produce simulation and an Avro body check against a Schema-Registry-backed record both
+compile and run. No coordinate or repository outside the README was needed.
+
+**This step is also a documentation test.** Follow the README literally, without consulting the build
+definition. If a step requires knowledge not in the README, FR-008 is unmet even though the code works.
+
+---
+
+## Step 6 — Gate G2: the Java and Kotlin facade
+
+```bash
+sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"
+```
+
+Then compile a plain Java simulation and a plain Kotlin simulation against the published artifact with
+Confluent absent, exercising `avro(JExpression, Serializer, Deserializer)` so overload resolution is
+actually forced.
+
+**Pass**: both compile. Per Contract E4, this establishes that the `SchemaRegistryClient`-typed
+overloads can stay in place, deprecated.
+
+**If it fails**: stop. Those overloads must move, which is a Java-source break with no deprecation
+window and a change to the release's compatibility story. Raise it with the maintainer rather than
+deciding it during implementation.
+
+---
+
+## Step 7 — Contract E5: nothing else moved
+
+```bash
+sbt scalafmtCheckAll scalafmtSbtCheck compile test
+```
+
+```bash
+sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport
+```
+
+**Pass**: green, with no suite relaxed, skipped, retried, or disabled to accommodate the dependency
+change. A suite modified to keep passing is a finding, not a pass — this run is the only evidence that
+relocating the Kafka client changed no runtime behavior.
+
+---
+
+## Step 8 — SC-006: an existing consumer upgrades cleanly
+
+Take a plain-serialization simulation written against 1.2.x, change only the plugin version, and build.
+
+**Pass**: compiles and runs with zero changes to build files or sources.
+
+Then take a Schema Registry Avro simulation written against 1.2.x with a self-configured Confluent
+resolver, and apply exactly the steps in the Migration Guide.
+
+**Pass**: compiles and runs. If any change beyond the documented steps is needed, FR-011 is unmet.
+
+---
+
+## Evidence checklist
+
+| Step | Contract / requirement | Must fail before the fix |
+| --- | --- | --- |
+| 0 | Defect reproduces | — (baseline) |
+| 1 | C4, gate G1 | yes — conflict reported |
+| 2 | C1, C2, C3, C5 | yes — 4 violations |
+| 3 | E1, FR-004, FR-005 | yes — `NoClassDefFoundError` |
+| 4 | FR-003, SC-001, SC-003 | yes — unresolved dependencies |
+| 5 | E2, FR-008, FR-009, SC-004 | n/a — path does not exist yet |
+| 6 | E4, gate G2 | unknown — this is what the gate settles |
+| 7 | E5, SC-009 | no — must pass before and after |
+| 8 | SC-005, SC-006, FR-011 | n/a — needs the release to exist |

--- a/specs/005-classpath-dependency-shedding/research.md
+++ b/specs/005-classpath-dependency-shedding/research.md
@@ -1,0 +1,353 @@
+# Phase 0 Research: Classpath and Dependency Shedding
+
+**Feature**: `005-classpath-dependency-shedding` | **Date**: 2026-08-09
+**Spec**: [spec.md](./spec.md)
+
+All findings below were established by probing live artifact repositories and by a compile spike in this
+worktree, not by reading the build definition. Commands and outcomes are recorded so they can be
+re-run.
+
+---
+
+## R1 — Which coordinates can replace the Confluent-only Kafka artifacts
+
+**Decision**: Relocate the Kafka client and Kafka Streams Scala artifacts to the Apache-released
+coordinates on Maven Central, targeting **3.9.2** — the newest 3.9.x on Central (3.9.3 does not exist).
+Keep both inherited by consumers.
+
+**Rationale**:
+
+- Confluent Platform 7.9.x is built from Apache Kafka 3.9.x, so 3.9.x is the equivalent line rather
+  than an upgrade. Version currency is explicitly out of scope for this feature. `main` currently pins
+  `7.9.9-ce`, which is still the 7.9 line, so 3.9.2 remains the matching target.
+- The broker images this project tests against are `confluentinc/cp-kafka:7.9.5` in both
+  `docker-compose.kafka.yml` and the Testcontainers integration specs — i.e. Apache 3.9.x brokers. A
+  3.9.x client matches them exactly.
+- CI's service broker is `wurstmeister/kafka:2.13-2.8.1` (Apache 2.8.1). Kafka clients are
+  backward-compatible across this gap for the APIs in use, and the current 7.9.5-ce client already
+  spans it.
+- The plugin uses only long-stable core client API. Full inventory of `org.apache.kafka` imports in
+  `src/main`: `clients.consumer.{ConsumerConfig, ConsumerRecord, ConsumerRebalanceListener,
+  KafkaConsumer}`, `clients.producer.{ProducerConfig, ProducerRecord, KafkaProducer, Producer,
+  RecordMetadata}`, `common.TopicPartition`, `common.errors.WakeupException`, `common.header.*`,
+  `common.serialization.*`, plus the two Streams types covered in R4. Nothing version-sensitive.
+
+**Verification performed** (2026-08-09):
+
+| Coordinate | Maven Central | Confluent repo |
+| --- | --- | --- |
+| `org.apache.kafka:kafka-clients:7.9.2-ccs` | 404 | — |
+| `org.apache.kafka:kafka-clients:7.9.5-ce` *(published 1.2.0)* | 404 | 200 |
+| `org.apache.kafka:kafka-clients:7.9.5-ccs` | 404 | — |
+| `org.apache.kafka:kafka-clients:7.9.8-ce` | 404 | 200 |
+| `org.apache.kafka:kafka-clients:7.9.8-ccs` | 404 | 200 |
+| `org.apache.kafka:kafka-clients:7.9.9-ce` *(current `main`)* | 404 | 200 |
+| `org.apache.kafka:kafka-clients:7.9.9-ccs` | 404 | 200 |
+| `org.apache.kafka:kafka-clients:3.9.0` | **200** | — |
+| `org.apache.kafka:kafka-clients:3.9.1` | **200** | — |
+| `org.apache.kafka:kafka-clients:3.9.2` | **200** | — |
+| `org.apache.kafka:kafka-clients:3.9.3` | 404 — does not exist | — |
+| `org.apache.kafka:kafka-streams-scala_2.13:3.9.1` | **200** | — |
+| `org.apache.kafka:kafka-streams-scala_2.13:3.9.2` | **200** | — |
+| `io.confluent:kafka-streams-avro-serde:7.9.8` | 404 | 200 |
+| `io.confluent:kafka-avro-serializer:7.9.8` | 404 | 200 |
+| `io.confluent:kafka-streams-avro-serde:7.9.9` *(current `main`)* | 404 | 200 |
+| `io.confluent:kafka-avro-serializer:7.9.9` *(current `main`)* | 404 | 200 |
+| `io.confluent:kafka-schema-registry-client:7.9.8` | 404 | — |
+
+Neither the `-ce` nor the `-ccs` vendor suffix is published to Maven Central at **any** of the seven
+versions checked, spanning both the published release and current `main`. There is no "just bump the
+version" escape — and note that bumping is exactly what has been happening: `main` moved from
+`7.9.5-ce`/`7.9.8` to `7.9.9-ce`/`7.9.9` while this specification was being written, with the defect
+fully intact. Relocation to Apache coordinates is the only route for the two `org.apache.kafka`
+artifacts, and there is no route at all for the two `io.confluent` ones — confirming R3's conclusion
+that they must stop being inherited.
+
+This is also the argument for making Contract C1 a standing assertion rather than a one-time fix:
+nothing currently tests the property, so every automated bump lands green while keeping the artifact
+unresolvable.
+
+**Alternatives considered**:
+
+- *Apache 4.x* (latest on Central is 4.3.1). Rejected: 4.x removes deprecated APIs and raises the
+  minimum broker, which is a compatibility change this feature has no mandate to make.
+- *Keep `-ce` and document the Confluent resolver in the README.* Rejected by FR-001/FR-002 — the
+  published POM cannot carry a resolver (`pomIncludeRepository := { _ => false }`), so the artifact
+  stays broken for anyone who does not read that specific README line before their first build.
+- *Make the client non-inherited.* Rejected by the maintainer at specification time (FR-018): it would
+  force every consumer, including plain-serialization users, to edit their build to upgrade.
+
+---
+
+## R2 — Does the plugin compile against the Apache coordinates?
+
+**Decision**: Yes for source compatibility — but the spike also proved the build does **not** actually
+resolve to the Apache version, so a resolution pin is required. See R3.
+
+**Spike performed twice** (2026-08-09, this worktree, reverted after each run). Run 1 set
+`Versions.kafka = "3.9.1"` against the branch point; run 2 set `Versions.kafka = "3.9.2"` against
+current `main` (`4516572`, which carries `7.9.9-ce` / `7.9.9`). Both ran:
+
+```bash
+sbt -batch "clean; compile; Test/compile; evicted"
+```
+
+**Result, both runs**: exit 0. `compile` built 28 Scala + 16 Java main sources and `Test/compile` built
+26 Scala + 4 Java test sources, under the project's `-Xfatal-warnings` setting, with **zero errors and
+zero compiler warnings**. Changing the coordinates is source-compatible for both the main and test
+source sets, and the result is stable across the dependency bump that landed mid-specification.
+
+**But neither spike tested what it appeared to test.** Run 2's `evicted` report showed:
+
+```text
+[warn] * org.apache.kafka:kafka-clients:7.9.9-ccs is selected over {3.9.2}
+[warn]     +- org.galaxio:gatling-kafka-plugin_2.13:… (depends on 7.9.9-ccs)
+[warn]     +- io.confluent:kafka-schema-registry-client:7.9.9 (depends on 7.9.9-ccs)
+[warn]     +- org.apache.kafka:kafka-streams:3.9.2 (depends on 3.9.2)
+[warn]     +- org.apache.kafka:kafka-clients:3.9.2 (depends on 3.9.2)
+```
+
+Run 1 was identical with `7.9.8-ccs` over `{3.9.1}`. The two `io.confluent` artifacts pull
+`kafka-schema-registry-client`, which depends on the vendor-suffixed client; sbt's version conflict
+resolution selects the higher version and evicts the Apache one. **The spikes compiled against the
+Confluent client, not the Apache one.** Their clean result is evidence that the coordinates are
+declarable, not yet that the Apache client works.
+
+A second, unrelated conflict appears for the same reason: `slf4j-api:2.0.17` (Apache 3.9.x) over
+`1.7.36` (Confluent chain). The build already excludes `slf4j-api` from its direct Kafka dependencies,
+so this is transitive-only.
+
+**Follow-up required in implementation**: pin the client version so the build compiles and tests
+against exactly what a consumer will resolve, then re-run the spike and confirm `evicted` reports no
+`kafka-clients` conflict. Until that pin exists, no claim about Apache 3.9.2 behavior is supported by
+evidence. This is captured as a plan task and as an explicit gate in [quickstart.md](./quickstart.md).
+
+**Why the pin is needed even though the artifacts become non-inherited**: a non-inherited dependency is
+still on the *plugin's own* compile and test classpath. Without a pin, the plugin would be built and
+tested against the Confluent client while consumers run it against the Apache one — the exact
+build/runtime mismatch that makes a green suite meaningless.
+
+---
+
+## R3 — Why the Confluent Avro artifacts must stop being inherited, and what that breaks
+
+**Decision**: Move `io.confluent:kafka-streams-avro-serde` and `io.confluent:kafka-avro-serializer` to a
+scope consumers do not inherit, matching the existing treatment of `avro4s-core`. There is no
+alternative — R1 shows no Maven Central equivalent exists at any version.
+
+**The obstacle**: the coupling is not confined to the Avro feature. Four sites in `src/main` reference
+Confluent types, and the first two are reached by *every* simulation:
+
+| Site | What it is | Reached by |
+| --- | --- | --- |
+| `request/KafkaSerdesImplicits.scala:45` | `implicit val avroSerde: Serde[GenericRecord] = new GenericAvroSerde()` | `Predef` — strict trait `val`, runs at object initialisation |
+| `request/KafkaSerdesImplicits.scala:35-43` | `serdeClass[T]` using `KafkaAvroSerializer` / `CachedSchemaRegistryClient` | `Predef` — but a `def`, body deferred |
+| `javaapi/checks/KafkaChecks.scala:26` | `val avroSerde: Serde[GenericRecord] = new GenericAvroSerde()` | Java DSL — strict object `val` |
+| `javaapi/KafkaDsl.java:103,107` and `javaapi/expressions/Builders.java:72` | `SchemaRegistryClient` in public Java signatures | Java facade |
+
+`Predef` is `object Predef extends KafkaDsl`, and `KafkaDsl extends KafkaCheckSupport with
+KafkaSerdesImplicits`. So merely touching `Predef` initialises the trait and executes
+`new GenericAvroSerde()`. Removing the artifact without addressing this converts today's
+resolution-time failure into a load-time `NoClassDefFoundError` in the middle of a load test — strictly
+worse for the consumer, and the reason FR-020 exists.
+
+**Key distinction that makes the fix tractable**: the *declared types* in these members are
+`Serde[T]` (kafka-clients, on Central) and `GenericRecord` (`org.apache.avro`, on Central). Only the
+*initialiser expressions* name Confluent types. Signatures can therefore stay exactly as they are
+while the Confluent construction is deferred.
+
+**Approach — delegation, not deferral machinery**:
+
+1. Add the opt-in entry point (R5). The Confluent constructions move there and live there. It is the
+   only place in `src/main` that names a Confluent type for serdes.
+2. The members staying on `KafkaSerdesImplicits` become one-line delegations to it, annotated
+   deprecated. `implicit val avroSerde: Serde[GenericRecord] = new GenericAvroSerde()` becomes
+   `implicit lazy val avroSerde: Serde[GenericRecord] = confluent.avroSerde`; `serdeClass[T]` delegates
+   the same way and needs no `lazy`, being already a `def`.
+3. `javaapi/checks/KafkaChecks.avroSerde` delegates identically.
+
+**Why this is smaller than it first looked.** An earlier draft of this research proposed making the
+`val`s lazy *and* isolating each construction behind a dedicated holder class, to be safe about when
+the JVM verifier resolves a missing type. Delegation gets both properties for free: the holder already
+exists — it is the opt-in object — and after delegation `KafkaSerdesImplicits` contains no reference to
+a Confluent type at all, in signatures or in bytecode. There is nothing left to be subtle about, and
+nothing to prove beyond the runtime check in R7. The whole change to the deprecated members is one
+keyword and one annotation each.
+
+`lazy` is still required on `avroSerde` for a second reason: without it, `Predef` initialisation would
+force `object confluent` to initialise, which would construct the Confluent serde eagerly again through
+one more hop.
+
+**Why signature-level decoupling matters for Scala specifically**: implicit search reads the signature
+of every implicit member of a trait in scope. Had a Confluent type appeared in one of those signatures,
+plain consumers would fail to compile regardless of laziness. That is precisely the situation of the
+two Kafka Streams implicits, which is why R4 reaches a different conclusion for them.
+
+**Open risk carried into implementation** — Java overload resolution. `javaapi/KafkaDsl.java` declares
+three `avro` overloads; two name `SchemaRegistryClient` and one takes `Serializer`/`Deserializer`
+instead. The JVM resolves method descriptors lazily, so a consumer who never calls the Schema Registry
+overloads should load and run fine. Whether **javac and kotlinc** can compile a call to the third
+overload while the other two name a type absent from the classpath is not established and must be
+tested, not assumed. If it fails, the `SchemaRegistryClient`-typed overloads move to the opt-in Java
+class and the in-place ones cannot be retained — which would be a Java-source break needing its own
+decision. Recorded as a decision gate in the plan.
+
+---
+
+## R4 — Why the Kafka Streams artifact stays inherited this release
+
+**Decision**: Keep `kafka-streams-scala` inherited, relocated to Apache coordinates under R1 so it
+satisfies FR-001. Deprecate the two implicits holding it; shed the artifact when they are removed.
+
+**Rationale**: unlike the Avro members, these two have Kafka Streams types **in their signatures**:
+
+```scala
+implicit def sessionWindowedSerde[T](implicit tSerde: Serde[T]): WindowedSerdes.SessionWindowedSerde[T]
+implicit def consumedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Consumed[K, V]
+```
+
+Scala implicit search reads these signatures for every simulation that imports the DSL. No amount of
+lazy initialisation helps: the types must be on the classpath for the trait to be usable at all.
+Keeping the implicits compiling for one more minor — required by Constitution Principle I — therefore
+*requires* keeping the artifact. The two obligations are inseparable, which is what the maintainer
+resolved in favour of the constitution at specification time (FR-019).
+
+R1 makes this harmless: the Apache coordinate is on Maven Central, so the retained artifact satisfies
+FR-001 like any other. Consumers see no change.
+
+**Alternatives considered**: shedding now (rejected — would break compilation for every consumer, not
+just users of the two implicits, since implicit search reads the signatures regardless of use);
+removing them outright as a major (rejected — promotes a packaging fix to a major version bump).
+
+---
+
+## R5 — Shape and naming of the opt-in Avro entry point
+
+**Decision**: A Scala `object org.galaxio.gatling.kafka.confluent`, imported as
+`import org.galaxio.gatling.kafka.confluent._`, holding the Schema-Registry-backed serde surface. For
+Java, a companion class carrying whichever entry points R3's verification shows cannot stay in place.
+
+**Rationale**:
+
+- The project already has exactly this pattern: `object org.galaxio.gatling.kafka.avro4s`, imported as
+  `import org.galaxio.gatling.kafka.avro4s._`, which holds the avro4s serde and is documented as
+  requiring a dependency the consumer adds. It depends only on Central-published artifacts, so it needs
+  no change — and it is the precedent to copy rather than invent against.
+- `confluent` rather than `avro` because the import name then matches the dependency the consumer must
+  add, which is the association the migration guide needs them to make. `avro` would be ambiguous
+  against the existing `avro4s` object and against plain Apache Avro, which does not require the
+  opt-in.
+
+**Consumer-visible change**: one import line for Schema-Registry Avro users, stated in the migration
+guide. This is the change the maintainer approved under FR-020.
+
+**Alternatives considered**: a mixin trait rather than an object (rejected — `avro4s` establishes the
+object-with-import idiom and a trait invites re-mixing into a custom `Predef`, re-coupling it); reusing
+the `avro4s` object (rejected — it would drag Confluent into a surface that is currently Central-clean).
+
+---
+
+## R6 — How to prove Maven Central-only resolvability
+
+**Decision**: Two complementary gates, cheapest first.
+
+1. **POM assertion (fast, always-on).** Assert on the output of `makePom`: no dependency in a scope
+   consumers inherit may carry vendor-suffixed or `io.confluent` coordinates. This is deterministic,
+   needs no network, and fails in seconds. It is also the gate that would have caught this defect
+   originally.
+2. **Scratch-project resolution (slow, CI).** Publish the plugin locally (`publishM2`), then for each
+   of sbt, Gradle, and Maven generate a minimal consumer configured with **Maven Central plus the local
+   repository only** — no Confluent resolver — and assert that resolution and compilation of a plain
+   simulation succeed.
+
+**Rationale**: gate 1 tests the published contract directly and runs on every build. Gate 2 tests the
+consumer experience end to end and is the only thing that catches a build-tool-specific scope
+difference — which FR-003 requires precisely because the three tools treat non-inherited scopes
+differently and translating one to the others by analogy is how this class of defect survives.
+
+**Why local publication is required**: the version under test is not on Central, so a genuine
+Central-only consumer cannot resolve it. Adding the local repository is the minimum deviation, and it
+does not weaken the test: the *transitive* dependencies still have to come from Central alone, which is
+exactly the property under test.
+
+**Alternatives considered**: sbt `scripted` tests. The infrastructure is not present (no `src/sbt-test`
+directory; the recent "sbt, scripted-plugin" bump is Scala Steward tracking sbt's own version) and
+scripted only covers the sbt path, leaving FR-003's Gradle and Maven requirements unmet. Rejected as
+insufficient alone; a scripted harness remains a reasonable later refinement for the sbt path.
+
+---
+
+## R7 — Test-first strategy for a classpath change
+
+**Decision**: The failing-first test is a **runtime check with the Confluent artifacts absent from the
+classpath**: construct the DSL entry point and execute a plain produce and a plain request-reply
+simulation against a real broker.
+
+**Rationale**: Constitution Principle IV requires a test that fails before the change and passes after.
+Against today's code this test fails at `Predef` initialisation with a `NoClassDefFoundError` for
+`GenericAvroSerde` — the precise defect R3 describes — and passes once the initialisation is deferred.
+Principle II is satisfied because the produce and request-reply paths run against Testcontainers rather
+than a stub; the classpath is what varies, not the broker.
+
+The POM assertion from R6 is the second failing-first test: it fails against the current build
+definition, naming all four offending coordinates.
+
+**Alternatives considered**: asserting on the build definition's text (rejected — tests the declaration,
+not the outcome, and would have passed happily throughout the period this defect shipped); a
+reflection-based check that the Confluent classes are unreferenced (rejected — proves less than simply
+running without them).
+
+---
+
+## R8 — Deprecations under `-Xfatal-warnings`
+
+**Decision**: Route every in-project usage of a newly deprecated member to its new home in the same
+change; suppress only where a deprecated member's own definition or its regression test must reference
+it.
+
+**Rationale**: the build compiles with `-Xfatal-warnings`, so a deprecation the project itself trips
+over turns the build red. An audit at spec time found no caller of either Kafka Streams implicit
+anywhere in sources, tests, or docs, so those two are free. The Avro members do have in-project users
+(examples and Java tests) which must move to the opt-in import — which has the useful side effect of
+making the examples demonstrate the documented consumer path.
+
+Two unused Kafka Streams imports in `src/test/.../examples/BasicSimulation.scala:11-12` are removed as
+part of this (FR-016); they are currently unused-but-tolerated and would otherwise become noise.
+
+**`since` value**: `@deprecated(..., "1.3.0")`. The build derives its version from the git tag via
+dynver, so there is no version constant to reference; the string is written literally and must match
+the release this ships in.
+
+---
+
+## R9 — What consumers inherit from the opt-in artifacts
+
+**Finding, for documentation rather than decision**: `io.confluent:kafka-avro-serializer` declares a
+dependency on `kafka_${scala.version}` — the Kafka **broker** artifact — alongside
+`kafka-schema-registry-client`, `avro`, `guava`, `commons-compress` and `logredactor`. Consumers who opt
+in inherit that whole chain, including a broker they will never run.
+
+This is not a regression — the same chain is inherited today, in a worse form, because the artifact is
+currently a compile-scope dependency. But since FR-008 requires the documentation to state exact
+coordinates, the snippet should be written knowing what it drags in, and should show the broker
+exclusion so that opting into Avro does not silently add tens of megabytes to a load-test classpath.
+
+---
+
+## Resolved unknowns summary
+
+| # | Question | Outcome |
+| --- | --- | --- |
+| R1 | Replacement coordinates | Apache **3.9.2** on Central (newest 3.9.x); no vendor-suffixed build is on Central at any of the seven versions checked |
+| R2 | Does it compile? | Yes, in two spikes, zero warnings under `-Xfatal-warnings` — but both resolved to the Confluent client, so a version pin is required before the result means anything |
+| R3 | Can the Avro artifacts become optional? | Yes, by deferring two strict `val` initialisers; signatures are already Confluent-free. Java overload resolution is an open verification gate |
+| R4 | Can Kafka Streams be shed now? | No — its types are in implicit signatures; it stays, relocated to Central |
+| R5 | Opt-in entry point | `object org.galaxio.gatling.kafka.confluent`, mirroring the existing `avro4s` object |
+| R6 | How to prove resolvability | POM assertion on every build, plus scratch-project resolution per build tool in CI |
+| R7 | Test-first approach | Run plain simulations with the Confluent artifacts off the classpath; fails today at `Predef` init |
+| R8 | Deprecations vs `-Xfatal-warnings` | No existing callers of the Streams implicits; Avro users in-project move to the opt-in import |
+| R9 | Opt-in artifact weight | Pulls the Kafka broker artifact transitively; document an exclusion in the snippet |
+
+**No unresolved NEEDS CLARIFICATION items remain.** Two items are carried into implementation as
+verification gates rather than open questions: the client version pin (R2) and Java overload resolution
+without Schema Registry on the classpath (R3).

--- a/specs/005-classpath-dependency-shedding/spec.md
+++ b/specs/005-classpath-dependency-shedding/spec.md
@@ -1,0 +1,487 @@
+# Feature Specification: Classpath and Dependency Shedding
+
+**Feature Branch**: `005-classpath-dependency-shedding`
+
+**Created**: 2026-08-09
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/gatling-kafka-plugin/milestone/10 — v1.3.0 Classpath and dependency shedding. S1 — a consumer following the README cannot resolve the plugin at all: compile-scope Confluent artifacts are not on Maven Central and the published POM strips the resolver. Also sheds the Kafka Streams dependency held by two unused implicits."
+
+**Milestone**: [v1.3.0 Classpath and dependency shedding](https://github.com/galax-io/gatling-kafka-plugin/milestone/10)
+
+**Tracked issues**: [#185](https://github.com/galax-io/gatling-kafka-plugin/issues/185) (bug, priority p1), [#214](https://github.com/galax-io/gatling-kafka-plugin/issues/214)
+
+---
+
+## Problem
+
+The published plugin artifact declares dependencies that a consumer cannot obtain. The result is that
+the installation path documented in the README does not work for a consumer whose build resolves from
+the default public artifact repository only — which is the default configuration of every supported
+build tool.
+
+### Verified evidence (2026-08-09)
+
+**What is published today.** The POM for `org.galaxio:gatling-kafka-plugin_2.13:1.2.0` declares **four**
+dependencies in a scope consumers inherit, none of which exist on Maven Central, and declares **no**
+repository from which to fetch them:
+
+| Declared in published `1.2.0` | Maven Central | Confluent repository |
+| --- | --- | --- |
+| `org.apache.kafka:kafka-clients:7.9.5-ce` | absent (404) | present (200) |
+| `org.apache.kafka:kafka-streams-scala_2.13:7.9.5-ce` | absent (404) | present (200) |
+| `io.confluent:kafka-streams-avro-serde:7.9.8` | absent (404) | present (200) |
+| `io.confluent:kafka-avro-serializer:7.9.8` | absent (404) | present (200) |
+
+**What the next release would publish.** `main` has since moved to newer versions of the same four
+coordinates, and every one of them is equally absent from Maven Central:
+
+| Declared on `main` | Maven Central | Confluent repository |
+| --- | --- | --- |
+| `org.apache.kafka:kafka-clients:7.9.9-ce` | absent (404) | present (200) |
+| `org.apache.kafka:kafka-streams-scala_2.13:7.9.9-ce` | absent (404) | present (200) |
+| `io.confluent:kafka-streams-avro-serde:7.9.9` | absent (404) | present (200) |
+| `io.confluent:kafka-avro-serializer:7.9.9` | absent (404) | present (200) |
+
+The repository list is stripped from the published POM by design (correct Sonatype hygiene for the
+publisher, but it removes the only signal a consumer could have followed). Issue #185 identified the two
+`io.confluent` artifacts; verification for this specification found that the two `org.apache.kafka`
+artifacts are affected identically, because the build pins Confluent's `-ce` rebuild rather than the
+Apache release. The problem is a property of the vendor coordinate, not of any particular version: the
+`-ccs` variants are absent from Maven Central too, at every version checked. Equivalent Apache-released
+coordinates (`org.apache.kafka:kafka-clients`, `org.apache.kafka:kafka-streams-scala_2.13`) are present.
+
+**Version automation cannot fix this and has been masking it.** Routine dependency updates keep moving
+these four coordinates forward inside the vendor line — `7.9.5-ce` → `7.9.9-ce`, `7.9.8` → `7.9.9` —
+which keeps them current and keeps them unresolvable. Nothing in the build asserts that an inherited
+dependency is fetchable from the default public repository, so each bump lands green. The same
+automation also maintains a dependency declaration the build never applies (`avro-compiler`, most
+recently bumped to 1.12.1), which is the FR-015 cleanup. This is why FR-001 needs an assertion attached
+to it rather than a one-time correction.
+
+The optional-dependency precedent already exists and is inconsistently applied: `avro4s-core` is
+correctly declared as a non-inherited dependency and documented as something consumers add themselves,
+while the Confluent artifacts serving the same optional Avro capability are inherited.
+
+### Why the Avro artifacts cannot simply be made optional
+
+Every simulation reaches the plugin through a single DSL entry point that transitively mixes in the
+serde surface. That surface eagerly constructs an Avro serde at initialisation and exposes
+Schema-Registry types in published Java signatures. Four sites in `src/main` carry the coupling:
+
+- `request/KafkaSerdesImplicits.scala` — an eagerly initialised Avro serde value, a Schema Registry
+  backed serde factory, and the two unused Kafka Streams implicits, all on the trait mixed into the
+  default Scala DSL import.
+- `javaapi/checks/KafkaChecks.scala` — a second eagerly initialised Avro serde value.
+- `javaapi/KafkaDsl.java` — public entry points whose parameter and return types are Schema Registry
+  and Avro types.
+- `javaapi/expressions/Builders.java` — a public constructor taking a Schema Registry client.
+
+Consequently a consumer without the Avro artifacts today fails when the DSL is loaded, not only when an
+Avro feature is used. Making the artifacts optional without addressing this would convert a
+resolution-time failure into a load-time failure — no better for the consumer.
+
+### Unused Kafka Streams surface
+
+Two implicits (`sessionWindowedSerde`, `consumedFromSerde`) have had no caller in sources, tests, or
+documentation since the initial commit. They belong to Kafka Streams — a different product with no role
+in a load test — and they are the only reason the Kafka Streams artifact is an inherited dependency.
+They also leak Streams types into the implicit scope of every simulation that imports the DSL. A
+hand-maintained exclusion on the Avro serde artifact exists solely to manage the resulting collision.
+Separately, one build dependency declaration (`avro-compiler`) is defined but never added to the build,
+and two Kafka Streams imports in an example simulation are unused.
+
+---
+
+## Clarifications
+
+### Session 2026-08-09
+
+- **Q: The mandatory Kafka client is also Confluent-only — issue #185 did not cover it. Relocate it, or
+  push it onto consumers to declare?**
+  → **A: Relocate.** Move to the Apache-released coordinates present on Maven Central and keep the
+  client inherited, so a consumer still gets a working plugin by declaring the plugin alone. Accepts a
+  visible change to the client version line, which the documented compatibility statement must track.
+  Rejected: making it non-inherited like the Gatling core artifacts, which would force every consumer —
+  including plain-serialization users — to edit their build in order to upgrade. Recorded as FR-018.
+
+- **Q: Milestone 10 calls for shedding the Kafka Streams artifact in v1.3.0, but Constitution Principle
+  I requires the two published implicits holding it to keep compiling for at least one more minor, and
+  they cannot compile without it. Which wins?**
+  → **A: The constitution wins.** Deprecate both implicits in this release naming their removal
+  release; keep the artifact inherited and make it Central-resolvable under FR-018's relocation; shed
+  the artifact when the implicits are removed. Rejected: shedding now, which risks breaking compilation
+  for *every* consumer — the implicits sit on the trait mixed into the default DSL entry point, so
+  implicit search reads their signatures whether or not a consumer uses them. Also rejected: removing
+  them immediately as a major release, which promotes a packaging fix into a major version bump.
+  Recorded as FR-019. The milestone's "shedding" in this release is therefore the deprecation and the
+  dead-declaration cleanup, not the artifact removal.
+
+- **Q: Making the Confluent Avro artifacts optional converts a resolution failure into a load failure
+  unless the Avro surface is separated from the default DSL entry point. Is a source change acceptable
+  for Avro consumers?**
+  → **A: Yes, one import.** Avro and Schema Registry entry points move behind a dedicated opt-in entry
+  point, with the current locations deprecated in place for at least this release and the one-line
+  change stated in the migration guide. Rejected: keeping everything reachable from the current import
+  by making the Confluent references inert, which is hard to prove and fails as a runtime
+  `NoClassDefFoundError` mid-load-test if one eager reference is missed — and may not be achievable at
+  all for the Java entry points that name Schema Registry types in their signatures. Recorded as
+  FR-020.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A new consumer can install and run the plugin (Priority: P1)
+
+A performance engineer adds the plugin to a project that resolves artifacts from the default public
+repository only, copies the minimal produce example from the README, and runs it against a broker. They
+do not use Avro, do not run a Schema Registry, and have not been told about any additional repository.
+
+**Why this priority**: This is the S1 defect. Until it is fixed, the documented installation path
+produces a hard build failure for every new consumer, and no other capability of the plugin is
+reachable. Fixing this alone restores the product.
+
+**Independent Test**: From a scratch project on each supported build tool, configured with the default
+public repository and nothing else, declare only the plugin, then compile and execute a plain
+produce simulation and a plain request-reply simulation against a broker. No manual repository
+configuration and no additional dependency declarations are permitted for this scenario to pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scratch sbt project whose only declared dependency is the plugin and whose only
+   configured repository is the default public one, **When** the build resolves dependencies,
+   **Then** resolution succeeds with no unresolved-dependency error.
+2. **Given** the same project, **When** a plain-serialization produce simulation is compiled,
+   **Then** compilation succeeds with no missing-class or missing-dependency error arising from the
+   plugin's own classpath.
+3. **Given** the same project and a running broker, **When** the produce simulation is executed,
+   **Then** it completes and reports successful requests, with no class-loading failure attributable
+   to an absent Avro or Schema Registry artifact.
+4. **Given** the same project, **When** a plain-serialization request-reply simulation is compiled and
+   executed against a broker, **Then** replies are correlated and checks report successfully.
+5. **Given** equivalent scratch projects for the Gradle and Maven installation instructions, **When**
+   each resolves and compiles the equivalent minimal simulation, **Then** both succeed under the same
+   constraints.
+
+---
+
+### User Story 2 - An Avro / Schema Registry consumer has a documented, working path (Priority: P2)
+
+A performance engineer needs Avro payloads validated against a Schema Registry. They read the
+installation documentation, add the artifacts and the repository it names, and run their existing Avro
+simulation.
+
+**Why this priority**: Avro support is a headline capability of the plugin and the reason the Confluent
+artifacts are present at all. Making them optional is only acceptable if the opt-in path is documented
+precisely enough to follow once, without trial and error. This story is what keeps the P1 fix from
+being a capability regression.
+
+**Independent Test**: From a scratch project configured with the default public repository plus exactly
+the repository named in the documentation, declare the plugin plus exactly the optional artifacts named
+in the documentation, then compile and execute an Avro produce simulation and an Avro-body check
+against a broker and Schema Registry. Passing requires that no coordinate or repository outside the
+documentation was needed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the installation documentation, **When** a consumer looks for Avro setup instructions,
+   **Then** they find the exact coordinates and the exact repository URL required, expressed for each
+   of the three documented build tools.
+2. **Given** a project following those instructions, **When** an Avro produce simulation using
+   automatic schema derivation is compiled and executed, **Then** it succeeds.
+3. **Given** a project following those instructions, **When** an Avro body check against a
+   Schema-Registry-backed record is compiled and executed, **Then** the check materialises and
+   evaluates successfully.
+4. **Given** a project following those instructions on the Java facade, **When** the Avro entry points
+   are used from Java or Kotlin, **Then** they compile and execute successfully.
+5. **Given** a consumer who does **not** follow the Avro instructions, **When** they use only plain
+   serialization, **Then** nothing in their build or run requires an Avro artifact.
+
+---
+
+### User Story 3 - An upgrading consumer is told exactly what changed (Priority: P2)
+
+A team on a 1.2.x release upgrades to this release. Their build previously inherited artifacts it will
+now have to declare, and their code may touch entry points that are being retired.
+
+**Why this priority**: The change deliberately removes artifacts from what consumers inherit. Without a
+migration entry, an upgrade turns a working suite into an unresolved-dependency or missing-class
+failure, and the fix is not discoverable from the error. This is equal in priority to Story 2 because a
+silent break for existing users is as damaging as an undocumented path for new ones.
+
+**Independent Test**: Take an existing simulation suite written against the previous release, upgrade
+only the plugin version, and apply exactly the steps listed in the migration guide. The suite must
+compile and run without any further change.
+
+**Acceptance Scenarios**:
+
+1. **Given** a suite using only plain serialization on the previous release, **When** only the plugin
+   version is upgraded, **Then** it compiles and runs with no change to build files or sources.
+2. **Given** a suite using Avro or Schema Registry on the previous release, **When** the plugin version
+   is upgraded and only the migration guide's listed steps are applied, **Then** it compiles and runs.
+3. **Given** the migration guide, **When** an upgrading consumer reads it, **Then** it states which
+   artifacts are no longer inherited, what to add, and which repository to configure.
+4. **Given** a suite that references a retired entry point, **When** it is compiled against this
+   release, **Then** it still compiles and the build reports a deprecation naming both the replacement
+   or rationale and the release in which removal will occur.
+
+---
+
+### User Story 4 - Every inherited dependency is justified, and dead weight is marked for removal (Priority: P3)
+
+A consumer inspects the plugin's dependency tree, or an auditor reviews what a load test drags onto its
+classpath. Everything inherited is either something the plugin executes, or something explicitly
+recorded as retained only until a named release.
+
+**Why this priority**: This is hygiene rather than a defect — nothing is broken for a consumer today by
+the unused surface alone. It is bundled here because the same artifacts are implicated in the P1 fix,
+and resolving both at once avoids touching the dependency set twice in two releases.
+
+**Independent Test**: Enumerate the plugin's inherited dependencies and, for each, name either a code
+path in the plugin that requires it or the deprecation it is retained for. Any dependency with neither
+fails this story. Independently, confirm no source or build file references a declaration that the
+build never applies.
+
+**Acceptance Scenarios**:
+
+1. **Given** the plugin's published dependency set, **When** each inherited artifact is traced,
+   **Then** every artifact resolves either to a plugin code path that uses it or to a recorded
+   deprecation that names the release in which the artifact goes away.
+2. **Given** the two unused Kafka Streams implicits, **When** the sources are inspected, **Then** each
+   is marked deprecated with a stated removal release, states that the plugin itself does not use it,
+   and no plugin code path calls either.
+3. **Given** the build definition, **When** it is inspected for dependency declarations, **Then** no
+   declaration exists that the build never applies.
+4. **Given** the example simulations, **When** they are compiled under the project's warnings-as-errors
+   settings, **Then** no unused import of a Kafka Streams type remains.
+5. **Given** any exclusion rule that exists only to resolve a collision between artifacts this release
+   relocates or stops inheriting, **When** the relocation is complete, **Then** either the exclusion is
+   removed or the collision it still prevents is stated in the build definition.
+
+---
+
+### Edge Cases
+
+- **A consumer who already configured the Confluent repository and relied on inherited Avro artifacts.**
+  Their build resolves today; after this change the artifacts are no longer inherited and their build
+  breaks at resolution or compilation. This case must be covered by the migration guide, not discovered
+  at runtime.
+- **A consumer using the default Scala DSL import but no Avro.** The DSL entry point currently
+  initialises an Avro serde eagerly, so absence of the Avro artifact is a load-time failure rather than
+  a use-time one. Plain usage must not require the Avro artifact to be present at compile time or at
+  run time.
+- **A consumer using the Java or Kotlin facade.** Published Java entry points expose Schema Registry
+  types in their signatures. Whatever separation is chosen must keep the Java facade usable for plain
+  serialization without Schema Registry artifacts present, and must not silently drop published Java
+  entry points.
+- **Build tools that do not propagate non-inherited scopes into the configuration the tests run in.**
+  The Gradle Gatling configuration and Maven test scope treat optional scopes differently from sbt.
+  Instructions must be verified per build tool rather than translated by analogy.
+- **A consumer compiling with warnings treated as errors.** A newly added deprecation must not turn an
+  otherwise-clean consumer build red without warning; the migration guide must say the deprecation is
+  coming and name its removal release.
+- **A change to the Kafka client artifact's version line.** If the mandatory Kafka client dependency
+  moves from the Confluent rebuild to the Apache release, the version string consumers see changes even
+  though the code is equivalent. Any broker-compatibility expectation stated in documentation must
+  match what is actually shipped.
+- **Transitive arrival of a shed artifact.** A consumer may still receive an artifact transitively via
+  another dependency. Verification must assert on what the plugin *declares*, not merely on whether a
+  particular test project happens to resolve.
+- **A consumer of the retired Kafka Streams implicits.** They have no in-plugin replacement, because
+  the capability belongs to a different product. The deprecation must say so rather than name a
+  replacement that does not exist.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Resolvability
+
+- **FR-001**: Every dependency the published artifact declares in a scope that consumers inherit MUST be
+  resolvable from the default public artifact repository alone, with no additional repository
+  configured by the consumer.
+- **FR-002**: The published artifact MUST NOT depend on a consumer configuring a repository that the
+  published metadata does not, and cannot, carry.
+- **FR-003**: Resolvability MUST be verified from a scratch consumer project for each documented
+  installation path — sbt, Gradle, and Maven — rather than inferred from the build definition.
+
+#### Plain-serialization usability
+
+- **FR-004**: A consumer using plain serialization MUST be able to compile and execute produce and
+  request-reply simulations with no Avro artifact, no Schema Registry artifact, and no Schema Registry
+  service present.
+- **FR-005**: Loading or importing the plugin's default DSL entry point MUST NOT require an Avro or
+  Schema Registry artifact to be present, at compile time or at run time.
+- **FR-006**: The Java and Kotlin facade MUST satisfy FR-004 and FR-005 on the same terms as the Scala
+  DSL.
+
+#### Optional Avro and Schema Registry support
+
+- **FR-007**: Avro and Schema Registry support MUST be declared in a scope consumers do not inherit,
+  consistent with the existing treatment of the Avro case-class support library.
+- **FR-008**: Installation documentation MUST state, for each of the three documented build tools, the
+  exact optional coordinates and the exact repository required to enable Avro and Schema Registry
+  support.
+- **FR-009**: With those artifacts and that repository added, every Avro and Schema Registry capability
+  available before this change MUST remain available and behave identically.
+
+#### Compatibility and migration
+
+- **FR-010**: Published Scala DSL and Java facade entry points MUST continue to compile. Any entry
+  point that must move or change MUST be handled under the project's deprecate-before-remove rule, with
+  the replacement named.
+- **FR-011**: A migration guide entry MUST state which artifacts are no longer inherited, what a
+  consumer must add to restore each capability, and which repository to configure.
+- **FR-012**: The example-simulation smoke validation MUST keep constructing every documented and
+  example simulation against the resulting API.
+- **FR-013**: If the shipped Kafka client version line changes, any documented compatibility statement
+  MUST be updated in the same change to match what is shipped.
+
+#### Shedding
+
+- **FR-014**: The two unused Kafka Streams implicits MUST be marked deprecated, each naming the release
+  in which it will be removed and stating that the plugin itself does not use it.
+- **FR-015**: Build dependency declarations that the build never applies MUST be removed.
+- **FR-016**: Unused imports of Kafka Streams types in example simulations MUST be removed.
+- **FR-017**: Any dependency exclusion that exists only to work around a collision between shed
+  artifacts MUST be removed once the collision no longer exists.
+
+#### Resolved scope decisions
+
+- **FR-018**: The mandatory Kafka client dependency MUST remain inherited by consumers and MUST be
+  sourced from coordinates published to the default public repository, replacing the vendor rebuild
+  currently pinned. A consumer therefore continues to acquire the Kafka client automatically by
+  declaring the plugin alone. The client version line consumers observe changes as a consequence, which
+  is what FR-013 governs.
+- **FR-019**: The Kafka Streams artifact MUST remain inherited in this release and MUST become
+  resolvable from the default public repository under FR-001, because the two deprecated implicits are
+  published API and cannot compile without it. Shedding the artifact itself is deferred to the release
+  in which those implicits are removed. Consumers MUST NOT be required to declare it, and MUST NOT
+  experience any compilation or runtime change from this decision.
+- **FR-020**: Avro and Schema Registry entry points MUST be reachable through a dedicated opt-in entry
+  point that a consumer imports deliberately, so that the default DSL entry point carries no reference
+  to an Avro or Schema Registry type. The entry points at their current locations MUST keep compiling
+  for at least this release under FR-010, each deprecated with its new location named, and the
+  migration guide MUST state the one-line change an Avro consumer makes.
+
+### Key Entities
+
+- **Inherited dependency set**: what a consumer's build acquires automatically by declaring the plugin.
+  Today it includes four artifacts unavailable from the default public repository. Its correctness is
+  the whole of Story 1.
+- **Opt-in dependency set**: artifacts a consumer declares deliberately to enable an optional
+  capability, together with any repository required to fetch them. Today it holds the Avro case-class
+  library; it must grow to hold Avro serialization and Schema Registry support.
+- **Plain-serialization surface**: the entry points reachable and executable with only the inherited
+  dependency set. Must be self-sufficient.
+- **Avro / Schema Registry surface**: the entry points requiring the opt-in set — Avro serdes, the
+  Schema-Registry-backed serde factory, Avro body checks, and the Java Avro entry points. Must be
+  inert, not merely unused, when the opt-in set is absent.
+- **Deprecated Kafka Streams surface**: two implicits with no caller, exposing types from a product the
+  plugin does not use, and the sole reason the Kafka Streams artifact is inherited.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The number of dependencies a consumer inherits that cannot be fetched from the default
+  public artifact repository is **zero**, down from four in the current release.
+- **SC-002**: A consumer starting from an empty project and following only the installation
+  documentation reaches a first successful message send **without configuring any repository** and
+  without consulting any source outside that documentation.
+- **SC-003**: All three documented installation paths — sbt, Gradle, Maven — resolve, compile, and
+  execute a plain simulation from a scratch project, verified independently rather than by analogy from
+  one to the others.
+- **SC-004**: A consumer enabling Avro and Schema Registry support succeeds by adding **only** the
+  coordinates and the repository named in the documentation, with **no source change** beyond what the
+  migration guide states.
+- **SC-005**: Every Avro and Schema Registry capability available in the previous release remains
+  available after opting in, with unchanged behavior.
+- **SC-006**: An existing plain-serialization suite upgrades with **zero** changes to its build files
+  and sources.
+- **SC-007**: Every inherited dependency traces to a plugin code path that uses it, with **exactly one**
+  recorded exception — the Kafka Streams artifact, retained solely to keep the deprecated implicits
+  compiling until their named removal release. The count of untraceable, unrecorded inherited
+  dependencies is **zero**.
+- **SC-008**: Every entry point retired by this change still compiles and reports a deprecation naming
+  its removal release; the count of published entry points removed without a deprecation period is
+  **zero**.
+- **SC-009**: The example-simulation smoke validation and the full test suite pass unchanged, with no
+  test relaxed or disabled to accommodate the dependency change.
+
+---
+
+## Assumptions
+
+- **The default public artifact repository is Maven Central.** It is the only repository configured by
+  default in sbt, Gradle, and Maven, and is what "a consumer following the README" implies.
+- **"Not inherited" follows the pattern already established in this build** by the Gatling core and Avro
+  case-class dependencies, which consumers declare themselves. This specification states the outcome —
+  the consumer does not acquire the artifact automatically — and leaves the mechanism to planning.
+- **Confluent's Avro serialization and Schema Registry artifacts have no Maven Central equivalent.**
+  Verified on 2026-08-09 at both the published (`7.9.8`) and current (`7.9.9`) versions: absent from
+  Maven Central, present in the Confluent repository. Therefore the only way to satisfy FR-001 for them
+  is to stop inheriting them; relocation is not an option.
+- **The mandatory Kafka client artifact does have a Maven Central equivalent.** Verified on 2026-08-09:
+  the Confluent `-ce` and `-ccs` rebuilds are absent from Maven Central at every version checked
+  (`7.9.2-ccs`, `7.9.5-ce`, `7.9.5-ccs`, `7.9.8-ce`, `7.9.8-ccs`, `7.9.9-ce`, `7.9.9-ccs`), while
+  Apache-released `kafka-clients` and `kafka-streams-scala` are present. FR-018 and FR-019 both depend
+  on this: the Kafka client and the Kafka Streams artifact can satisfy FR-001 by relocation, without
+  either being pushed onto the consumer to declare.
+- **The version numbers in this specification are a snapshot.** Dependency automation moves them
+  regularly. Every requirement here is written against the *property* — inherited versus opt-in,
+  Central-resolvable versus vendor-only — not against a version string, so a bump landing before
+  implementation changes the evidence but not the work.
+- **The Apache-released Kafka client is functionally equivalent to the vendor rebuild for this
+  plugin's purposes.** The rebuild carries the same upstream code under a vendor version scheme. If
+  planning finds a behavioral difference that matters to the plugin, that is a finding to raise, not an
+  assumption to work around silently.
+- **Consumers run the plugin in a test or load-test configuration**, not as a production runtime
+  dependency, so requiring a small number of explicit opt-in declarations is acceptable when documented.
+- **The three installation paths in the README — sbt, Gradle Kotlin DSL, and Maven — are the supported
+  set.** No other build tool is in scope for verification.
+- **A broker and a Schema Registry are available for verification**, via the project's existing
+  containerised test infrastructure and Compose stack.
+- **The current release line is 1.2.x and this work targets 1.3.0**, a minor release. Deprecations added
+  here name their removal in the next major release.
+- **The two unused Kafka Streams implicits have no consumers worth preserving compatibility for beyond
+  the project's standard deprecation window.** They have never had a caller in this repository, and the
+  capability they expose belongs to a different product.
+
+---
+
+## Out of Scope
+
+- Upgrading the Kafka, Avro, Gatling, or Schema Registry version lines for any reason other than
+  satisfying FR-001. Version currency is separate work.
+- Restructuring the Avro or Schema Registry feature set, changing how serdes are selected, or altering
+  check semantics. This work relocates and documents existing capability; it does not redesign it.
+- Removing the two deprecated Kafka Streams implicits, and removing the Kafka Streams artifact from the
+  inherited set. Per FR-019 both are deferred to the release named in the deprecation.
+- Removing the Avro and Schema Registry entry points from their current locations. Per FR-020 they are
+  deprecated in place this release and removed later.
+- Changing the publishing configuration's repository-stripping behavior, which is correct for a
+  Sonatype release and is not the defect.
+- Any change to request-reply correlation, tracker, or consumer behavior. Those are covered by prior
+  features.
+- Publishing a release. This feature ends when the change is merged and verified; tagging follows the
+  project's normal release process.
+
+---
+
+## Dependencies
+
+- Access to the published artifact metadata for the current release, to verify the declared dependency
+  set as consumers see it.
+- Scratch consumer projects for sbt, Gradle, and Maven, resolving from the default public repository
+  only, used as the acceptance harness for Stories 1 and 2.
+- The project's containerised broker and Schema Registry infrastructure, for executing the plain and
+  Avro simulations named in the acceptance scenarios.
+- A Maven Central Kafka client release compatible with the brokers the project tests against, since
+  FR-018 relocates the client artifact rather than pinning the vendor rebuild.

--- a/specs/005-classpath-dependency-shedding/tasks.md
+++ b/specs/005-classpath-dependency-shedding/tasks.md
@@ -39,12 +39,16 @@ Single-module Scala/sbt project:
 Principle V requires one tracked issue per semantic commit, and the story partition does not line up
 with it. Implement by story; **commit** by this table.
 
-| Commit | Issue | Tasks |
-| --- | --- | --- |
-| `docs(speckit): add 005-classpath-dependency-shedding spec/plan/tasks` | — | spec artifacts, lands first |
-| `fix(build): resolve every inherited dependency from Maven Central (#NEW)` | companion issue (T001) | T004–T009 |
-| `fix(build): make Confluent Avro support opt-in (#185)` | #185 | T010–T031 |
-| `refactor(request): deprecate the unused Kafka Streams surface (#214)` | #214 | T032–T038 |
+| Commit | Issue | Tasks | Branch |
+| --- | --- | --- | --- |
+| `docs(speckit): add 005-classpath-dependency-shedding spec/plan/tasks` | — | spec artifacts | `005-classpath-dependency-shedding` (PR #229) |
+| `fix(build): resolve every inherited dependency from Maven Central (#185)` | #185 | T004–T031 | `005-impl-classpath-shedding` |
+| `refactor(request): deprecate the unused Kafka Streams surface (#214)` | #214 | T032–T038 | `005-impl-classpath-shedding` |
+
+**Resolved 2026-08-09**: #185's scope was extended to cover all four coordinates rather than opening a
+companion issue, so the relocation and the opt-in change are one commit against one issue. The
+implementation lands on a branch stacked on the spec branch, as one PR carrying both semantic commits,
+leaving PR #229 spec-only.
 
 Each commit must be green on its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`.
 
@@ -54,9 +58,9 @@ Each commit must be green on its own under `sbt scalafmtCheckAll scalafmtSbtChec
 
 **Purpose**: Establish tracking and confirm the defect still reproduces before changing anything.
 
-- [ ] T001 Open a companion GitHub issue for the Kafka client relocation (or extend the scope of #185), assign it to milestone 10, and record its number in the Story → Commit Mapping table above and in the Issue Decomposition table in `specs/005-classpath-dependency-shedding/plan.md`
-- [ ] T002 [P] Confirm the baseline per [quickstart.md](./quickstart.md) Step 0: fetch the published `1.2.0` POM, verify four inherited dependencies and no `<repositories>` element
-- [ ] T003 [P] Re-probe the vendor coordinates currently declared in `project/Dependencies.scala` against Maven Central, using whatever versions dependency automation has landed since specification; a `200` on any `-ce`/`-ccs` coordinate is a new finding that invalidates R1 and must stop the work
+- [X] T001 Open a companion GitHub issue for the Kafka client relocation (or extend the scope of #185), assign it to milestone 10, and record the outcome in the Story → Commit Mapping table above (done: #185 extended to all four coordinates, no new issue opened)
+- [X] T002 [P] Confirm the baseline per [quickstart.md](./quickstart.md) Step 0: fetch the published `1.2.0` POM, verify four inherited dependencies and no `<repositories>` element
+- [X] T003 [P] Re-probe the vendor coordinates currently declared in `project/Dependencies.scala` against Maven Central, using whatever versions dependency automation has landed since specification; a `200` on any `-ce`/`-ccs` coordinate is a new finding that invalidates R1 and must stop the work
 
 ---
 
@@ -67,15 +71,31 @@ from plan.md. Nothing downstream produces trustworthy evidence until G1 closes.
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T004 Add a failing-first sbt check task in `build.sbt` asserting Contracts C1–C3 over `makePom` output: no inherited-scope dependency may match `io.confluent:*` or `org.apache.kafka:*` with a `-ce`/`-ccs` version suffix. Use an offline pattern deny-list, not a network probe, so a network failure cannot read as a pass. Confirm it **FAILS** naming all four coordinates
-- [ ] T005 Extend the same check in `build.sbt` with Contract C5: `groupId`, `artifactId`, `packaging`, `licenses`, `scm`, `developers`, `organization`, `url`, and the `provided`/`test` status of the Gatling and testing artifacts are unchanged
-- [ ] T006 Relocate `kafka-clients` and `kafka-streams-scala` from `7.9.9-ce` to Apache `3.9.2` in `project/Dependencies.scala`
-- [ ] T007 Close Gate G1: stop the Confluent client from evicting the Apache one via `dependencyOverrides` or an exclusion on the transitive `kafka-schema-registry-client` path, in `project/Dependencies.scala` / `build.sbt`
-- [ ] T008 Verify Gate G1 with `sbt -batch "clean; compile; Test/compile; evicted"` — pass requires exit 0 **and** no `org.apache.kafka:kafka-clients` conflict in the `evicted` report. Record the outcome in the Verification Gates table in `plan.md`
-- [ ] T009 Close Gate G2: compile a plain Java simulation and a plain Kotlin simulation against `target/scala-2.13/classes` with all `io.confluent` jars excluded from the classpath, exercising `KafkaDsl.avro(JExpression, Serializer, Deserializer)` so overload resolution is forced. Record the verdict in `research.md` R3 and in `plan.md`. **STOP and escalate to the maintainer if it fails** — the `SchemaRegistryClient`-typed overloads would have to move, which is a Java-source break with no deprecation window
+- [X] T004 Add a failing-first sbt check task in `build.sbt` asserting Contracts C1–C3 over `makePom` output: no inherited-scope dependency may match `io.confluent:*` or `org.apache.kafka:*` with a `-ce`/`-ccs` version suffix. Use an offline pattern deny-list, not a network probe, so a network failure cannot read as a pass. Confirm it **FAILS** naming all four coordinates
+- [X] T005 Extend the same check in `build.sbt` with Contract C5: `groupId`, `artifactId`, `packaging`, `licenses`, `scm`, `developers`, `organization`, `url`, and the `provided`/`test` status of the Gatling and testing artifacts are unchanged
+- [X] T006 Relocate `kafka-clients` and `kafka-streams-scala` from `7.9.9-ce` to Apache `3.9.2` in `project/Dependencies.scala`
+- [X] T007 Close Gate G1: stop the Confluent client from evicting the Apache one via `dependencyOverrides` or an exclusion on the transitive `kafka-schema-registry-client` path, in `project/Dependencies.scala` / `build.sbt`
+- [X] T008 Verify Gate G1 with `sbt -batch "clean; compile; Test/compile; evicted"` — pass requires exit 0 **and** no `org.apache.kafka:kafka-clients` conflict in the `evicted` report. Record the outcome in the Verification Gates table in `plan.md`
+- [X] T009 Close Gate G2: compile a plain Java simulation and a plain Kotlin simulation against `target/scala-2.13/classes` with all `io.confluent` jars excluded from the classpath, exercising `KafkaDsl.avro(JExpression, Serializer, Deserializer)` so overload resolution is forced. Record the verdict in `research.md` R3 and in `plan.md`. **STOP and escalate to the maintainer if it fails** — the `SchemaRegistryClient`-typed overloads would have to move, which is a Java-source break with no deprecation window
 
 **Checkpoint**: The build declares Central-resolvable Kafka coordinates, compiles and tests against the
 same client it ships, and the Java facade's constraint is known rather than assumed.
+
+**Phase 2 outcome (2026-08-09)**
+
+- **G1 CLOSED.** `dependencyOverrides` pins `kafka-clients`, `kafka-streams`, and `kafka-streams-scala`
+  to the declared Apache version. `sbt "clean; compile; Test/compile; evicted"` exits 0 with **zero**
+  `kafka-clients` conflicts; the only remaining conflict is the pre-existing, transitive-only
+  `slf4j-api`. The overrides do **not** appear in the published POM, so C5 is unaffected.
+- **G2 CLOSED FOR JAVA, UNVERIFIED FOR KOTLIN.** `javac` compiled a probe calling
+  `avro(JExpression, Serializer, Deserializer)` plus plain DSL usage against a 95-entry classpath with
+  all 7 `io.confluent` jars removed — exit 0. Overload resolution does **not** force loading
+  `SchemaRegistryClient`, so those two overloads can stay in place, deprecated. **The Kotlin half could
+  not be run**: `kotlinc` is not installed on this machine, and the build has no Kotlin plugin, so the
+  four simulations under `src/test/kotlin/` are compiled by nothing. There is no local signal either
+  way — see T045.
+- **POM violations: 8 → 6.** Both `org.apache.kafka` C1 violations are gone. The six remaining all
+  belong to the two `io.confluent` artifacts and are what Phase 3 clears.
 
 ---
 
@@ -92,24 +112,53 @@ compile, and execute a plain produce simulation and a plain request-reply simula
 
 > Write these first and confirm they FAIL before any implementation task in this phase.
 
-- [ ] T010 [P] [US1] Failing-first classloader spec in `src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala`: assert `org.galaxio.gatling.kafka.Predef` and `org.galaxio.gatling.kafka.javaapi.checks.KafkaChecks` both initialise under a classloader that refuses `io.confluent.*`. Must fail today with `NoClassDefFoundError: io/confluent/kafka/streams/serdes/avro/GenericAvroSerde`
-- [ ] T011 [P] [US1] Guard `src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala` against a vacuous pass: it must fail loudly if `GenericAvroSerde` *is* loadable through the restricted classloader, so a misconfigured harness reports itself instead of reporting success
+- [X] T010 [P] [US1] Failing-first classloader spec in `src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala`: assert `org.galaxio.gatling.kafka.Predef` and `org.galaxio.gatling.kafka.javaapi.checks.KafkaChecks` both initialise under a classloader that refuses `io.confluent.*`. Must fail today with `NoClassDefFoundError: io/confluent/kafka/streams/serdes/avro/GenericAvroSerde`
+- [X] T011 [P] [US1] Guard `src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala` against a vacuous pass: it must fail loudly if `GenericAvroSerde` *is* loadable through the restricted classloader, so a misconfigured harness reports itself instead of reporting success
 - [ ] T012 [P] [US1] Create the consumer-resolution harness in `scripts/consumer-resolution/` — minimal sbt, Gradle, and Maven fixture projects configured with Maven Central plus the local repository only, each declaring nothing but the plugin and containing the README's minimal produce simulation. Confirm all three **FAIL** to resolve today
 
 ### Implementation for User Story 1
 
-- [ ] T013 [US1] Create `src/main/scala/org/galaxio/gatling/kafka/confluent.scala` — an `object confluent` holding `avroSerde` and `serdeClass[T]`, mirroring the existing `object avro4s` in `src/main/scala/org/galaxio/gatling/kafka/avro4s.scala`. This becomes the only place in `src/main` that constructs a Confluent serde
-- [ ] T014 [US1] In `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala`, replace `implicit val avroSerde = new GenericAvroSerde()` with `implicit lazy val avroSerde: Serde[GenericRecord] = confluent.avroSerde`, and delegate `serdeClass[T]` the same way. `lazy` is required: without it, `Predef` initialisation would force `object confluent` to initialise and reconstruct the serde one hop later. Remove the now-unused `io.confluent` imports
-- [ ] T015 [US1] In `src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaChecks.scala`, replace `val avroSerde = new GenericAvroSerde()` with a lazy delegation to `confluent.avroSerde` and remove the `io.confluent` import
-- [ ] T016 [US1] Move `avroSerdes` and `avroSerializers` to `provided` scope in `project/Dependencies.scala`
-- [ ] T017 [US1] Verify T010–T011 in `src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala` now pass, and that no file reachable from `Predef` names a Confluent type in a signature or in bytecode (Contract E1)
-- [ ] T018 [US1] Verify the T004–T005 check in `build.sbt` now passes (Contracts C1–C3, C5)
+- [X] T013 [US1] Create `src/main/scala/org/galaxio/gatling/kafka/confluent.scala` — an `object confluent` holding `avroSerde` and `serdeClass[T]`, mirroring the existing `object avro4s` in `src/main/scala/org/galaxio/gatling/kafka/avro4s.scala`. This becomes the only place in `src/main` that constructs a Confluent serde
+- [X] T014 [US1] In `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala`, replace `implicit val avroSerde = new GenericAvroSerde()` with `implicit lazy val avroSerde: Serde[GenericRecord] = confluent.avroSerde`, and delegate `serdeClass[T]` the same way. `lazy` is required: without it, `Predef` initialisation would force `object confluent` to initialise and reconstruct the serde one hop later. Remove the now-unused `io.confluent` imports
+- [X] T015 [US1] In `src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaChecks.scala`, replace `val avroSerde = new GenericAvroSerde()` with a lazy delegation to `confluent.avroSerde` and remove the `io.confluent` import
+- [X] T016 [US1] Move `avroSerdes` and `avroSerializers` to `provided` scope in `project/Dependencies.scala`
+- [X] T017 [US1] Verify T010–T011 in `src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala` now pass, and that no file reachable from `Predef` names a Confluent type in a signature or in bytecode (Contract E1)
+- [X] T018 [US1] Verify the T004–T005 check in `build.sbt` now passes (Contracts C1–C3, C5)
 - [ ] T019 [US1] Verify T012: all three scratch projects resolve and compile. Then execute the plain produce and plain request-reply simulations from the sbt fixture against the `docker-compose.kafka.yml` broker, satisfying Contract E1 items 3 and 4
 - [ ] T020 [US1] Wire the harness into `.github/workflows/ci.yml` as a job that runs `sbt publishM2` and then all three fixture checks
-- [ ] T021 [US1] Update the Installation section of `README.md` with plain install snippets for sbt, Gradle, and Maven that require no additional repository
+- [X] T021 [US1] Update the Installation section of `README.md` with plain install snippets for sbt, Gradle, and Maven that require no additional repository
 
 **Checkpoint**: A Central-only consumer can install the plugin and run plain simulations. This is the
 MVP and closes the S1 defect.
+
+**Design change found during T013-T014 — FR-020 / Contracts E2 and E3 are superseded.**
+
+The approved design moved the Avro members behind an opt-in import, deprecated in place. Implementing
+it showed that shipping the *implicits* in two places breaks any consumer who follows the migration
+note. Proven with `scalac` 2.13.18 against the built classes:
+
+| Imports in scope | Result |
+| --- | --- |
+| `Predef._` only | compiles |
+| opt-in object only | compiles |
+| **both** | **fails** — `could not find implicit value for parameter e: Serde[GenericRecord]` |
+
+Every simulation already imports `Predef._`, so "add this import" would have turned a working Avro
+suite red, with an error message that says the implicit is *missing* when the real cause is two
+candidates cancelling out. That is a worse migration than the one it was meant to enable.
+
+**What shipped instead**: `ConfluentSerdes` (`src/main/scala/.../request/ConfluentSerdes.scala`) is a
+non-implicit holder — the only place in `src/main` that constructs a Confluent type. The implicits stay
+on `KafkaSerdesImplicits`, `lazy` and delegating, so `Predef` holds no Confluent reference in a
+signature or in bytecode, and implicit resolution is unchanged for consumers.
+
+Consequences, all in the consumer's favour:
+
+- Avro consumers change **no source at all** — only their build file, to declare the two artifacts.
+- Nothing is deprecated, so T023 and T024 are moot: there is no replaced entry point to annotate and
+  nothing to migrate off.
+- The Gate G2 verdict still matters and still holds: the `SchemaRegistryClient`-typed Java overloads
+  stay exactly where they are.
 
 ---
 
@@ -128,9 +177,9 @@ an Avro produce simulation and an Avro body check against the broker and Schema 
 
 ### Implementation for User Story 2
 
-- [ ] T023 [US2] Move every in-project use of the deprecated Avro members to `import org.galaxio.gatling.kafka.confluent._` across `src/test/scala/`, `src/test/java/`, and `src/test/kotlin/`. Required by `-Xfatal-warnings`, and it makes the examples demonstrate the documented consumer path
-- [ ] T024 [US2] Apply the Gate G2 verdict to the Java facade in `src/main/java/org/galaxio/gatling/kafka/javaapi/KafkaDsl.java` and `src/main/java/org/galaxio/gatling/kafka/javaapi/expressions/Builders.java`: if G2 passed, annotate the `SchemaRegistryClient`-typed entry points `@Deprecated` naming their opt-in replacement and leave them in place; if G2 failed, do not proceed without the maintainer decision from T009
-- [ ] T025 [US2] Document the Avro opt-in path in the Avro Support section of `README.md`: exact coordinates, the exact Confluent repository URL, the broker exclusion, and the opt-in import — expressed for sbt, Gradle, and Maven (FR-008)
+- [~] T023 [US2] **MOOT** — nothing was deprecated, so there is nothing to move. Originally: move every in-project use of the deprecated Avro members to `import org.galaxio.gatling.kafka.confluent._` across `src/test/scala/`, `src/test/java/`, and `src/test/kotlin/`. Required by `-Xfatal-warnings`, and it makes the examples demonstrate the documented consumer path
+- [~] T024 [US2] **MOOT** — G2 passed and no Java entry point moves, so there is no replacement to name in a `@Deprecated`. Originally: apply the Gate G2 verdict to the Java facade in `src/main/java/org/galaxio/gatling/kafka/javaapi/KafkaDsl.java` and `src/main/java/org/galaxio/gatling/kafka/javaapi/expressions/Builders.java`: if G2 passed, annotate the `SchemaRegistryClient`-typed entry points `@Deprecated` naming their opt-in replacement and leave them in place; if G2 failed, do not proceed without the maintainer decision from T009
+- [X] T025 [US2] Document the Avro opt-in path in the Avro Support section of `README.md`: exact coordinates, the exact Confluent repository URL, the broker exclusion, and the opt-in import — expressed for sbt, Gradle, and Maven (FR-008)
 - [ ] T026 [US2] Verify the Avro fixture in `scripts/consumer-resolution/` (T022) passes, and that every Avro and Schema Registry capability available before this change behaves identically (FR-009), including the Java and Kotlin Avro entry points
 
 **Checkpoint**: The opt-in Avro path works end to end and is fully documented.
@@ -152,8 +201,8 @@ migration guide's steps, and build.
 
 ### Implementation for User Story 3
 
-- [ ] T029 [US3] Add a Migration Guide entry to `README.md` stating which artifacts are no longer inherited, exactly what to add to restore each capability, which repository to configure, and the one-line import change for Schema Registry Avro users
-- [ ] T030 [US3] Add a Kafka client column to the Compatibility table in `README.md` reflecting the relocated version line (FR-013)
+- [X] T029 [US3] Add a Migration Guide entry to `README.md` stating which artifacts are no longer inherited, exactly what to add to restore each capability, which repository to configure, and the one-line import change for Schema Registry Avro users
+- [X] T030 [US3] Add a Kafka client column to the Compatibility table in `README.md` reflecting the relocated version line (FR-013)
 - [ ] T031 [US3] Verify every deprecation in `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala` and `src/main/java/org/galaxio/gatling/kafka/javaapi/KafkaDsl.java` names both its replacement (or, for the Kafka Streams implicits, the absence of one) and its removal release, and that a consumer compiling with warnings-as-errors is forewarned by the migration entry
 
 **Checkpoint**: Upgrading is mechanical and documented for every consumer population.
@@ -170,28 +219,37 @@ a recorded deprecation. Confirm no build declaration exists that the build never
 
 ### Tests for User Story 4 (MANDATORY — Principle IV) ⚠️
 
-- [ ] T032 [P] [US4] Extend the `build.sbt` check with Contract C3 and data-model rule DR-4: every inherited dependency traces to a code path or a recorded deprecation, and **at most one** may be justified by deprecation. Confirm it fails before T033–T035 land
+- [X] T032 [P] [US4] Extend the `build.sbt` check with Contract C3 and data-model rule DR-4: every inherited dependency traces to a code path or a recorded deprecation, and **at most one** may be justified by deprecation. Confirm it fails before T033–T035 land
 
 ### Implementation for User Story 4
 
-- [ ] T033 [P] [US4] Annotate `sessionWindowedSerde` and `consumedFromSerde` in `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala` as `@deprecated(..., "1.3.0")`, each stating that the plugin does not use it and that Kafka Streams users should depend on the artifact directly. Do **not** name a replacement — none exists, and inventing one would imply a capability this plugin does not offer
-- [ ] T034 [P] [US4] Remove the `avroCompiler` declaration from `project/Dependencies.scala` — the build never adds it to `libraryDependencies`, yet dependency automation has been maintaining it (FR-015)
-- [ ] T035 [P] [US4] Remove the unused Kafka Streams imports at `src/test/scala/org/galaxio/gatling/kafka/examples/BasicSimulation.scala:11-12` (FR-016)
-- [ ] T036 [US4] Review the `.exclude("org.apache.kafka", "kafka-streams-scala")` on `avroSerdes` in `project/Dependencies.scala` (FR-017): remove it if the relocation and scope change dissolved the collision, otherwise state in a comment which collision it still prevents
-- [ ] T037 [US4] Verify no plugin code path calls either implicit deprecated in `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala`, and that `kafka-streams-scala` remains inherited and Central-resolvable as the single recorded exception under DR-4
-- [ ] T038 [US4] Verify the Contract C3 / DR-4 check added to `build.sbt` in T032 passes
+- [X] T033 [P] [US4] Annotate `sessionWindowedSerde` and `consumedFromSerde` in `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala` as `@deprecated(..., "1.3.0")`, each stating that the plugin does not use it and that Kafka Streams users should depend on the artifact directly. Do **not** name a replacement — none exists, and inventing one would imply a capability this plugin does not offer
+- [X] T034 [P] [US4] Remove the `avroCompiler` declaration from `project/Dependencies.scala` — the build never adds it to `libraryDependencies`, yet dependency automation has been maintaining it (FR-015)
+- [X] T035 [P] [US4] Remove the unused Kafka Streams imports at `src/test/scala/org/galaxio/gatling/kafka/examples/BasicSimulation.scala:11-12` (FR-016)
+- [X] T036 [US4] Review the `.exclude("org.apache.kafka", "kafka-streams-scala")` on `avroSerdes` in `project/Dependencies.scala` (FR-017): remove it if the relocation and scope change dissolved the collision, otherwise state in a comment which collision it still prevents
+- [X] T037 [US4] Verify no plugin code path calls either implicit deprecated in `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala`, and that `kafka-streams-scala` remains inherited and Central-resolvable as the single recorded exception under DR-4
+- [X] T038 [US4] Verify the Contract C3 / DR-4 check added to `build.sbt` in T032 passes
 
 **Checkpoint**: The dependency set is justified end to end, with exactly one documented exception.
+
+**Phase 6 outcome (2026-08-09)**: both implicits deprecated naming 2.0.0 and stating the plugin does
+not use them; `avroCompiler` removed (declared but never applied, and dependency automation had been
+maintaining it); two unused Kafka Streams imports removed from `BasicSimulation.scala`. The
+hand-managed `kafka-streams-scala` exclusion on `avroSerdes` was **removed** — `dependencyOverrides`
+pins that coordinate build-wide, so it had nothing left to prevent, and `sbt evicted` now reports **no
+version conflicts at all** (previously two). Compiling clean under `-Xfatal-warnings` after adding the
+deprecations confirms T037: no plugin code path calls either implicit.
 
 ---
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T039 Run `sbt scalafmtAll scalafmtSbt`, then `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [X] T039 Run `sbt scalafmtAll scalafmtSbt`, then `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
 - [ ] T040 Run `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` (API-compat gate, Principle I)
 - [ ] T041 Run the full CI gate: `sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport`. Contract E5 and SC-009 require this to be green with **no** suite relaxed, skipped, retried, or disabled to accommodate the dependency change — a modified suite is a finding, not a pass
 - [ ] T042 [P] Walk [quickstart.md](./quickstart.md) Steps 0–8 end to end and confirm each "must fail before the fix" row actually did
-- [ ] T043 [P] Update the Verification Gates table in `plan.md` with the G1 and G2 outcomes, and the Complexity Tracking table if the G2 verdict changed the compatibility story
+- [X] T043 [P] Update the Verification Gates table in `plan.md` with the G1 and G2 outcomes, and the Complexity Tracking table if the G2 verdict changed the compatibility story
+- [ ] T045 [P] Record the Kotlin verification gap: `src/test/kotlin/` holds four simulations that no build step compiles (no Kotlin plugin in `project/plugins.sbt`), so Gate G2's Kotlin half has no local signal. Out of scope to fix here — raise it separately rather than silently treating Java's result as covering Kotlin
 - [ ] T044 Confirm the commits match the Story → Commit Mapping table in `specs/005-classpath-dependency-shedding/tasks.md`, each carrying milestone 10 and `Closes #NNN`, with no spec artifacts folded into an implementation commit (Principle V)
 
 ---

--- a/specs/005-classpath-dependency-shedding/tasks.md
+++ b/specs/005-classpath-dependency-shedding/tasks.md
@@ -1,0 +1,282 @@
+---
+
+description: "Task list for 005-classpath-dependency-shedding"
+---
+
+# Tasks: Classpath and Dependency Shedding
+
+**Input**: Design documents from `/specs/005-classpath-dependency-shedding/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md),
+[data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+**Tests**: Mandatory per Constitution Principle IV. This feature changes observable behavior — what a
+consumer's build resolves and whether the DSL loads without vendor artifacts — so every behavior task
+is preceded by a test written to fail first. Two tests fail against today's code for the exact reason
+this feature exists: the POM check (Contract C1) and the classpath-isolation spec (Contract E1). Per
+Principle II, the produce and request-reply verification runs against a real broker.
+
+**Organization**: Tasks are grouped by user story. Note that stories and *commits* are not the same
+partition — see the mapping below.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single-module Scala/sbt project:
+
+- **Scala plugin sources**: `src/main/scala/org/galaxio/gatling/kafka/`
+- **Java facade**: `src/main/java/org/galaxio/gatling/kafka/javaapi/`
+- **Tests**: `src/test/{scala,java,kotlin}/`
+- **Build/dependency truth**: `build.sbt`, `project/Dependencies.scala`
+
+## Story → Commit Mapping
+
+Principle V requires one tracked issue per semantic commit, and the story partition does not line up
+with it. Implement by story; **commit** by this table.
+
+| Commit | Issue | Tasks |
+| --- | --- | --- |
+| `docs(speckit): add 005-classpath-dependency-shedding spec/plan/tasks` | — | spec artifacts, lands first |
+| `fix(build): resolve every inherited dependency from Maven Central (#NEW)` | companion issue (T001) | T004–T009 |
+| `fix(build): make Confluent Avro support opt-in (#185)` | #185 | T010–T031 |
+| `refactor(request): deprecate the unused Kafka Streams surface (#214)` | #214 | T032–T038 |
+
+Each commit must be green on its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish tracking and confirm the defect still reproduces before changing anything.
+
+- [ ] T001 Open a companion GitHub issue for the Kafka client relocation (or extend the scope of #185), assign it to milestone 10, and record its number in the Story → Commit Mapping table above and in the Issue Decomposition table in `specs/005-classpath-dependency-shedding/plan.md`
+- [ ] T002 [P] Confirm the baseline per [quickstart.md](./quickstart.md) Step 0: fetch the published `1.2.0` POM, verify four inherited dependencies and no `<repositories>` element
+- [ ] T003 [P] Re-probe the vendor coordinates currently declared in `project/Dependencies.scala` against Maven Central, using whatever versions dependency automation has landed since specification; a `200` on any `-ce`/`-ccs` coordinate is a new finding that invalidates R1 and must stop the work
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The published-metadata gate, the coordinate relocation, and the two verification gates
+from plan.md. Nothing downstream produces trustworthy evidence until G1 closes.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T004 Add a failing-first sbt check task in `build.sbt` asserting Contracts C1–C3 over `makePom` output: no inherited-scope dependency may match `io.confluent:*` or `org.apache.kafka:*` with a `-ce`/`-ccs` version suffix. Use an offline pattern deny-list, not a network probe, so a network failure cannot read as a pass. Confirm it **FAILS** naming all four coordinates
+- [ ] T005 Extend the same check in `build.sbt` with Contract C5: `groupId`, `artifactId`, `packaging`, `licenses`, `scm`, `developers`, `organization`, `url`, and the `provided`/`test` status of the Gatling and testing artifacts are unchanged
+- [ ] T006 Relocate `kafka-clients` and `kafka-streams-scala` from `7.9.9-ce` to Apache `3.9.2` in `project/Dependencies.scala`
+- [ ] T007 Close Gate G1: stop the Confluent client from evicting the Apache one via `dependencyOverrides` or an exclusion on the transitive `kafka-schema-registry-client` path, in `project/Dependencies.scala` / `build.sbt`
+- [ ] T008 Verify Gate G1 with `sbt -batch "clean; compile; Test/compile; evicted"` — pass requires exit 0 **and** no `org.apache.kafka:kafka-clients` conflict in the `evicted` report. Record the outcome in the Verification Gates table in `plan.md`
+- [ ] T009 Close Gate G2: compile a plain Java simulation and a plain Kotlin simulation against `target/scala-2.13/classes` with all `io.confluent` jars excluded from the classpath, exercising `KafkaDsl.avro(JExpression, Serializer, Deserializer)` so overload resolution is forced. Record the verdict in `research.md` R3 and in `plan.md`. **STOP and escalate to the maintainer if it fails** — the `SchemaRegistryClient`-typed overloads would have to move, which is a Java-source break with no deprecation window
+
+**Checkpoint**: The build declares Central-resolvable Kafka coordinates, compiles and tests against the
+same client it ships, and the Java facade's constraint is known rather than assumed.
+
+---
+
+## Phase 3: User Story 1 - A new consumer can install and run the plugin (Priority: P1) 🎯 MVP
+
+**Goal**: A consumer whose build resolves from Maven Central only can declare the plugin and nothing
+else, then compile and run plain produce and request-reply simulations.
+
+**Independent Test**: From a scratch project on each of sbt, Gradle, and Maven — configured with Maven
+Central and the local repository only, no Confluent resolver — declare only the plugin, then resolve,
+compile, and execute a plain produce simulation and a plain request-reply simulation against a broker.
+
+### Tests for User Story 1 (MANDATORY — Principle IV) ⚠️
+
+> Write these first and confirm they FAIL before any implementation task in this phase.
+
+- [ ] T010 [P] [US1] Failing-first classloader spec in `src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala`: assert `org.galaxio.gatling.kafka.Predef` and `org.galaxio.gatling.kafka.javaapi.checks.KafkaChecks` both initialise under a classloader that refuses `io.confluent.*`. Must fail today with `NoClassDefFoundError: io/confluent/kafka/streams/serdes/avro/GenericAvroSerde`
+- [ ] T011 [P] [US1] Guard `src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala` against a vacuous pass: it must fail loudly if `GenericAvroSerde` *is* loadable through the restricted classloader, so a misconfigured harness reports itself instead of reporting success
+- [ ] T012 [P] [US1] Create the consumer-resolution harness in `scripts/consumer-resolution/` — minimal sbt, Gradle, and Maven fixture projects configured with Maven Central plus the local repository only, each declaring nothing but the plugin and containing the README's minimal produce simulation. Confirm all three **FAIL** to resolve today
+
+### Implementation for User Story 1
+
+- [ ] T013 [US1] Create `src/main/scala/org/galaxio/gatling/kafka/confluent.scala` — an `object confluent` holding `avroSerde` and `serdeClass[T]`, mirroring the existing `object avro4s` in `src/main/scala/org/galaxio/gatling/kafka/avro4s.scala`. This becomes the only place in `src/main` that constructs a Confluent serde
+- [ ] T014 [US1] In `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala`, replace `implicit val avroSerde = new GenericAvroSerde()` with `implicit lazy val avroSerde: Serde[GenericRecord] = confluent.avroSerde`, and delegate `serdeClass[T]` the same way. `lazy` is required: without it, `Predef` initialisation would force `object confluent` to initialise and reconstruct the serde one hop later. Remove the now-unused `io.confluent` imports
+- [ ] T015 [US1] In `src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaChecks.scala`, replace `val avroSerde = new GenericAvroSerde()` with a lazy delegation to `confluent.avroSerde` and remove the `io.confluent` import
+- [ ] T016 [US1] Move `avroSerdes` and `avroSerializers` to `provided` scope in `project/Dependencies.scala`
+- [ ] T017 [US1] Verify T010–T011 in `src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala` now pass, and that no file reachable from `Predef` names a Confluent type in a signature or in bytecode (Contract E1)
+- [ ] T018 [US1] Verify the T004–T005 check in `build.sbt` now passes (Contracts C1–C3, C5)
+- [ ] T019 [US1] Verify T012: all three scratch projects resolve and compile. Then execute the plain produce and plain request-reply simulations from the sbt fixture against the `docker-compose.kafka.yml` broker, satisfying Contract E1 items 3 and 4
+- [ ] T020 [US1] Wire the harness into `.github/workflows/ci.yml` as a job that runs `sbt publishM2` and then all three fixture checks
+- [ ] T021 [US1] Update the Installation section of `README.md` with plain install snippets for sbt, Gradle, and Maven that require no additional repository
+
+**Checkpoint**: A Central-only consumer can install the plugin and run plain simulations. This is the
+MVP and closes the S1 defect.
+
+---
+
+## Phase 4: User Story 2 - Avro / Schema Registry has a documented, working path (Priority: P2)
+
+**Goal**: A consumer needing Schema-Registry-backed Avro adds exactly what the documentation names and
+their simulation compiles and runs, with behavior identical to before.
+
+**Independent Test**: From a scratch project configured with Maven Central plus exactly the repository
+the README names, declaring the plugin plus exactly the coordinates the README names, compile and run
+an Avro produce simulation and an Avro body check against the broker and Schema Registry.
+
+### Tests for User Story 2 (MANDATORY — Principle IV) ⚠️
+
+- [ ] T022 [P] [US2] Add an Avro variant to `scripts/consumer-resolution/` — Confluent repository plus the two opt-in coordinates with the Kafka broker artifact excluded (R9) — compiling and running an Avro produce simulation and an Avro body check against the Compose stack. Confirm it fails before the opt-in entry point exists
+
+### Implementation for User Story 2
+
+- [ ] T023 [US2] Move every in-project use of the deprecated Avro members to `import org.galaxio.gatling.kafka.confluent._` across `src/test/scala/`, `src/test/java/`, and `src/test/kotlin/`. Required by `-Xfatal-warnings`, and it makes the examples demonstrate the documented consumer path
+- [ ] T024 [US2] Apply the Gate G2 verdict to the Java facade in `src/main/java/org/galaxio/gatling/kafka/javaapi/KafkaDsl.java` and `src/main/java/org/galaxio/gatling/kafka/javaapi/expressions/Builders.java`: if G2 passed, annotate the `SchemaRegistryClient`-typed entry points `@Deprecated` naming their opt-in replacement and leave them in place; if G2 failed, do not proceed without the maintainer decision from T009
+- [ ] T025 [US2] Document the Avro opt-in path in the Avro Support section of `README.md`: exact coordinates, the exact Confluent repository URL, the broker exclusion, and the opt-in import — expressed for sbt, Gradle, and Maven (FR-008)
+- [ ] T026 [US2] Verify the Avro fixture in `scripts/consumer-resolution/` (T022) passes, and that every Avro and Schema Registry capability available before this change behaves identically (FR-009), including the Java and Kotlin Avro entry points
+
+**Checkpoint**: The opt-in Avro path works end to end and is fully documented.
+
+---
+
+## Phase 5: User Story 3 - An upgrading consumer is told exactly what changed (Priority: P2)
+
+**Goal**: Existing suites upgrade with no surprises — plain suites need nothing, Avro suites need only
+the documented steps.
+
+**Independent Test**: Upgrade a 1.2.x suite by changing only the plugin version, apply exactly the
+migration guide's steps, and build.
+
+### Tests for User Story 3 (MANDATORY — Principle IV) ⚠️
+
+- [ ] T027 [P] [US3] Verify SC-006 per [quickstart.md](./quickstart.md) Step 8: a plain-serialization suite written against 1.2.x compiles and runs after changing only the plugin version, with zero edits to build files or sources
+- [ ] T028 [P] [US3] Verify a Schema Registry Avro suite written against 1.2.x compiles and runs after applying only the steps listed in the Migration Guide of `README.md`. Any change beyond those steps means FR-011 is unmet
+
+### Implementation for User Story 3
+
+- [ ] T029 [US3] Add a Migration Guide entry to `README.md` stating which artifacts are no longer inherited, exactly what to add to restore each capability, which repository to configure, and the one-line import change for Schema Registry Avro users
+- [ ] T030 [US3] Add a Kafka client column to the Compatibility table in `README.md` reflecting the relocated version line (FR-013)
+- [ ] T031 [US3] Verify every deprecation in `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala` and `src/main/java/org/galaxio/gatling/kafka/javaapi/KafkaDsl.java` names both its replacement (or, for the Kafka Streams implicits, the absence of one) and its removal release, and that a consumer compiling with warnings-as-errors is forewarned by the migration entry
+
+**Checkpoint**: Upgrading is mechanical and documented for every consumer population.
+
+---
+
+## Phase 6: User Story 4 - Every inherited dependency is justified (Priority: P3)
+
+**Goal**: Nothing is inherited without a reason, and the dead weight that remains is marked with a
+removal release.
+
+**Independent Test**: Enumerate the inherited dependencies; each must trace to a plugin code path or to
+a recorded deprecation. Confirm no build declaration exists that the build never applies.
+
+### Tests for User Story 4 (MANDATORY — Principle IV) ⚠️
+
+- [ ] T032 [P] [US4] Extend the `build.sbt` check with Contract C3 and data-model rule DR-4: every inherited dependency traces to a code path or a recorded deprecation, and **at most one** may be justified by deprecation. Confirm it fails before T033–T035 land
+
+### Implementation for User Story 4
+
+- [ ] T033 [P] [US4] Annotate `sessionWindowedSerde` and `consumedFromSerde` in `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala` as `@deprecated(..., "1.3.0")`, each stating that the plugin does not use it and that Kafka Streams users should depend on the artifact directly. Do **not** name a replacement — none exists, and inventing one would imply a capability this plugin does not offer
+- [ ] T034 [P] [US4] Remove the `avroCompiler` declaration from `project/Dependencies.scala` — the build never adds it to `libraryDependencies`, yet dependency automation has been maintaining it (FR-015)
+- [ ] T035 [P] [US4] Remove the unused Kafka Streams imports at `src/test/scala/org/galaxio/gatling/kafka/examples/BasicSimulation.scala:11-12` (FR-016)
+- [ ] T036 [US4] Review the `.exclude("org.apache.kafka", "kafka-streams-scala")` on `avroSerdes` in `project/Dependencies.scala` (FR-017): remove it if the relocation and scope change dissolved the collision, otherwise state in a comment which collision it still prevents
+- [ ] T037 [US4] Verify no plugin code path calls either implicit deprecated in `src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala`, and that `kafka-streams-scala` remains inherited and Central-resolvable as the single recorded exception under DR-4
+- [ ] T038 [US4] Verify the Contract C3 / DR-4 check added to `build.sbt` in T032 passes
+
+**Checkpoint**: The dependency set is justified end to end, with exactly one documented exception.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T039 Run `sbt scalafmtAll scalafmtSbt`, then `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [ ] T040 Run `sbt "Test / runMain org.galaxio.gatling.kafka.examples.ExampleSmokeValidation"` (API-compat gate, Principle I)
+- [ ] T041 Run the full CI gate: `sbt coverage "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaGatlingTest" "Gatling / testOnly org.galaxio.gatling.kafka.examples.KafkaJavaapiMethodsGatlingTest" test coverageOff coverageReport`. Contract E5 and SC-009 require this to be green with **no** suite relaxed, skipped, retried, or disabled to accommodate the dependency change — a modified suite is a finding, not a pass
+- [ ] T042 [P] Walk [quickstart.md](./quickstart.md) Steps 0–8 end to end and confirm each "must fail before the fix" row actually did
+- [ ] T043 [P] Update the Verification Gates table in `plan.md` with the G1 and G2 outcomes, and the Complexity Tracking table if the G2 verdict changed the compatibility story
+- [ ] T044 Confirm the commits match the Story → Commit Mapping table in `specs/005-classpath-dependency-shedding/tasks.md`, each carrying milestone 10 and `Closes #NNN`, with no spec artifacts folded into an implementation commit (Principle V)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies
+- **Foundational (Phase 2)**: depends on Setup — **BLOCKS all user stories**. T008 (G1) in particular gates the trustworthiness of every later test result; T009 (G2) gates the Java design in US2
+- **US1 (Phase 3)**: depends on Phase 2
+- **US2 (Phase 4)**: depends on US1 — the opt-in object created in T013 is what US2 documents and tests
+- **US3 (Phase 5)**: depends on US1 and US2 — the migration guide describes both halves
+- **US4 (Phase 6)**: depends on Phase 2 only; independent of US1–US3 and can run in parallel with them
+- **Polish (Phase 7)**: depends on all stories
+
+### Story Independence
+
+US4 is genuinely independent and could ship alone. US2 and US3 are not independent of US1 in this
+feature: US1 creates the opt-in entry point that US2 documents, and US3 documents the upgrade path
+across both. This is a deliberate departure from the usual one-story-per-slice rule — the stories
+partition the *outcome*, while the commits partition the *scope*, which is what the Story → Commit
+Mapping exists to reconcile.
+
+### Within Each Story
+
+Tests are written and confirmed failing before implementation (Principle IV). The only tasks exempt are
+the pure-mechanical ones in Phase 6 (T034, T035), which remove declarations and imports the build never
+uses — demonstrable as behavior-neutral by the existing suite passing unchanged.
+
+### Parallel Opportunities
+
+- T002, T003 in Setup
+- T010, T011, T012 — the three US1 test tasks, different files
+- T033, T034, T035 — different files, no ordering between them
+- T042, T043 in Polish
+- **Phase 6 (US4) can run in parallel with Phases 3–5** once Phase 2 completes, with one caveat: T036
+  touches `project/Dependencies.scala`, which T016 also edits — sequence those two
+
+---
+
+## Parallel Example: User Story 1 Tests
+
+```bash
+# Launch the three failing-first US1 test tasks together (different files):
+Task: "Classloader spec in src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala"
+Task: "Vacuous-pass guard for the same spec"
+Task: "Consumer-resolution fixtures in scripts/consumer-resolution/ for sbt, Gradle, Maven"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (User Story 1)
+
+1. Phase 1: Setup — open the companion issue, confirm the baseline
+2. Phase 2: Foundational — **critical**, and do not treat any later result as evidence until T008 passes
+3. Phase 3: US1
+4. **STOP and VALIDATE**: a Central-only consumer installs and runs plain simulations
+5. The S1 defect is closed at this point; everything after is completeness
+
+### Incremental Delivery
+
+1. Setup + Foundational → the build declares and resolves what it ships
+2. US1 → plain consumers work from Central alone (**MVP**)
+3. US2 → Avro consumers have a documented, working opt-in path
+4. US3 → upgrading is mechanical for every population
+5. US4 → dependency set fully justified
+
+### Sequencing Note
+
+The single highest-risk item is **T009 (Gate G2)**. It sits in Phase 2 deliberately: if the Java facade
+cannot compile without Schema Registry on the classpath, the `SchemaRegistryClient`-typed overloads
+must move, which is a Java-source break with no deprecation window and a possible change to the
+release's version number. Discovering that in Phase 4 would mean reworking US1's design decisions
+after they shipped.
+
+---
+
+## Notes
+
+- [P] = different files, no dependencies
+- Commit per tracked issue, not per task — see the Story → Commit Mapping
+- Verify tests fail before implementing; a test that passes before the fix is a broken test
+- Version strings in these tasks (`7.9.9-ce`, `3.9.2`) are a snapshot of `main` at `4516572`.
+  Dependency automation moves them; the tasks are written against dependency *properties*, so a bump
+  changes the numbers and nothing else

--- a/src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaChecks.scala
+++ b/src/main/java/org/galaxio/gatling/kafka/javaapi/checks/KafkaChecks.scala
@@ -1,7 +1,6 @@
 package org.galaxio.gatling.kafka.javaapi.checks
 
 import com.fasterxml.jackson.databind.JsonNode
-import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde
 import io.gatling.core.check._
 import io.gatling.core.check.bytes.BodyBytesCheckType
 import io.gatling.core.check.jmespath.JmesPathCheckType
@@ -23,7 +22,11 @@ import scala.jdk.CollectionConverters._
 object KafkaChecks {
   class SimpleChecksScala extends KafkaCheckSupport {}
 
-  val avroSerde: Serde[GenericRecord] = new GenericAvroSerde()
+  // Deferred for the same reason as KafkaSerdesImplicits.avroSerde: this object is reached by the Java
+  // facade's plain entry points too, so constructing a Confluent serde while it initialises would make
+  // the optional artifact mandatory for every Java simulation. Its own instance, as before — the Scala
+  // DSL and the Java facade have never shared one, and GenericAvroSerde carries mutable configure state.
+  val avroSerde: Serde[GenericRecord] = new org.galaxio.gatling.kafka.request.LazyGenericAvroSerde
 
   private def toScalaCheck(javaCheckBuilder: io.gatling.javaapi.core.CheckBuilder): KafkaCheck = {
     val scalaCheck = javaCheckBuilder.asScala

--- a/src/main/scala/org/galaxio/gatling/kafka/request/ConfluentSerdes.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/ConfluentSerdes.scala
@@ -1,0 +1,88 @@
+package org.galaxio.gatling.kafka.request
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import io.confluent.kafka.serializers.{KafkaAvroDeserializer, KafkaAvroSerializer}
+import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer}
+
+import java.util
+import scala.jdk.CollectionConverters._
+
+/** Every construction of a Confluent Schema Registry type in the Scala sources lives here.
+  *
+  * The `io.confluent` artifacts are not published to Maven Central and are therefore optional: consumers declare them alongside
+  * the Confluent resolver only if they want Schema-Registry-backed Avro. That is only workable if nothing on the path a *plain*
+  * simulation takes constructs one of these types, and `Predef` is on every simulation's path.
+  *
+  * `LazyGenericAvroSerde` is what lets the DSL keep handing out a `Serde[GenericRecord]` from a strict `val` — which the
+  * published trait ABI requires — without that val's construction touching Confluent.
+  *
+  * The Java facade still names Confluent types directly in `javaapi.KafkaDsl` and `javaapi.request.expressions.Builders`; those
+  * are public signatures under Principle I and cannot move. They are safe because the JVM resolves method descriptors lazily,
+  * and `PlainClasspathIsolationSpec` covers them.
+  *
+  * Contract E1 of `specs/005-classpath-dependency-shedding/contracts/dsl-entry-points.md`.
+  */
+object ConfluentSerdes {
+
+  /** A fresh serde for generic Avro records, resolving schemas through the Schema Registry client configured on the surrounding
+    * Kafka properties.
+    *
+    * A `def`, not a `val`: each caller gets its own instance, because `GenericAvroSerde` carries mutable `configure`/`close`
+    * state and the Scala DSL and the Java facade have always held separate ones.
+    */
+  def newAvroSerde(): Serde[GenericRecord] = new GenericAvroSerde()
+
+  /** Serde for a type whose schema is registered in the Schema Registry at `schemaRegUrl`.
+    *
+    * @param schemaRegUrl
+    *   comma-separated Schema Registry base URLs
+    */
+  def schemaRegistrySerde[T](schemaRegUrl: String): Serde[T] = new Serde[T] {
+    // One client per serde, not one per accessor call. `serializer()` and `deserializer()` are invoked per message
+    // (KafkaAction.serializeKey/serializeValue, AvroBodyCheckBuilder, KafkaMessagePreparer), so a `def` here handed every
+    // record a client whose schema cache was empty by construction — turning the "Cached" client into a Schema Registry
+    // round trip per record, inside the hot path of a load generator. CachedSchemaRegistryClient is thread-safe.
+    private lazy val client: CachedSchemaRegistryClient =
+      new CachedSchemaRegistryClient(schemaRegUrl.split(',').toList.asJava, 16)
+
+    override def serializer(): Serializer[T] =
+      new KafkaAvroSerializer(client).asInstanceOf[Serializer[T]]
+
+    override def deserializer(): Deserializer[T] =
+      new KafkaAvroDeserializer(client).asInstanceOf[Deserializer[T]]
+  }
+}
+
+/** A `Serde[GenericRecord]` that builds its Confluent-backed delegate on first use rather than on construction.
+  *
+  * This exists to satisfy two requirements that would otherwise conflict:
+  *
+  *   - Constitution Principle I: `KafkaSerdesImplicits.avroSerde` is a published concrete trait member. Turning it into a
+  *     `lazy val` deletes the mixin setter from the interface, so a simulation compiled against an earlier release keeps its
+  *     own field, never has it assigned, and silently observes `null` — with no linkage error to point at the cause. It must
+  *     stay a strict `val`.
+  *   - Contract E1: initialising `Predef` must not construct a Confluent type, or the optional artifacts become mandatory for
+  *     every simulation, Avro or not.
+  *
+  * Constructing one of these does neither: the constructor is empty and the only reference to `ConfluentSerdes` sits in a lazy
+  * initialiser the JVM resolves on first call.
+  */
+final class LazyGenericAvroSerde extends Serde[GenericRecord] {
+
+  @volatile private var constructed               = false
+  private lazy val delegate: Serde[GenericRecord] = {
+    constructed = true
+    ConfluentSerdes.newAvroSerde()
+  }
+
+  override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = delegate.configure(configs, isKey)
+
+  /** Closing a serde nobody used must not be the thing that drags Confluent onto the classpath. */
+  override def close(): Unit = if (constructed) delegate.close()
+
+  override def serializer(): Serializer[GenericRecord] = delegate.serializer()
+
+  override def deserializer(): Deserializer[GenericRecord] = delegate.deserializer()
+}

--- a/src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala
@@ -25,6 +25,17 @@ trait KafkaSerdesImplicits {
   implicit def javaIntegerSerde: Serde[java.lang.Integer]             = JSerdes.Integer()
   implicit def uuidSerde: Serde[UUID]                                 = JSerdes.UUID()
 
+  // No replacement is named on purpose: session windowing belongs to Kafka Streams, which this plugin
+  // neither uses nor wraps. Pointing at something inside the plugin would imply a capability that does
+  // not exist. These two implicits are also the sole reason kafka-streams-scala is still a dependency
+  // consumers inherit — they cannot be dropped before the implicits go, because their Kafka Streams
+  // types appear in the *signatures* that implicit search reads for every simulation.
+  @deprecated(
+    "Kafka Streams windowing has no role in a Gatling load test and this plugin never uses it. " +
+      "Depend on org.apache.kafka:kafka-streams-scala_2.13 directly if you build Streams topologies. " +
+      "Removed in 2.0.0 together with the kafka-streams-scala dependency.",
+    "1.3.0",
+  )
   implicit def sessionWindowedSerde[T](implicit tSerde: Serde[T]): WindowedSerdes.SessionWindowedSerde[T] =
     new WindowedSerdes.SessionWindowedSerde[T](tSerde)
 
@@ -44,6 +55,12 @@ trait KafkaSerdesImplicits {
 
   implicit val avroSerde: Serde[GenericRecord] = new LazyGenericAvroSerde
 
+  @deprecated(
+    "Consumed is a Kafka Streams topology parameter and this plugin never builds a topology. " +
+      "Depend on org.apache.kafka:kafka-streams-scala_2.13 directly if you build Streams topologies. " +
+      "Removed in 2.0.0 together with the kafka-streams-scala dependency.",
+    "1.3.0",
+  )
   implicit def consumedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Consumed[K, V] =
     Consumed.`with`[K, V]
 

--- a/src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala
+++ b/src/main/scala/org/galaxio/gatling/kafka/request/KafkaSerdesImplicits.scala
@@ -1,16 +1,12 @@
 package org.galaxio.gatling.kafka.request
 
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
-import io.confluent.kafka.serializers.{KafkaAvroDeserializer, KafkaAvroSerializer}
-import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde
 import org.apache.avro.generic.GenericRecord
-import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer, Serdes => JSerdes}
+import org.apache.kafka.common.serialization.{Serde, Serdes => JSerdes}
 import org.apache.kafka.streams.kstream.WindowedSerdes
 import org.apache.kafka.streams.scala.kstream.Consumed
 
 import java.nio.ByteBuffer
 import java.util.UUID
-import scala.jdk.CollectionConverters._
 
 trait KafkaSerdesImplicits {
   implicit def stringSerde: Serde[String]                             = JSerdes.String()
@@ -32,17 +28,21 @@ trait KafkaSerdesImplicits {
   implicit def sessionWindowedSerde[T](implicit tSerde: Serde[T]): WindowedSerdes.SessionWindowedSerde[T] =
     new WindowedSerdes.SessionWindowedSerde[T](tSerde)
 
-  implicit def serdeClass[T](implicit schemaRegUrl: String): Serde[T] = new Serde[T] {
-    override def serializer(): Serializer[T] = new KafkaAvroSerializer(
-      new CachedSchemaRegistryClient(schemaRegUrl.split(',').toList.asJava, 16),
-    ).asInstanceOf[Serializer[T]]
+  // The two Avro members below construct no Confluent type, so this trait — which `Predef` mixes in,
+  // and every simulation imports — holds no reference to one. Their declared types (`Serde`,
+  // `GenericRecord`) come from Maven Central-published artifacts, so implicit search over this trait
+  // works with no Confluent artifact present.
+  //
+  // `avroSerde` MUST stay a strict `val`. It is a published concrete trait member: making it `lazy`
+  // deletes the mixin setter from the compiled interface, so a simulation compiled against an earlier
+  // release keeps its own field, never has it assigned by `$init$`, and silently reads `null` — with no
+  // linkage error naming the cause. `LazyGenericAvroSerde` is what defers the Confluent construction
+  // instead, so the strict val and Contract E1 can both hold.
 
-    override def deserializer(): Deserializer[T] = new KafkaAvroDeserializer(
-      new CachedSchemaRegistryClient(schemaRegUrl.split(',').toList.asJava, 16),
-    ).asInstanceOf[Deserializer[T]]
-  }
+  implicit def serdeClass[T](implicit schemaRegUrl: String): Serde[T] =
+    ConfluentSerdes.schemaRegistrySerde[T](schemaRegUrl)
 
-  implicit val avroSerde: Serde[GenericRecord] = new GenericAvroSerde()
+  implicit val avroSerde: Serde[GenericRecord] = new LazyGenericAvroSerde
 
   implicit def consumedFromSerde[K, V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Consumed[K, V] =
     Consumed.`with`[K, V]

--- a/src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/classpath/PlainClasspathIsolationSpec.scala
@@ -1,0 +1,155 @@
+package org.galaxio.gatling.kafka.classpath
+
+/** Contract E1: the default DSL entry points must be usable with only the inherited dependency set.
+  *
+  * The Confluent Avro artifacts are optional and not inherited by consumers, but `Predef` is imported by every simulation —
+  * plain ones included. If anything reachable from an entry point *constructs* a Confluent type while that entry point
+  * initialises, then a consumer who never touches Avro still fails, and moving the artifacts out of the inherited set only
+  * trades a resolution-time error for a `NoClassDefFoundError` in the middle of a load test.
+  *
+  * This suite loads each entry point through a classloader that refuses `io.confluent.*` and forces static initialisation. It
+  * is deliberately a *unit* check: the end-to-end proof — plain produce and request-reply simulations running with the
+  * artifacts genuinely absent — is the consumer-resolution work still open as T012/T019/T020 in
+  * `specs/005-classpath-dependency-shedding/tasks.md`. Until that exists, this suite is the only enforcement of E1, which is
+  * why it carries the positive control below rather than trusting its own mechanism.
+  */
+final class PlainClasspathIsolationSpec extends munit.FunSuite {
+
+  private val ConfluentAvroSerde = "io.confluent.kafka.streams.serdes.avro.GenericAvroSerde"
+  private val PluginPrefix       = "org.galaxio.gatling.kafka."
+
+  /** Refuses every `io.confluent.*` class, and loads plugin classes itself so that *their* references resolve through this
+    * loader rather than through the parent. Everything else — Gatling, the Kafka client, the Scala library — is delegated, so
+    * the only variable under test is Confluent's presence.
+    */
+  private final class ConfluentDenyingClassLoader(parent: ClassLoader) extends ClassLoader(parent) {
+
+    private def defineFromParentResource(name: String): Option[Class[_]] = {
+      val resource = name.replace('.', '/') + ".class"
+      Option(parent.getResourceAsStream(resource)).map { in =>
+        try {
+          val bytes = in.readAllBytes()
+          defineClass(name, bytes, 0, bytes.length)
+        } finally in.close()
+      }
+    }
+
+    override protected def loadClass(name: String, resolve: Boolean): Class[_] = synchronized {
+      if (name.startsWith("io.confluent."))
+        throw new ClassNotFoundException(s"denied by $getClass: $name")
+
+      val own: Option[Class[_]] =
+        if (name.startsWith(PluginPrefix)) Option(findLoadedClass(name)).orElse(defineFromParentResource(name))
+        else None
+
+      own match {
+        case Some(loaded) =>
+          if (resolve) resolveClass(loaded)
+          loaded
+        case None         =>
+          super.loadClass(name, resolve)
+      }
+    }
+  }
+
+  private def denyingLoader: ClassLoader =
+    new ConfluentDenyingClassLoader(getClass.getClassLoader)
+
+  /** Loads and initialises `className`, and asserts the denying loader actually *defined* it.
+    *
+    * Without that second assertion the suite is worthless: `loadClass` falls back to `super.loadClass` whenever the class bytes
+    * are unreadable as a resource, which hands back the parent's copy — whose references resolve against the parent, where
+    * Confluent is present. Every assertion below would then pass with zero isolation.
+    */
+  private def initialiseUnderDenyingLoader(className: String, loader: ClassLoader): Class[_] = {
+    val loaded = Class.forName(className, true, loader)
+    assertEquals(
+      loaded.getClassLoader,
+      loader,
+      s"$className was loaded by the parent, so nothing in this test was actually isolated",
+    )
+    loaded
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Guards. Without these the suite could report success for the wrong reason.
+  // ---------------------------------------------------------------------------------------------
+
+  test("guard: the Confluent Avro serde IS on the test classpath") {
+    val loaded = Class.forName(ConfluentAvroSerde, false, getClass.getClassLoader)
+    assertEquals(
+      loaded.getName,
+      ConfluentAvroSerde,
+      "this suite is only meaningful when the artifact it hides is otherwise present",
+    )
+  }
+
+  test("guard: the denying classloader refuses a direct load") {
+    intercept[ClassNotFoundException] {
+      Class.forName(ConfluentAvroSerde, false, denyingLoader)
+    }: Unit
+  }
+
+  test("positive control: a plugin class that DOES construct a Confluent type fails under the denying loader") {
+    // The load-bearing guard. It proves the deny-list reaches references made *from child-defined plugin classes*, which is the
+    // mechanism every assertion below depends on. Initialising ConfluentSerdes$ alone is not enough — its <clinit> only assigns
+    // MODULE$; the construction lives in newAvroSerde(), so the call has to be forced.
+    val loader = denyingLoader
+    val cls    = initialiseUnderDenyingLoader("org.galaxio.gatling.kafka.request.ConfluentSerdes$", loader)
+    val module = cls.getField("MODULE$").get(null)
+    val thrown = intercept[java.lang.reflect.InvocationTargetException] {
+      cls.getMethod("newAvroSerde").invoke(module): Unit
+    }
+    assert(
+      thrown.getCause.isInstanceOf[NoClassDefFoundError],
+      s"expected NoClassDefFoundError from the denied Confluent construction, got ${thrown.getCause}",
+    )
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Contract E1 — every entry point a simulation reaches.
+  // ---------------------------------------------------------------------------------------------
+
+  test("the Scala DSL entry point initialises with no Confluent artifact present") {
+    initialiseUnderDenyingLoader("org.galaxio.gatling.kafka.Predef$", denyingLoader): Unit
+  }
+
+  test("the Java facade's DSL entry point initialises with no Confluent artifact present") {
+    // Named in every Java and Kotlin simulation as `import static ...KafkaDsl.*`, and it holds SchemaRegistryClient in three
+    // public signatures. Safe only as long as it has no Confluent-touching static state; this is what enforces that.
+    initialiseUnderDenyingLoader("org.galaxio.gatling.kafka.javaapi.KafkaDsl", denyingLoader): Unit
+  }
+
+  test("the Java facade's checks object initialises with no Confluent artifact present") {
+    initialiseUnderDenyingLoader("org.galaxio.gatling.kafka.javaapi.checks.KafkaChecks$", denyingLoader): Unit
+  }
+
+  test("the Java facade's Avro expression builder initialises with no Confluent artifact present") {
+    initialiseUnderDenyingLoader(
+      "org.galaxio.gatling.kafka.javaapi.request.expressions.Builders$AvroExpressionBuilder",
+      denyingLoader,
+    ): Unit
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // The mechanism that lets `avroSerde` stay a strict val (published trait ABI) without Confluent on
+  // the plain path. If this regressed, E1 would hold only by making avroSerde lazy — which silently
+  // returns null for consumers compiled against an earlier release.
+  // ---------------------------------------------------------------------------------------------
+
+  test("LazyGenericAvroSerde constructs and closes without touching Confluent, and fails only on use") {
+    val loader = denyingLoader
+    val cls    = initialiseUnderDenyingLoader("org.galaxio.gatling.kafka.request.LazyGenericAvroSerde", loader)
+
+    val serde = cls.getDeclaredConstructor().newInstance()
+    cls.getMethod("close").invoke(serde): Unit
+
+    val thrown = intercept[java.lang.reflect.InvocationTargetException] {
+      cls.getMethod("serializer").invoke(serde): Unit
+    }
+    assert(
+      thrown.getCause.isInstanceOf[NoClassDefFoundError],
+      s"expected the delegate construction to be deferred to first use, got ${thrown.getCause}",
+    )
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/kafka/examples/BasicSimulation.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/examples/BasicSimulation.scala
@@ -8,8 +8,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.common.header.internals.RecordHeaders
-import org.apache.kafka.streams.{KafkaStreams, KeyValue, StreamsBuilder, StreamsConfig}
-import org.apache.kafka.streams.kstream.KeyValueMapper
 import org.galaxio.gatling.kafka.Predef._
 import org.galaxio.gatling.kafka.protocol.KafkaProtocol
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage


### PR DESCRIPTION
Milestone [v1.3.0 Classpath and dependency shedding](https://github.com/galax-io/gatling-kafka-plugin/milestone/10). Everything for this feature: spec artifacts and implementation.

Three commits, spec first, then one per issue:

| Commit | Issue |
|---|---|
| `docs(speckit): add 005-classpath-dependency-shedding spec/plan/tasks` | — |
| `fix(build)!: resolve every inherited dependency from Maven Central` | Closes #185 |
| `refactor(request): deprecate the unused Kafka Streams surface` | Closes #214 |

Each of the two implementation commits is green on its own under `sbt scalafmtCheckAll scalafmtSbtCheck compile test` — verified separately, not just at the tip.

## The defect

The published POM declared four dependencies in a scope consumers inherit that are not on Maven Central, and carries no repository from which to fetch them (`pomIncludeRepository := { _ => false }` strips them, correctly, for a Sonatype release). A consumer following the README got an unresolved-dependency failure on their first build.

#185 originally named two artifacts; verification found four — `kafka-clients` and `kafka-streams-scala` were pinned to Confluent's `-ce` rebuild. The issue scope was extended rather than opening a companion issue, so one issue still maps to one commit.

Version automation had been masking it: the four coordinates advanced `7.9.5-ce`/`7.9.8` → `7.9.9-ce`/`7.9.9` during specification, staying equally unresolvable, because nothing asserted the property.

## What changed

**Relocated** `kafka-clients` and `kafka-streams-scala` to Apache `3.9.2`. The plugin uses only core Apache client API, so the vendor pin was accidental.

**Made the two `io.confluent` artifacts `provided`**, matching how `avro4s` was already handled. They have no Central equivalent at any version.

**Decoupled `Predef`.** It eagerly constructed a `GenericAvroSerde`, so every simulation needed Confluent whether or not it used Avro. The obvious fix — making `avroSerde` a `lazy val` — is a silent binary break: `javap` against the published jar shows the old interface declares an abstract mixin setter that `$init$` calls, and the lazy form has neither, so a simulation compiled against 1.2.x keeps its own field, never has it assigned, and reads `null` with no linkage error. `LazyGenericAvroSerde` defers the Confluent construction instead, so the member stays a strict `val` with a byte-identical ABI.

**Pinned the client version.** With the Apache coordinate declared, the build still resolved `7.9.9-ccs` via `kafka-schema-registry-client` and compiled against it. `sbt evicted` now reports no conflicts at all.

**Deprecated** the two unused Kafka Streams implicits (removal in 2.0.0, no replacement named — the capability belongs to Kafka Streams). Removed the `avroCompiler` declaration the build never applied, two unused imports, and a now-redundant exclusion.

## Consumer impact

- **Plain, avro4s, everything except Schema Registry Avro**: no change. Bump the version.
- **Schema Registry Avro**: add two artifacts and the Confluent resolver, excluding `kafka-clients` from both. **No source change** — imports and implicits are unchanged.

## Verification

- **`checkPublishedPom`** — new build gate over `makePom` output *and* the resolved Runtime graph, since consumers inherit the transitive closure. Failed before naming all four coordinates; now passes over 4 declared and 18 transitive dependencies. Written over coordinate *patterns*, not versions. Wired to `test` and to every publish task, so the release path is gated by the build rather than by step ordering in one workflow file.
- **`PlainClasspathIsolationSpec`** — loads `Predef`, both Java facade entry points that name `SchemaRegistryClient`, and the checks object through a classloader refusing `io.confluent.*`, asserting each was actually defined by that loader. Carries a positive control proving the deny-list reaches child-defined classes. Failed before with `NoClassDefFoundError`.
- **Full suite**: 14 suites, 74 tests, 0 failed — including all 7 Testcontainers integration specs against real brokers. The client relocation changes no observable behavior.
- **Gate G2**: `javac` compiles a plain Java simulation, including the `avro(JExpression, Serializer, Deserializer)` overload, against a classpath with all seven `io.confluent` jars removed.

A review pass found and fixed 15 issues in the first draft of this work, including the binary-compatibility break above, an Avro snippet that let Confluent's client evict the Apache one, a documented exclusion that matched no artifact, and a test that could not fail. Those fixes are folded into the commits they correct.

## Known gaps

- **Consumer-resolution fixtures** for sbt/Gradle/Maven and the CI job that runs them (T012/T019/T020/T022 in `tasks.md`) are not built. The POM gate and the classloader spec prove the property in-repo, but FR-003 asks for a scratch consumer per build tool resolving from Central alone.
- **Gate G2's Kotlin half** is unverified: `kotlinc` is not installed locally, and the build declares no Kotlin plugin at all — the four simulations in `src/test/kotlin/` are compiled by nothing and could have drifted unnoticed.
- The spec-artifact updates in the `fix(build)!` commit are implementation records (gate outcomes, task checkboxes) rather than spec changes, but they do sit inside an implementation commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
