### PR TITLE
test(readiness): stop PositionedReadinessSpec failing at random

### DIFF
--- a/src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/kafka/integration/PositionedReadinessSpec.scala
@@ -10,7 +10,7 @@ import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySe
 import org.galaxio.gatling.kafka.client.{DynamicKafkaConsumer, KafkaSender}
 import org.galaxio.gatling.kafka.request.KafkaProtocolMessage
 
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
@@ -57,6 +57,11 @@ class PositionedReadinessSpec extends munit.FunSuite with TestContainerForAll wi
     * is both the start and the end, and a skipped record cannot be told from a delivered one.
     */
   private val WarmUpRecords = 50
+
+  /** How long delivery is given after readiness completes. Generous because it is only ever spent on a genuine failure: the
+    * correct implementation delivers within a poll interval, so a run that spends this budget has found something real.
+    */
+  private val DeliveryBudget = 30.seconds
 
   private def producerSettings(bootstrap: String): Map[String, AnyRef] = Map(
     ProducerConfig.ACKS_CONFIG                   -> "1",
@@ -114,14 +119,17 @@ class PositionedReadinessSpec extends munit.FunSuite with TestContainerForAll wi
       producerThread.setDaemon(true)
       producerThread.start()
 
+      // Both the "has anything arrived" signal and the sequence number the assertion reads, deliberately the same
+      // variable: its -1 sentinel is the "nothing yet" state. A separate arrived-flag published *ahead* of this value is
+      // what made this spec flaky — the wait below exited on the flag, read the sequence number before the callback had
+      // stored it, and reported a delivery timeout it had never actually waited out.
       val firstDelivered = new AtomicLong(-1L)
-      val delivered      = new AtomicInteger(0)
       val consumer       = DynamicKafkaConsumer[Array[Byte], Array[Byte]](
         consumerSettings(bootstrap),
         Set.empty,
         record => {
-          delivered.incrementAndGet()
-          firstDelivered.compareAndSet(-1L, new String(record.value()).toLong)
+          val sequence = new String(record.value()).toLong
+          firstDelivered.compareAndSet(-1L, sequence)
         },
         error => logger.error("[positioned-readiness] consumer failed", error),
       )
@@ -138,12 +146,21 @@ class PositionedReadinessSpec extends munit.FunSuite with TestContainerForAll wi
         // "Now", in the units the contract is written in. Sampled the instant readiness completed.
         val s = produced.get()
 
-        // Let the stream run on so there is something after S to deliver.
-        val deadline = System.currentTimeMillis() + 30000
-        while (delivered.get() == 0 && System.currentTimeMillis() < deadline) Thread.sleep(20)
+        // Let the stream run on so there is something after S to deliver. The condition is the same variable the
+        // assertion reads, so the loop cannot fall through to a value that has not been published yet.
+        val waitingSince = System.currentTimeMillis()
+        val deadline     = waitingSince + DeliveryBudget.toMillis
+        while (firstDelivered.get() < 0 && System.currentTimeMillis() < deadline) Thread.sleep(20)
+        val waited       = System.currentTimeMillis() - waitingSince
 
         val f = firstDelivered.get()
-        assert(f >= 0, s"nothing was delivered within 30 s of readiness completing (producer reached ${produced.get()})")
+        // `waited` is reported rather than the budget: a timeout message that names a budget it never spent sends the
+        // next reader after the broker instead of after the test.
+        assert(
+          f >= 0,
+          s"nothing was delivered in the $DeliveryBudget after readiness completed; waited $waited ms " +
+            s"(producer reached ${produced.get()})",
+        )
         // `s + 1`, not `s`. `produced` is incremented before `sender.send`, and the send is asynchronous, so `S` counts
         // records handed to the producer while the consumer positions at the *appended* log end. When nothing happens to be
         // in flight at resolution time the correct implementation legitimately delivers `S + 1` first, and asserting `f <= s`


### PR DESCRIPTION
## What

`PositionedReadinessSpec` (the issue #193 gate) failed at random. Three consecutive runs on identical, unmodified code gave pass, pass, fail — always on the same delivery-timeout assertion:

```
munit.FailException: nothing was delivered within 30 s of readiness completing (producer reached 153)
```

This makes the wait genuinely bounded by the budget it claims. Test-only change; no production code touched.

## Why

The failing runs finished in **under 7 s** while reporting a **30 s** window. That discrepancy was the tell — the wait was never a slow environment, it was a publication race in the spec itself.

The consumer callback raised an arrival flag *before* storing the value the assertion reads:

```scala
record => {
  delivered.incrementAndGet()                                        // (1) flag
  firstDelivered.compareAndSet(-1L, new String(record.value()).toLong)  // (2) value
}
```

while the waiter exited on (1) and asserted on (2):

```scala
while (delivered.get() == 0 && System.currentTimeMillis() < deadline) Thread.sleep(20)
val f = firstDelivered.get()
assert(f >= 0, "nothing was delivered within 30 s ...")
```

Between (1) and (2) sit a value read, a `String` allocation and a `toLong` parse. Deschedule the consumer thread there — ordinary when the Docker daemon is contended, which is exactly the reported condition — and the waiter wakes on its 20 ms tick, sees the flag, reads `-1`, and reports a budget it never spent.

Confirmed in a standalone model of the same pattern. Sharply load-dependent, and the wait never exceeds ~35 ms in any case:

| preemption between (1) and (2) | failures | wait actually spent |
|---|---|---|
| 0–5 ms | 0/300 | ~30 ms |
| 20 ms | 202/300 | ~37 ms |
| 50 ms | 300/300 | ~32 ms |

## How

Wait on `firstDelivered` — its `-1` sentinel already *is* the "nothing yet" state, so the loop cannot fall through to a value that has not been published yet. The `delivered` counter had no other reader and is gone. The budget becomes a named `DeliveryBudget` constant so the message cannot drift from the value again, and the message now reports the time actually waited, so a future timeout points at the broker only when the broker is really what failed.

Of the three candidate fixes, the other two would not have helped: **widening the budget** fixes nothing when the budget is never consumed, and **awaiting broker readiness first** was already the case — the clock starts after `readiness.get(60s)` returns.

## Verification

- **6/6** consecutive runs pass on an already-loaded machine (load avg 5.7, 3 containers running, Docker contended).
- **The gate still catches the bug.** Re-injected issue #193 into `DynamicKafkaConsumer` (readiness completing on assignment alone, fetch positions unresolved) — the spec fails **3/3** on the real `f <= s + 1` assertion with the #193 diagnosis, *not* on the delivery timeout. Consumer restored; this PR touches only the spec.
- `sbt scalafmtCheckAll scalafmtSbtCheck compile test` green — all 7 suites, 0 failures.

## Reviewer notes

- I checked the neighbouring `f <= s + 1` tolerance for the same class of load sensitivity. It holds by construction: `s` is sampled *after* the position resolves, so contention pushes `F` further *below* `s`. It will not become the next flake.
- Out of scope, flagged not fixed: the warm-up loop `while (produced.get() < WarmUpRecords) Thread.sleep(10)` is unbounded. If the producer thread ever dies it hangs to the 5-minute `munitTimeout` instead of failing. Different failure mode, never observed.
- This branch carries the fix; the flake was originally observed on `007-multilang-example-ci-coverage`, which will pick it up from `main`.