### PR TITLE
chore(deps): bound Scala Steward to the Apache Kafka and CP 7 lines

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,17 @@
+# Scala Steward scans every resolver the build declares, and build.sbt declares the Confluent one
+# (packages.confluent.io) because the optional Avro path needs io.confluent artifacts. That resolver
+# also carries Confluent's rebuilds of org.apache.kafka:* under Confluent Platform version numbers
+# (8.3.1-ce, 8.3.1-ccs), which sort above the Apache line this project tracks (3.9.x). Left alone,
+# Steward reads those as upgrades and opens PRs that cannot merge:
+#
+#   #234  kafka-clients/kafka-streams -> 8.3.1-ce   does not resolve at all
+#   #235  kafka-streams-scala -> 8.3.1-ccs          fails checkPublishedPom contract C1
+#   #233  kafka-avro-serializer -> 8.3.1            fails to compile (needs kafka-clients 4.x)
+#
+# Pin the lines instead of ignoring the groups, so patch updates inside 3.x / 7.x still arrive.
+# Moving to Kafka 4.x / Confluent Platform 8.x is deliberate work (brokers in docker-compose and CI,
+# Apache vs -ce/-ccs coordinates, the deprecated Streams surface), not a dependency bump.
+updates.pin = [
+  { groupId = "org.apache.kafka", version = { prefix = "3." } },
+  { groupId = "io.confluent", version = { prefix = "7." } }
+]


### PR DESCRIPTION
## Problem

`build.sbt` declares the Confluent resolver (`packages.confluent.io`) so the optional Avro path can resolve `io.confluent` artifacts. Scala Steward scans every declared resolver, and that repository also serves Confluent's rebuilds of `org.apache.kafka:*` under Confluent Platform version numbers — `8.3.1-ce`, `8.3.1-ccs` — which sort above the Apache line this project tracks (`3.9.2`).

Steward reads that different versioning scheme as an upgrade and opens PRs that cannot merge. All three were red:

| PR | Proposal | Failure |
|----|----------|---------|
| #234 | `kafka-clients`, `kafka-streams` -> `8.3.1-ce` | does not resolve — `kafka-streams-scala_2.13:8.3.1-ce` is on neither Maven Central nor packages.confluent.io |
| #235 | `kafka-streams-scala` -> `8.3.1-ccs` | `checkPublishedPom` C1 — `-ccs` builds are vendor-only and the released POM carries no resolver |
| #233 | `kafka-avro-serializer`, `kafka-streams-avro-serde` -> `8.3.1` | compile error — SR 8.3.1 is built against Kafka 4.x and needs `org.apache.kafka.common.metrics.Monitorable` |

No `.scala-steward.conf` existed, so nothing bounded this and the same three PRs regenerated every week.

## Change

Add `.scala-steward.conf` pinning `org.apache.kafka` to the `3.` line and `io.confluent` to the `7.` line. Pinning rather than ignoring keeps patch updates inside those lines flowing (`3.9.2` -> `3.9.3` still gets a PR); only the jump into Confluent's version space is suppressed.

Moving to Kafka 4.x / Confluent Platform 8.x is deliberate work — brokers in `docker-compose.kafka.yml` and CI, Apache vs `-ce`/`-ccs` coordinates, the deprecated Streams surface from #214 — not a dependency bump.

#233, #234 and #235 are closed as part of this.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)